### PR TITLE
Fix eth2 slashing deposit openAPI schema had wrong scope level of "type" element

### DIFF
--- a/core/src/main/resources/openapi/web3signer-eth2.yaml
+++ b/core/src/main/resources/openapi/web3signer-eth2.yaml
@@ -169,20 +169,23 @@ components:
     DepositSigning:
       type: object
       properties:
+        type:
+          type: "string"
         deposit:
           type: object
           properties:
-            type:
-              type: "string"
-            signingRoot:
-              type: "string"
             pubkey:
               type: "string"
             withdrawal_credentials:
               type: "string"
             amount:
               type: "string"
+            signingRoot:
+              description: 'signing root for optional verification if field present'
+              type: "string"
+
       required:
+        - type
         - deposit
     RandaoRevealSigning:
       allOf:


### PR DESCRIPTION
This fix #287  