### PR TITLE
cleanup openapi debug logging

### DIFF
--- a/app/src/main/resources/log4j2.xml
+++ b/app/src/main/resources/log4j2.xml
@@ -2,6 +2,7 @@
 <Configuration status="INFO">
   <Properties>
     <Property name="root.log.level">INFO</Property>
+    <Property name="dependency.log.level">INFO</Property>
   </Properties>
 
   <Appenders>
@@ -13,5 +14,8 @@
     <Root level="${sys:root.log.level}">
       <AppenderRef ref="Console"/>
     </Root>
+    <Logger name="com.networknt.schema" level="${env:dependency.log.level}" additivity="false">
+      <AppenderRef ref="Console"/>
+    </Logger>
   </Loggers>
 </Configuration>

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -79,7 +79,7 @@ public abstract class Runner implements Runnable {
   public void run() {
     if (config.getLogLevel() != null) {
       System.out.println("Setting logging level to " + config.getLogLevel().name());
-      Configurator.setAllLevels("", config.getLogLevel());
+      Configurator.setRootLevel(config.getLogLevel());
     }
 
     final MetricsEndpoint metricsEndpoint =


### PR DESCRIPTION
This reduces the openAPI validation logging to info level. As when debug logging is enabled for com.networknt.schema there are large amounts of logging per request ~100 lines which isn't helpful for debugging.

If the debug level for com.networknt.schema is required this can be overridden with a custom log4j file.