### PR TITLE
Vertx metrics

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,6 +24,9 @@ dependencies {
   implementation 'commons-io:commons-io'
   implementation 'commons-lang:commons-lang'
 
+  compile 'io.vertx:vertx-micrometer-metrics:3.9.3'
+  compile 'io.micrometer:micrometer-registry-prometheus:1.5.5'
+
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-net'
   implementation 'org.web3j:core'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,8 +24,8 @@ dependencies {
   implementation 'commons-io:commons-io'
   implementation 'commons-lang:commons-lang'
 
-  compile 'io.vertx:vertx-micrometer-metrics:3.9.3'
-  compile 'io.micrometer:micrometer-registry-prometheus:1.5.5'
+  implementation 'io.vertx:vertx-micrometer-metrics:3.9.3'
+  implementation 'io.micrometer:micrometer-registry-prometheus:1.5.5'
 
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-net'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -37,7 +37,11 @@ dependencyManagement {
       entry 'vertx-web-client'
       entry 'vertx-web'
       entry 'vertx-web-api-contract'
+      entry 'vertx-micrometer-metrics'
     }
+
+    dependency 'io.micrometer:micrometer-registry-prometheus:1.5.5'
+
 
     dependency 'javax.activation:activation:1.1.1'
 


### PR DESCRIPTION
Exposes Vertx metrics provided by Vertx micrometer module.

This exposes the metrics on an endpoint /metrics/vertx on the main application port. It's not possible to easily expose these on the metrics port on /metrics at the moment without changes to the external metrics library we are using.