### PR TITLE
remove fork_info as required param for deposit data signing requests

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/Eth2RequestUtils.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/Eth2RequestUtils.java
@@ -168,7 +168,6 @@ public class Eth2RequestUtils {
   }
 
   private static Eth2SigningRequestBody createDepositRequest() {
-    final ForkInfo forkInfo = forkInfo();
     final DepositMessage depositMessage =
         new DepositMessage(
             BLSPubKey.fromHexString(

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/Eth2RequestUtils.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/Eth2RequestUtils.java
@@ -181,7 +181,7 @@ public class Eth2RequestUtils {
     return new Eth2SigningRequestBody(
         ArtifactType.DEPOSIT,
         signingRoot,
-        forkInfo,
+        null,
         null,
         null,
         null,

--- a/core/src/main/resources/openapi/web3signer-eth2.yaml
+++ b/core/src/main/resources/openapi/web3signer-eth2.yaml
@@ -167,19 +167,21 @@ components:
           required:
             - block
     DepositSigning:
-      allOf:
-        - $ref: '#/components/schemas/Signing'
-        - type: object
+      type: object
+      properties:
+        deposit:
+          type: object
           properties:
-            deposit:
-              type: object
-              properties:
-                pubkey:
-                  type: "string"
-                withdrawal_credentials:
-                  type: "string"
-                amount:
-                  type: "string"
+            type:
+              type: "string"
+            signingRoot:
+              type: "string"
+            pubkey:
+              type: "string"
+            withdrawal_credentials:
+              type: "string"
+            amount:
+              type: "string"
       required:
         - deposit
     RandaoRevealSigning:


### PR DESCRIPTION
The signing request for deposit data doesn't require the forkInfo to compute the domain. This removes this from the request so that dummy data doesn't need to be provided.