### PR TITLE
Eth2 slashing protection signing low watermark

### DIFF
--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/ColumnMappers.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/ColumnMappers.java
@@ -50,7 +50,9 @@ public class ColumnMappers {
       return Optional.of(
           (ColumnMapper<UInt64>)
               (r, columnNumber, ctx) ->
-                  UInt64.valueOf(r.getBigDecimal(columnNumber).toBigInteger()));
+                  r.getBigDecimal(columnNumber) == null
+                      ? null
+                      : UInt64.valueOf(r.getBigDecimal(columnNumber).toBigInteger()));
     }
   }
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -128,7 +128,7 @@ public class DbSlashingProtection implements SlashingProtection {
 
     final Optional<UInt64> minimumSourceEpoch =
         signedAttestationsDao.minimumSourceEpoch(h, validatorId);
-    if (minimumSourceEpoch.filter(minEpoch -> sourceEpoch.compareTo(minEpoch) < 0).isPresent()) {
+    if (minimumSourceEpoch.map(minEpoch -> sourceEpoch.compareTo(minEpoch) < 0).orElse(false)) {
       LOG.warn(
           "Attestation source epoch {} is below minimum existing attestation source epoch {}",
           sourceEpoch,
@@ -138,7 +138,7 @@ public class DbSlashingProtection implements SlashingProtection {
 
     final Optional<UInt64> minimumTargetEpoch =
         signedAttestationsDao.minimumTargetEpoch(h, validatorId);
-    if (minimumTargetEpoch.filter(minEpoch -> targetEpoch.compareTo(minEpoch) <= 0).isPresent()) {
+    if (minimumTargetEpoch.map(minEpoch -> targetEpoch.compareTo(minEpoch) <= 0).orElse(false)) {
       LOG.warn(
           "Attestation target epoch {} is below minimum existing attestation target epoch {}",
           targetEpoch,
@@ -217,7 +217,7 @@ public class DbSlashingProtection implements SlashingProtection {
     }
 
     final Optional<UInt64> minimumSlot = signedBlocksDao.minimumSlot(handle, validatorId);
-    if (minimumSlot.filter(slot -> blockSlot.compareTo(slot) <= 0).isPresent()) {
+    if (minimumSlot.map(slot -> blockSlot.compareTo(slot) <= 0).orElse(false)) {
       LOG.warn(
           "Block slot {} is below minimum existing block slot {}", blockSlot, minimumSlot.get());
       return false;

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDao.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDao.java
@@ -82,8 +82,7 @@ public class SignedAttestationsDao {
 
   public Optional<UInt64> minimumSourceEpoch(final Handle handle, final int validatorId) {
     return handle
-        .createQuery(
-            "SELECT source_epoch FROM signed_attestations WHERE validator_id = ? ORDER BY source_epoch LIMIT 1")
+        .createQuery("SELECT MIN(source_epoch) FROM signed_attestations WHERE validator_id = ?")
         .bind(0, validatorId)
         .mapTo(UInt64.class)
         .findFirst();
@@ -91,8 +90,7 @@ public class SignedAttestationsDao {
 
   public Optional<UInt64> minimumTargetEpoch(final Handle handle, final int validatorId) {
     return handle
-        .createQuery(
-            "SELECT target_epoch FROM signed_attestations WHERE validator_id = ? ORDER BY target_epoch LIMIT 1")
+        .createQuery("SELECT MIN(target_epoch) FROM signed_attestations WHERE validator_id = ?")
         .bind(0, validatorId)
         .mapTo(UInt64.class)
         .findFirst();

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDao.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDao.java
@@ -79,4 +79,22 @@ public class SignedAttestationsDao {
         .bind(3, signedAttestation.getTargetEpoch())
         .execute();
   }
+
+  public Optional<UInt64> minimumSourceEpoch(final Handle handle, final int validatorId) {
+    return handle
+        .createQuery(
+            "SELECT source_epoch FROM signed_attestations WHERE validator_id = ? ORDER BY source_epoch LIMIT 1")
+        .bind(0, validatorId)
+        .mapTo(UInt64.class)
+        .findFirst();
+  }
+
+  public Optional<UInt64> minimumTargetEpoch(final Handle handle, final int validatorId) {
+    return handle
+        .createQuery(
+            "SELECT target_epoch FROM signed_attestations WHERE validator_id = ? ORDER BY target_epoch LIMIT 1")
+        .bind(0, validatorId)
+        .mapTo(UInt64.class)
+        .findFirst();
+  }
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDao.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDao.java
@@ -42,7 +42,7 @@ public class SignedBlocksDao {
 
   public Optional<UInt64> minimumSlot(final Handle handle, final int validatorId) {
     return handle
-        .createQuery("SELECT slot FROM signed_blocks WHERE validator_id = ? ORDER BY slot LIMIT 1")
+        .createQuery("SELECT MIN(slot) FROM signed_blocks WHERE validator_id = ?")
         .bind(0, validatorId)
         .mapTo(UInt64.class)
         .findFirst();

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDao.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDao.java
@@ -20,7 +20,7 @@ import org.jdbi.v3.core.Handle;
 public class SignedBlocksDao {
 
   public Optional<SignedBlock> findExistingBlock(
-      final Handle handle, int validatorId, final UInt64 slot) {
+      final Handle handle, final int validatorId, final UInt64 slot) {
     return handle
         .createQuery(
             "SELECT validator_id, slot, signing_root FROM signed_blocks WHERE validator_id = ? AND slot = ?")
@@ -38,5 +38,13 @@ public class SignedBlocksDao {
         .bind(1, signedBlock.getSlot())
         .bind(2, signedBlock.getSigningRoot())
         .execute();
+  }
+
+  public Optional<UInt64> minimumSlot(final Handle handle, final int validatorId) {
+    return handle
+        .createQuery("SELECT slot FROM signed_blocks WHERE validator_id = ? ORDER BY slot LIMIT 1")
+        .bind(0, validatorId)
+        .mapTo(UInt64.class)
+        .findFirst();
   }
 }

--- a/slashing-protection/src/main/resources/migrations/postgresql/V1__initial.sql
+++ b/slashing-protection/src/main/resources/migrations/postgresql/V1__initial.sql
@@ -1,7 +1,7 @@
 CREATE TABLE validators (
-  id SERIAL PRIMARY KEY,
-  public_key BYTEA NOT NULL,
-  UNIQUE(public_key)
+    id SERIAL PRIMARY KEY,
+    public_key BYTEA NOT NULL,
+    UNIQUE(public_key)
 );
 CREATE TABLE signed_blocks (
     validator_id INTEGER NOT NULL,

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
@@ -21,7 +21,6 @@ import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestation;
@@ -300,7 +299,7 @@ public class DbSlashingProtectionTest {
     assertThat(dbSlashingProtection.maySignBlock(PUBLIC_KEY1, SIGNING_ROOT, UInt64.ONE)).isFalse();
 
     verify(signedBlocksDao).minimumSlot(any(), eq(VALIDATOR_ID));
-    verifyNoMoreInteractions(signedBlocksDao);
+    verify(signedBlocksDao, never()).insertBlockProposal(any(), any());
   }
 
   @Test
@@ -310,7 +309,7 @@ public class DbSlashingProtectionTest {
     assertThat(dbSlashingProtection.maySignBlock(PUBLIC_KEY1, SIGNING_ROOT, SLOT)).isFalse();
 
     verify(signedBlocksDao).minimumSlot(any(), eq(VALIDATOR_ID));
-    verifyNoMoreInteractions(signedBlocksDao);
+    verify(signedBlocksDao, never()).insertBlockProposal(any(), any());
   }
 
   @Test
@@ -324,7 +323,7 @@ public class DbSlashingProtectionTest {
         .isFalse();
 
     verify(signedAttestationsDao).minimumSourceEpoch(any(), eq(VALIDATOR_ID));
-    verifyNoMoreInteractions(signedAttestationsDao);
+    verify(signedAttestationsDao, never()).insertAttestation(any(), any());
   }
 
   @Test
@@ -357,7 +356,7 @@ public class DbSlashingProtectionTest {
 
     verify(signedAttestationsDao).minimumSourceEpoch(any(), eq(VALIDATOR_ID));
     verify(signedAttestationsDao).minimumTargetEpoch(any(), eq(VALIDATOR_ID));
-    verifyNoMoreInteractions(signedAttestationsDao);
+    verify(signedAttestationsDao, never()).insertAttestation(any(), any());
   }
 
   @Test
@@ -374,6 +373,6 @@ public class DbSlashingProtectionTest {
 
     verify(signedAttestationsDao).minimumSourceEpoch(any(), eq(VALIDATOR_ID));
     verify(signedAttestationsDao).minimumTargetEpoch(any(), eq(VALIDATOR_ID));
-    verifyNoMoreInteractions(signedAttestationsDao);
+    verify(signedAttestationsDao, never()).insertAttestation(any(), any());
   }
 }

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDaoTest.java
@@ -177,6 +177,8 @@ public class SignedAttestationsDaoTest {
     assertThat(existingAttestation.get().getSigningRoot()).isEmpty();
   }
 
+  // TODO tests for minSourceEpoch, minTargetEpoch
+
   private void insertAttestation(
       final Handle h,
       final Bytes publicKey,

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDaoTest.java
@@ -53,7 +53,8 @@ public class SignedAttestationsDaoTest {
 
   @Test
   public void findsExistingAttestationInDb() {
-    insertAttestation(handle, Bytes.of(100), 1, Bytes.of(2), UInt64.valueOf(3), UInt64.valueOf(4));
+    insertValidator(Bytes.of(100), 1);
+    insertAttestation(1, Bytes.of(2), UInt64.valueOf(3), UInt64.valueOf(4));
 
     final Optional<SignedAttestation> existingAttestation =
         signedAttestationsDao.findExistingAttestation(handle, 1, UInt64.valueOf(4));
@@ -179,24 +180,29 @@ public class SignedAttestationsDaoTest {
 
   @Test
   public void determinesMinimumSourceEpoch() {
-    insertAttestation(handle, Bytes.of(100), 1, Bytes.of(2), UInt64.valueOf(3), UInt64.valueOf(4));
-    assertThat(signedAttestationsDao.minimumSourceEpoch(handle, 1)).hasValue(UInt64.valueOf(3));
+    insertValidator(Bytes.of(100), 1);
+    insertAttestation(1, Bytes.of(2), UInt64.valueOf(2), UInt64.valueOf(3));
+    insertAttestation(1, Bytes.of(2), UInt64.valueOf(3), UInt64.valueOf(4));
+    assertThat(signedAttestationsDao.minimumSourceEpoch(handle, 1)).hasValue(UInt64.valueOf(2));
   }
 
   @Test
   public void determinesMinimumTargetEpoch() {
-    insertAttestation(handle, Bytes.of(100), 1, Bytes.of(2), UInt64.valueOf(3), UInt64.valueOf(4));
-    assertThat(signedAttestationsDao.minimumTargetEpoch(handle, 1)).hasValue(UInt64.valueOf(4));
+    insertValidator(Bytes.of(100), 1);
+    insertAttestation(1, Bytes.of(2), UInt64.valueOf(2), UInt64.valueOf(3));
+    insertAttestation(1, Bytes.of(2), UInt64.valueOf(3), UInt64.valueOf(4));
+    assertThat(signedAttestationsDao.minimumTargetEpoch(handle, 1)).hasValue(UInt64.valueOf(3));
+  }
+
+  private void insertValidator(final Bytes publicKey, final int validatorId) {
+    handle.execute("INSERT INTO validators (id, public_key) VALUES (?, ?)", validatorId, publicKey);
   }
 
   private void insertAttestation(
-      final Handle h,
-      final Bytes publicKey,
       final int validatorId,
       final Bytes signingRoot,
       final UInt64 sourceEpoch,
       final UInt64 targetEpoch) {
-    h.execute("INSERT INTO validators (id, public_key) VALUES (?, ?)", validatorId, publicKey);
     handle.execute(
         "INSERT INTO signed_attestations "
             + "(validator_id, signing_root, source_epoch, target_epoch) "

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDaoTest.java
@@ -177,7 +177,17 @@ public class SignedAttestationsDaoTest {
     assertThat(existingAttestation.get().getSigningRoot()).isEmpty();
   }
 
-  // TODO tests for minSourceEpoch, minTargetEpoch
+  @Test
+  public void determinesMinimumSourceEpoch() {
+    insertAttestation(handle, Bytes.of(100), 1, Bytes.of(2), UInt64.valueOf(3), UInt64.valueOf(4));
+    assertThat(signedAttestationsDao.minimumSourceEpoch(handle, 1)).hasValue(UInt64.valueOf(3));
+  }
+
+  @Test
+  public void determinesMinimumTargetEpoch() {
+    insertAttestation(handle, Bytes.of(100), 1, Bytes.of(2), UInt64.valueOf(3), UInt64.valueOf(4));
+    assertThat(signedAttestationsDao.minimumTargetEpoch(handle, 1)).hasValue(UInt64.valueOf(4));
+  }
 
   private void insertAttestation(
       final Handle h,

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
@@ -109,7 +109,7 @@ public class SignedBlocksDaoTest {
   }
 
   @Test
-  public void determineSlotGreaterThanMinSlot() {
+  public void determinesMinimumSlot() {
     final SignedBlocksDao signedBlocksDao = new SignedBlocksDao();
     insertBlock(handle, Bytes.of(100), 1, 2, null);
     assertThat(signedBlocksDao.minimumSlot(handle, 1)).hasValue(UInt64.valueOf(2));

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
@@ -108,6 +108,13 @@ public class SignedBlocksDaoTest {
     assertThat(block.get().getSigningRoot()).isEmpty();
   }
 
+  @Test
+  public void determineSlotGreaterThanMinSlot() {
+    final SignedBlocksDao signedBlocksDao = new SignedBlocksDao();
+    insertBlock(handle, Bytes.of(100), 1, 2, null);
+    assertThat(signedBlocksDao.minimumSlot(handle, 1)).hasValue(UInt64.valueOf(2));
+  }
+
   private void insertBlock(
       final Handle h,
       final Bytes publicKey,

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
@@ -51,7 +51,8 @@ public class SignedBlocksDaoTest {
 
   @Test
   public void findsExistingBlockInDb() {
-    insertBlock(handle, Bytes.of(100), 1, 2, Bytes.of(3));
+    insertValidator(Bytes.of(100), 1);
+    insertBlock(1, 2, Bytes.of(3));
     final SignedBlocksDao signedBlocksDao = new SignedBlocksDao();
 
     final Optional<SignedBlock> existingBlock =
@@ -64,7 +65,8 @@ public class SignedBlocksDaoTest {
 
   @Test
   public void returnsEmptyForNonExistingBlockInDb() {
-    insertBlock(handle, Bytes.of(100), 1, 2, Bytes.of(3));
+    insertValidator(Bytes.of(100), 1);
+    insertBlock(1, 2, Bytes.of(3));
     final SignedBlocksDao signedBlocksDao = new SignedBlocksDao();
     assertThat(signedBlocksDao.findExistingBlock(handle, 1, UInt64.valueOf(1))).isEmpty();
     assertThat(signedBlocksDao.findExistingBlock(handle, 2, UInt64.valueOf(2))).isEmpty();
@@ -102,7 +104,8 @@ public class SignedBlocksDaoTest {
   @Test
   public void canCreateBlocksWithNoSigningRoot() {
     final SignedBlocksDao signedBlocksDao = new SignedBlocksDao();
-    insertBlock(handle, Bytes.of(100), 1, 2, null);
+    insertValidator(Bytes.of(100), 1);
+    insertBlock(1, 2, null);
     Optional<SignedBlock> block = signedBlocksDao.findExistingBlock(handle, 1, UInt64.valueOf(2));
     assertThat(block).isNotEmpty();
     assertThat(block.get().getSigningRoot()).isEmpty();
@@ -111,21 +114,21 @@ public class SignedBlocksDaoTest {
   @Test
   public void determinesMinimumSlot() {
     final SignedBlocksDao signedBlocksDao = new SignedBlocksDao();
-    insertBlock(handle, Bytes.of(100), 1, 2, null);
+    insertValidator(Bytes.of(100), 1);
+    insertBlock(1, 2, null);
+    insertBlock(1, 3, null);
     assertThat(signedBlocksDao.minimumSlot(handle, 1)).hasValue(UInt64.valueOf(2));
   }
 
-  private void insertBlock(
-      final Handle h,
-      final Bytes publicKey,
-      final int validatorId,
-      final int slot,
-      final Bytes signingRoot) {
-    h.execute("INSERT INTO validators (id, public_key) VALUES (?, ?)", validatorId, publicKey);
-    h.execute(
+  private void insertBlock(final int validatorId, final int slot, final Bytes signingRoot) {
+    handle.execute(
         "INSERT INTO signed_blocks (validator_id, slot, signing_root) VALUES (?, ?, ?)",
         validatorId,
         slot,
         signingRoot);
+  }
+
+  private void insertValidator(final Bytes publicKey, final int validatorId) {
+    handle.execute("INSERT INTO validators (id, public_key) VALUES (?, ?)", validatorId, publicKey);
   }
 }

--- a/slashing-protection/src/test/resources/log4j2.xml
+++ b/slashing-protection/src/test/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+  <Properties>
+    <Property name="root.log.level">DEBUG</Property>
+  </Properties>
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSSZZZ} | %t | %-5level | %c{1} | %msg%n" />    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="${sys:root.log.level}">
+      <AppenderRef ref="Console" />
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
Adds a low watermark for signing blocks and attestations which below we will not sign. This is so we don't sign when we don't have data for the slot or epoch.

Required as part of implementing the slashing database interchange format.