### PR TITLE
Update signer library to 1.0.13

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -86,7 +86,7 @@ dependencyManagement {
 
     dependency 'tech.pegasys:jblst:0.2.0-RELEASE'
 
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.12') {
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.13') {
       entry 'bls-keystore'
       entry 'keystorage-hashicorp'
       entry 'keystorage-azure'


### PR DESCRIPTION
 -- Allows to read BLS keystores (EIP-2335) without UUID and Path fields

Signed-off-by: Usman Saleem <usman@usmans.info>