### PR TITLE
Use low watermark in Slashing logic

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/slashing/SlashingProtectionAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/slashing/SlashingProtectionAcceptanceTest.java
@@ -33,7 +33,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class SlashingAcceptanceTest extends AcceptanceTestBase {
+public class SlashingProtectionAcceptanceTest extends AcceptanceTestBase {
 
   private static final MetadataFileHelpers metadataFileHelpers = new MetadataFileHelpers();
   public static final String DB_USERNAME = "postgres";

--- a/slashing-protection/build.gradle
+++ b/slashing-protection/build.gradle
@@ -30,6 +30,7 @@ dependencies {
   implementation 'org.jdbi:jdbi3-sqlobject'
   implementation 'org.hyperledger.besu:plugin-api'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
+  implementation 'com.google.guava:guava'
 
   runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
 

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeBaseIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeBaseIntegrationTest.java
@@ -14,6 +14,7 @@ package tech.pegasys.web3signer.slashingprotection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestation;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlock;
@@ -27,8 +28,9 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.flywaydb.core.Flyway;
-import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +42,7 @@ public class InterchangeBaseIntegrationTest {
   protected final SignedBlocksDao signedBlocks = new SignedBlocksDao();
   protected final SignedAttestationsDao signedAttestations = new SignedAttestationsDao();
   protected final ValidatorsDao validators = new ValidatorsDao();
+  protected final LowWatermarkDao lowWatermarkDao = new LowWatermarkDao();
 
   protected EmbeddedPostgres db;
   protected String databaseUrl;
@@ -48,6 +51,9 @@ public class InterchangeBaseIntegrationTest {
 
   private static final String USERNAME = "postgres";
   private static final String PASSWORD = "postgres";
+  protected static final String GENESIS_VALIDATORS_ROOT =
+      "0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673";
+  protected static final Bytes32 GVR = Bytes32.fromHexString(GENESIS_VALIDATORS_ROOT);
 
   @BeforeEach
   public void setupTest() {
@@ -87,28 +93,37 @@ public class InterchangeBaseIntegrationTest {
     return slashingDatabase;
   }
 
-  protected List<SignedAttestation> findAllAttestations(final Handle handle) {
-    return handle
-        .createQuery(
-            "SELECT validator_id, source_epoch, target_epoch, signing_root "
-                + "FROM signed_attestations")
-        .mapToBean(SignedAttestation.class)
-        .list();
+  protected List<SignedAttestation> findAllAttestations() {
+    return jdbi.withHandle(
+        h ->
+            h.createQuery(
+                    "SELECT validator_id, source_epoch, target_epoch, signing_root "
+                        + "FROM signed_attestations")
+                .mapToBean(SignedAttestation.class)
+                .list());
   }
 
-  protected List<SignedBlock> findAllBlocks(final Handle handle) {
-    return handle
-        .createQuery("SELECT validator_id, slot, signing_root FROM signed_blocks")
-        .mapToBean(SignedBlock.class)
-        .list();
+  protected List<SignedBlock> findAllBlocks() {
+    return jdbi.withHandle(
+        h ->
+            h.createQuery("SELECT validator_id, slot, signing_root FROM signed_blocks")
+                .mapToBean(SignedBlock.class)
+                .list());
+  }
+
+  protected void insertValidator(final Bytes publicKey, final int validatorId) {
+    jdbi.useHandle(
+        h ->
+            h.execute(
+                "INSERT INTO validators (id, public_key) VALUES (?, ?)", validatorId, publicKey));
   }
 
   protected void assertDbIsEmpty(final Jdbi jdbi) {
     jdbi.useHandle(
         h -> {
           assertThat(validators.findAllValidators(h)).isEmpty();
-          assertThat(findAllAttestations(h)).isEmpty();
-          assertThat(findAllBlocks(h)).isEmpty();
+          assertThat(findAllAttestations()).isEmpty();
+          assertThat(findAllBlocks()).isEmpty();
         });
   }
 }

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeBaseIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeBaseIntegrationTest.java
@@ -19,6 +19,7 @@ import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestation;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlock;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlocksDao;
+import tech.pegasys.web3signer.slashingprotection.dao.SigningWatermark;
 import tech.pegasys.web3signer.slashingprotection.dao.ValidatorsDao;
 import tech.pegasys.web3signer.slashingprotection.interchange.InterchangeModule;
 
@@ -30,6 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt64;
 import org.flywaydb.core.Flyway;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.AfterEach;
@@ -125,5 +127,21 @@ public class InterchangeBaseIntegrationTest {
           assertThat(findAllAttestations()).isEmpty();
           assertThat(findAllBlocks()).isEmpty();
         });
+  }
+
+  protected void insertBlockAt(final UInt64 blockSlot, final Bytes publicKey) {
+    assertThat(slashingProtection.maySignBlock(publicKey, Bytes.of(100), blockSlot, GVR)).isTrue();
+  }
+
+  protected void insertAttestationAt(
+      final UInt64 sourceEpoch, final UInt64 targetEpoch, final Bytes publicKey) {
+    assertThat(
+            slashingProtection.maySignAttestation(
+                publicKey, Bytes.of(100), sourceEpoch, targetEpoch, GVR))
+        .isTrue();
+  }
+
+  protected SigningWatermark getWatermark(final int validatorId) {
+    return jdbi.withHandle(h -> lowWatermarkDao.findLowWatermarkForValidator(h, validatorId)).get();
   }
 }

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeExportIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeExportIntegrationTest.java
@@ -34,8 +34,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.Test;
 
 public class InterchangeExportIntegrationTest extends InterchangeBaseIntegrationTest {
-  private static final String GENESIS_VALIDATORS_ROOT =
-      "0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673";
+
   private final MetadataDao metadata = new MetadataDao();
 
   @Test

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeImportConflictsIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeImportConflictsIntegrationTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestation;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlock;
+import tech.pegasys.web3signer.slashingprotection.dao.SigningWatermark;
 
 import java.io.IOException;
 import java.net.URL;
@@ -34,44 +35,46 @@ public class InterchangeImportConflictsIntegrationTest extends InterchangeBaseIn
     final URL importFile = Resources.getResource("interchange/singleValidBlock.json");
     slashingProtection.importData(importFile.openStream());
     slashingProtection.importData(importFile.openStream()); // attempt to reimport
-    jdbi.useHandle(
-        handle -> {
-          final List<SignedBlock> blocksInDb = findAllBlocks(handle);
-          assertThat(blocksInDb).hasSize(1);
-          assertThat(blocksInDb.get(0).getSlot()).isEqualTo(UInt64.valueOf(12345));
-          assertThat(blocksInDb.get(0).getValidatorId()).isEqualTo(1);
-          assertThat(blocksInDb.get(0).getSigningRoot())
-              .isEqualTo(
-                  Optional.of(
-                      Bytes.fromHexString(
-                          "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b")));
-        });
+    final List<SignedBlock> blocksInDb = findAllBlocks();
+    assertThat(blocksInDb).hasSize(1);
+    assertThat(blocksInDb.get(0).getSlot()).isEqualTo(UInt64.valueOf(12345));
+    assertThat(blocksInDb.get(0).getValidatorId()).isEqualTo(1);
+    assertThat(blocksInDb.get(0).getSigningRoot())
+        .isEqualTo(
+            Optional.of(
+                Bytes.fromHexString(
+                    "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b")));
+
+    final Optional<SigningWatermark> watermark =
+        jdbi.withHandle(h -> lowWatermarkDao.findLowWatermarkForValidator(h, 1));
+    assertThat(watermark).isNotEmpty();
+    assertThat(watermark.get().getSourceEpoch()).isNull();
+    assertThat(watermark.get().getTargetEpoch()).isNull();
+    assertThat(watermark.get().getSlot()).isEqualTo(UInt64.valueOf(12345));
   }
 
   @Test
   void canLoadConflictingBlocksInSameSlot() throws IOException {
     final URL importFile = Resources.getResource("interchange/conflictingBlocks.json");
     slashingProtection.importData(importFile.openStream());
-    jdbi.useHandle(
-        handle -> {
-          final List<SignedBlock> blocksInDb = findAllBlocks(handle);
-          assertThat(blocksInDb).hasSize(2);
-          assertThat(blocksInDb.get(0).getSlot()).isEqualTo(UInt64.valueOf(12345));
-          assertThat(blocksInDb.get(0).getValidatorId()).isEqualTo(1);
-          assertThat(blocksInDb.get(0).getSigningRoot())
-              .isEqualTo(
-                  Optional.of(
-                      Bytes.fromHexString(
-                          "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b")));
 
-          assertThat(blocksInDb.get(1).getSlot()).isEqualTo(UInt64.valueOf(12345));
-          assertThat(blocksInDb.get(1).getValidatorId()).isEqualTo(1);
-          assertThat(blocksInDb.get(1).getSigningRoot())
-              .isEqualTo(
-                  Optional.of(
-                      Bytes.fromHexString(
-                          "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850c")));
-        });
+    final List<SignedBlock> blocksInDb = findAllBlocks();
+    assertThat(blocksInDb).hasSize(2);
+    assertThat(blocksInDb.get(0).getSlot()).isEqualTo(UInt64.valueOf(12345));
+    assertThat(blocksInDb.get(0).getValidatorId()).isEqualTo(1);
+    assertThat(blocksInDb.get(0).getSigningRoot())
+        .isEqualTo(
+            Optional.of(
+                Bytes.fromHexString(
+                    "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b")));
+
+    assertThat(blocksInDb.get(1).getSlot()).isEqualTo(UInt64.valueOf(12345));
+    assertThat(blocksInDb.get(1).getValidatorId()).isEqualTo(1);
+    assertThat(blocksInDb.get(1).getSigningRoot())
+        .isEqualTo(
+            Optional.of(
+                Bytes.fromHexString(
+                    "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850c")));
   }
 
   @Test
@@ -79,18 +82,16 @@ public class InterchangeImportConflictsIntegrationTest extends InterchangeBaseIn
     final URL importFile = Resources.getResource("interchange/duplicateBlocks.json");
     slashingProtection.importData(importFile.openStream());
     slashingProtection.importData(importFile.openStream()); // attempt to reimport
-    jdbi.useHandle(
-        handle -> {
-          final List<SignedBlock> blocksInDb = findAllBlocks(handle);
-          assertThat(blocksInDb).hasSize(1);
-          assertThat(blocksInDb.get(0).getSlot()).isEqualTo(UInt64.valueOf(12345));
-          assertThat(blocksInDb.get(0).getValidatorId()).isEqualTo(1);
-          assertThat(blocksInDb.get(0).getSigningRoot())
-              .isEqualTo(
-                  Optional.of(
-                      Bytes.fromHexString(
-                          "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b")));
-        });
+
+    final List<SignedBlock> blocksInDb = findAllBlocks();
+    assertThat(blocksInDb).hasSize(1);
+    assertThat(blocksInDb.get(0).getSlot()).isEqualTo(UInt64.valueOf(12345));
+    assertThat(blocksInDb.get(0).getValidatorId()).isEqualTo(1);
+    assertThat(blocksInDb.get(0).getSigningRoot())
+        .isEqualTo(
+            Optional.of(
+                Bytes.fromHexString(
+                    "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b")));
   }
 
   @Test
@@ -98,16 +99,14 @@ public class InterchangeImportConflictsIntegrationTest extends InterchangeBaseIn
     final URL importFile = Resources.getResource("interchange/singleValidAttestation.json");
     slashingProtection.importData(importFile.openStream());
     slashingProtection.importData(importFile.openStream()); // attempt to reimport
-    jdbi.useHandle(
-        handle -> {
-          final List<SignedAttestation> attestationsInDb = findAllAttestations(handle);
-          assertThat(attestationsInDb).hasSize(1);
-          assertThat(attestationsInDb.get(0).getSourceEpoch()).isEqualTo(UInt64.valueOf(5));
-          assertThat(attestationsInDb.get(0).getTargetEpoch()).isEqualTo(UInt64.valueOf(6));
-          assertThat(attestationsInDb.get(0).getValidatorId()).isEqualTo(1);
-          assertThat(attestationsInDb.get(0).getSigningRoot())
-              .isEqualTo(Optional.of(Bytes.fromHexString("0x123456")));
-        });
+
+    final List<SignedAttestation> attestationsInDb = findAllAttestations();
+    assertThat(attestationsInDb).hasSize(1);
+    assertThat(attestationsInDb.get(0).getSourceEpoch()).isEqualTo(UInt64.valueOf(5));
+    assertThat(attestationsInDb.get(0).getTargetEpoch()).isEqualTo(UInt64.valueOf(6));
+    assertThat(attestationsInDb.get(0).getValidatorId()).isEqualTo(1);
+    assertThat(attestationsInDb.get(0).getSigningRoot())
+        .isEqualTo(Optional.of(Bytes.fromHexString("0x123456")));
   }
 
   @Test
@@ -115,34 +114,30 @@ public class InterchangeImportConflictsIntegrationTest extends InterchangeBaseIn
     final URL importFile = Resources.getResource("interchange/duplicateAttestation.json");
     slashingProtection.importData(importFile.openStream());
     slashingProtection.importData(importFile.openStream()); // attempt to reimport
-    jdbi.useHandle(
-        handle -> {
-          final List<SignedAttestation> attestationsInDb = findAllAttestations(handle);
-          assertThat(attestationsInDb).hasSize(1);
-          assertThat(attestationsInDb.get(0).getSourceEpoch()).isEqualTo(UInt64.valueOf(5));
-          assertThat(attestationsInDb.get(0).getTargetEpoch()).isEqualTo(UInt64.valueOf(6));
-          assertThat(attestationsInDb.get(0).getValidatorId()).isEqualTo(1);
-          assertThat(attestationsInDb.get(0).getSigningRoot())
-              .isEqualTo(Optional.of(Bytes.fromHexString("0x123456")));
-        });
+
+    final List<SignedAttestation> attestationsInDb = findAllAttestations();
+    assertThat(attestationsInDb).hasSize(1);
+    assertThat(attestationsInDb.get(0).getSourceEpoch()).isEqualTo(UInt64.valueOf(5));
+    assertThat(attestationsInDb.get(0).getTargetEpoch()).isEqualTo(UInt64.valueOf(6));
+    assertThat(attestationsInDb.get(0).getValidatorId()).isEqualTo(1);
+    assertThat(attestationsInDb.get(0).getSigningRoot())
+        .isEqualTo(Optional.of(Bytes.fromHexString("0x123456")));
   }
 
   @Test
   void canLoadInterchangeFormatWithMissingSigningRootForBlock() throws IOException {
     final URL importFile = Resources.getResource("interchange/multipleNullSigningRootBlock.json");
     slashingProtection.importData(importFile.openStream());
-    jdbi.useHandle(
-        handle -> {
-          final List<SignedBlock> blocksInDb = findAllBlocks(handle);
-          assertThat(blocksInDb).hasSize(2);
-          assertThat(blocksInDb.get(0).getSlot()).isEqualTo(UInt64.valueOf(12345));
-          assertThat(blocksInDb.get(0).getValidatorId()).isEqualTo(1);
-          assertThat(blocksInDb.get(0).getSigningRoot()).isEmpty();
 
-          assertThat(blocksInDb.get(1).getSlot()).isEqualTo(UInt64.valueOf(12346));
-          assertThat(blocksInDb.get(1).getValidatorId()).isEqualTo(1);
-          assertThat(blocksInDb.get(1).getSigningRoot()).isEmpty();
-        });
+    final List<SignedBlock> blocksInDb = findAllBlocks();
+    assertThat(blocksInDb).hasSize(2);
+    assertThat(blocksInDb.get(0).getSlot()).isEqualTo(UInt64.valueOf(12345));
+    assertThat(blocksInDb.get(0).getValidatorId()).isEqualTo(1);
+    assertThat(blocksInDb.get(0).getSigningRoot()).isEmpty();
+
+    assertThat(blocksInDb.get(1).getSlot()).isEqualTo(UInt64.valueOf(12346));
+    assertThat(blocksInDb.get(1).getValidatorId()).isEqualTo(1);
+    assertThat(blocksInDb.get(1).getSigningRoot()).isEmpty();
   }
 
   @Test
@@ -150,18 +145,16 @@ public class InterchangeImportConflictsIntegrationTest extends InterchangeBaseIn
     final URL importFile = Resources.getResource("interchange/multipleNullSigningRootBlock.json");
     slashingProtection.importData(importFile.openStream());
     slashingProtection.importData(importFile.openStream());
-    jdbi.useHandle(
-        handle -> {
-          final List<SignedBlock> blocksInDb = findAllBlocks(handle);
-          assertThat(blocksInDb).hasSize(2);
-          assertThat(blocksInDb.get(0).getSlot()).isEqualTo(UInt64.valueOf(12345));
-          assertThat(blocksInDb.get(0).getValidatorId()).isEqualTo(1);
-          assertThat(blocksInDb.get(0).getSigningRoot()).isEmpty();
 
-          assertThat(blocksInDb.get(1).getSlot()).isEqualTo(UInt64.valueOf(12346));
-          assertThat(blocksInDb.get(1).getValidatorId()).isEqualTo(1);
-          assertThat(blocksInDb.get(1).getSigningRoot()).isEmpty();
-        });
+    final List<SignedBlock> blocksInDb = findAllBlocks();
+    assertThat(blocksInDb).hasSize(2);
+    assertThat(blocksInDb.get(0).getSlot()).isEqualTo(UInt64.valueOf(12345));
+    assertThat(blocksInDb.get(0).getValidatorId()).isEqualTo(1);
+    assertThat(blocksInDb.get(0).getSigningRoot()).isEmpty();
+
+    assertThat(blocksInDb.get(1).getSlot()).isEqualTo(UInt64.valueOf(12346));
+    assertThat(blocksInDb.get(1).getValidatorId()).isEqualTo(1);
+    assertThat(blocksInDb.get(1).getSigningRoot()).isEmpty();
   }
 
   @Test
@@ -169,20 +162,18 @@ public class InterchangeImportConflictsIntegrationTest extends InterchangeBaseIn
     final URL importFile =
         Resources.getResource("interchange/multipleNullSigningRootAttestation.json");
     slashingProtection.importData(importFile.openStream());
-    jdbi.useHandle(
-        handle -> {
-          final List<SignedAttestation> attestationsInDb = findAllAttestations(handle);
-          assertThat(attestationsInDb).hasSize(2);
-          assertThat(attestationsInDb.get(0).getSourceEpoch()).isEqualTo(UInt64.valueOf(5));
-          assertThat(attestationsInDb.get(0).getTargetEpoch()).isEqualTo(UInt64.valueOf(6));
-          assertThat(attestationsInDb.get(0).getValidatorId()).isEqualTo(1);
-          assertThat(attestationsInDb.get(0).getSigningRoot()).isEmpty();
 
-          assertThat(attestationsInDb.get(1).getSourceEpoch()).isEqualTo(UInt64.valueOf(7));
-          assertThat(attestationsInDb.get(1).getTargetEpoch()).isEqualTo(UInt64.valueOf(8));
-          assertThat(attestationsInDb.get(1).getValidatorId()).isEqualTo(1);
-          assertThat(attestationsInDb.get(1).getSigningRoot()).isEmpty();
-        });
+    final List<SignedAttestation> attestationsInDb = findAllAttestations();
+    assertThat(attestationsInDb).hasSize(2);
+    assertThat(attestationsInDb.get(0).getSourceEpoch()).isEqualTo(UInt64.valueOf(5));
+    assertThat(attestationsInDb.get(0).getTargetEpoch()).isEqualTo(UInt64.valueOf(6));
+    assertThat(attestationsInDb.get(0).getValidatorId()).isEqualTo(1);
+    assertThat(attestationsInDb.get(0).getSigningRoot()).isEmpty();
+
+    assertThat(attestationsInDb.get(1).getSourceEpoch()).isEqualTo(UInt64.valueOf(7));
+    assertThat(attestationsInDb.get(1).getTargetEpoch()).isEqualTo(UInt64.valueOf(8));
+    assertThat(attestationsInDb.get(1).getValidatorId()).isEqualTo(1);
+    assertThat(attestationsInDb.get(1).getSigningRoot()).isEmpty();
   }
 
   @Test
@@ -191,20 +182,18 @@ public class InterchangeImportConflictsIntegrationTest extends InterchangeBaseIn
         Resources.getResource("interchange/multipleNullSigningRootAttestation.json");
     slashingProtection.importData(importFile.openStream());
     slashingProtection.importData(importFile.openStream());
-    jdbi.useHandle(
-        handle -> {
-          final List<SignedAttestation> attestationsInDb = findAllAttestations(handle);
-          assertThat(attestationsInDb).hasSize(2);
-          assertThat(attestationsInDb.get(0).getSourceEpoch()).isEqualTo(UInt64.valueOf(5));
-          assertThat(attestationsInDb.get(0).getTargetEpoch()).isEqualTo(UInt64.valueOf(6));
-          assertThat(attestationsInDb.get(0).getValidatorId()).isEqualTo(1);
-          assertThat(attestationsInDb.get(0).getSigningRoot()).isEmpty();
 
-          assertThat(attestationsInDb.get(1).getSourceEpoch()).isEqualTo(UInt64.valueOf(7));
-          assertThat(attestationsInDb.get(1).getTargetEpoch()).isEqualTo(UInt64.valueOf(8));
-          assertThat(attestationsInDb.get(1).getValidatorId()).isEqualTo(1);
-          assertThat(attestationsInDb.get(1).getSigningRoot()).isEmpty();
-        });
+    final List<SignedAttestation> attestationsInDb = findAllAttestations();
+    assertThat(attestationsInDb).hasSize(2);
+    assertThat(attestationsInDb.get(0).getSourceEpoch()).isEqualTo(UInt64.valueOf(5));
+    assertThat(attestationsInDb.get(0).getTargetEpoch()).isEqualTo(UInt64.valueOf(6));
+    assertThat(attestationsInDb.get(0).getValidatorId()).isEqualTo(1);
+    assertThat(attestationsInDb.get(0).getSigningRoot()).isEmpty();
+
+    assertThat(attestationsInDb.get(1).getSourceEpoch()).isEqualTo(UInt64.valueOf(7));
+    assertThat(attestationsInDb.get(1).getTargetEpoch()).isEqualTo(UInt64.valueOf(8));
+    assertThat(attestationsInDb.get(1).getValidatorId()).isEqualTo(1);
+    assertThat(attestationsInDb.get(1).getSigningRoot()).isEmpty();
   }
 
   @Test
@@ -217,17 +206,14 @@ public class InterchangeImportConflictsIntegrationTest extends InterchangeBaseIn
                 Bytes.fromHexString(
                     "0xb845089a1457f811bfc000588fbb4e713669be8ce060ea6be3c6ece09afc3794106c91ca73acda5e5457122d58723bed")));
     slashingProtection.importData(importFile.openStream());
-    jdbi.useHandle(
-        handle -> {
-          final List<SignedBlock> blocksInDb = findAllBlocks(handle);
-          assertThat(blocksInDb).hasSize(1);
-          assertThat(blocksInDb.get(0).getSlot()).isEqualTo(UInt64.valueOf(12345));
-          assertThat(blocksInDb.get(0).getValidatorId()).isEqualTo(1);
-          assertThat(blocksInDb.get(0).getSigningRoot())
-              .isEqualTo(
-                  Optional.of(
-                      Bytes.fromHexString(
-                          "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b")));
-        });
+    final List<SignedBlock> blocksInDb = findAllBlocks();
+    assertThat(blocksInDb).hasSize(1);
+    assertThat(blocksInDb.get(0).getSlot()).isEqualTo(UInt64.valueOf(12345));
+    assertThat(blocksInDb.get(0).getValidatorId()).isEqualTo(1);
+    assertThat(blocksInDb.get(0).getSigningRoot())
+        .isEqualTo(
+            Optional.of(
+                Bytes.fromHexString(
+                    "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b")));
   }
 }

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeImportConflictsIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeImportConflictsIntegrationTest.java
@@ -16,7 +16,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestation;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlock;
-import tech.pegasys.web3signer.slashingprotection.dao.SigningWatermark;
 
 import java.io.IOException;
 import java.net.URL;

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeImportConflictsIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeImportConflictsIntegrationTest.java
@@ -44,13 +44,6 @@ public class InterchangeImportConflictsIntegrationTest extends InterchangeBaseIn
             Optional.of(
                 Bytes.fromHexString(
                     "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b")));
-
-    final Optional<SigningWatermark> watermark =
-        jdbi.withHandle(h -> lowWatermarkDao.findLowWatermarkForValidator(h, 1));
-    assertThat(watermark).isNotEmpty();
-    assertThat(watermark.get().getSourceEpoch()).isNull();
-    assertThat(watermark.get().getTargetEpoch()).isNull();
-    assertThat(watermark.get().getSlot()).isEqualTo(UInt64.valueOf(12345));
   }
 
   @Test

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeImportConflictsIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeImportConflictsIntegrationTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestation;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlock;
+import tech.pegasys.web3signer.slashingprotection.dao.SigningWatermark;
 
 import java.io.IOException;
 import java.net.URL;

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/WatermarkUpdatesIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/WatermarkUpdatesIntegrationTest.java
@@ -71,7 +71,6 @@ public class WatermarkUpdatesIntegrationTest extends InterchangeBaseIntegrationT
     assertThat(getWatermark())
         .isEqualToComparingFieldByField(
             new SigningWatermark(VALIDATOR_ID, UInt64.valueOf(3), null, null));
-
   }
 
   @Test

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/WatermarkUpdatesIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/WatermarkUpdatesIntegrationTest.java
@@ -84,6 +84,17 @@ public class WatermarkUpdatesIntegrationTest extends InterchangeBaseIntegrationT
             new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(3), UInt64.valueOf(4)));
   }
 
+  @Test
+  public void attestationWatermarkIsNotChangedOnSubsequentAttestations() {
+    insertValidator(PUBLIC_KEY, VALIDATOR_ID);
+    slashingProtection.registerValidators(List.of(PUBLIC_KEY));
+    insertAttestationAt(UInt64.valueOf(3), UInt64.valueOf(4));
+    insertAttestationAt(UInt64.valueOf(4), UInt64.valueOf(5));
+    assertThat(getWatermark())
+        .isEqualToComparingFieldByField(
+            new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(3), UInt64.valueOf(4)));
+  }
+
   private void insertBlockAt(final UInt64 blockSlot) {
     assertThat(slashingProtection.maySignBlock(PUBLIC_KEY, Bytes.of(100), blockSlot, GVR)).isTrue();
   }

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/WatermarkUpdatesIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/WatermarkUpdatesIntegrationTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.slashingprotection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import tech.pegasys.web3signer.slashingprotection.dao.SigningWatermark;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt64;
+import org.junit.jupiter.api.Test;
+
+public class WatermarkUpdatesIntegrationTest extends InterchangeBaseIntegrationTest {
+
+  final Bytes PUBLIC_KEY =
+      Bytes.fromHexString(
+          "0xb845089a1457f811bfc000588fbb4e713669be8ce060ea6be3c6ece09afc3794106c91ca73acda5e5457122d58723bed");
+  final int VALIDATOR_ID = 1;
+
+  @Test
+  public void watermarkIsEmptyAtStartup() {
+    Optional<SigningWatermark> watermark =
+        jdbi.withHandle(h -> lowWatermarkDao.findLowWatermarkForValidator(h, VALIDATOR_ID));
+    assertThat(watermark).isEmpty();
+  }
+
+  @Test
+  public void blockWatermarkIsSetOnFirstBlock() {
+    final UInt64 blockSlot = UInt64.valueOf(3);
+    insertValidator(PUBLIC_KEY, VALIDATOR_ID);
+    slashingProtection.registerValidators(List.of(PUBLIC_KEY));
+    insertBlockAt(blockSlot);
+
+    assertThat(findAllBlocks()).hasSize(1);
+    assertThat(getWatermark())
+        .isEqualToComparingFieldByField(new SigningWatermark(VALIDATOR_ID, blockSlot, null, null));
+  }
+
+  @Test
+  public void blockWatermarkDoesNotChangeOnSecondBlock() {
+    insertValidator(PUBLIC_KEY, VALIDATOR_ID);
+    slashingProtection.registerValidators(List.of(PUBLIC_KEY));
+
+    insertBlockAt(UInt64.valueOf(3));
+    assertThat(findAllBlocks()).hasSize(1);
+    assertThat(getWatermark())
+        .isEqualToComparingFieldByField(
+            new SigningWatermark(VALIDATOR_ID, UInt64.valueOf(3), null, null));
+
+    insertBlockAt(UInt64.valueOf(4));
+    assertThat(findAllBlocks()).hasSize(2);
+    assertThat(getWatermark())
+        .isEqualToComparingFieldByField(
+            new SigningWatermark(VALIDATOR_ID, UInt64.valueOf(3), null, null));
+
+    insertBlockAt(UInt64.valueOf(5));
+    assertThat(findAllBlocks()).hasSize(3);
+    assertThat(getWatermark())
+        .isEqualToComparingFieldByField(
+            new SigningWatermark(VALIDATOR_ID, UInt64.valueOf(3), null, null));
+
+  }
+
+  @Test
+  public void attestationWatermarkIsSetOnFirstAtestation() {
+    insertValidator(PUBLIC_KEY, VALIDATOR_ID);
+    slashingProtection.registerValidators(List.of(PUBLIC_KEY));
+    insertAttestationAt(UInt64.valueOf(3), UInt64.valueOf(4));
+    assertThat(getWatermark())
+        .isEqualToComparingFieldByField(
+            new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(3), UInt64.valueOf(4)));
+  }
+
+  private void insertBlockAt(final UInt64 blockSlot) {
+    assertThat(slashingProtection.maySignBlock(PUBLIC_KEY, Bytes.of(100), blockSlot, GVR)).isTrue();
+  }
+
+  private void insertAttestationAt(final UInt64 sourceEpoch, final UInt64 targetEpoch) {
+    assertThat(
+            slashingProtection.maySignAttestation(
+                PUBLIC_KEY, Bytes.of(100), sourceEpoch, targetEpoch, GVR))
+        .isTrue();
+  }
+
+  private SigningWatermark getWatermark() {
+    return jdbi.withHandle(h -> lowWatermarkDao.findLowWatermarkForValidator(h, VALIDATOR_ID))
+        .get();
+  }
+}

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -69,8 +69,17 @@ public class DbSlashingProtection implements SlashingProtection {
       final Jdbi jdbi,
       final ValidatorsDao validatorsDao,
       final SignedBlocksDao signedBlocksDao,
-      final SignedAttestationsDao signedAttestationsDao) {
-    this(jdbi, validatorsDao, signedBlocksDao, signedAttestationsDao, new HashMap<>());
+      final SignedAttestationsDao signedAttestationsDao,
+      final MetadataDao metadataDao,
+      final LowWatermarkDao lowWatermarkDao) {
+    this(
+        jdbi,
+        validatorsDao,
+        signedBlocksDao,
+        signedAttestationsDao,
+        metadataDao,
+        lowWatermarkDao,
+        new HashMap<>());
   }
 
   public DbSlashingProtection(
@@ -145,6 +154,7 @@ public class DbSlashingProtection implements SlashingProtection {
                   validatorId,
                   signedAttestationsDao,
                   lowWatermarkDao);
+
           final GenesisValidatorRootValidator gvrValidator =
               new GenesisValidatorRootValidator(handle, metadataDao);
 
@@ -153,6 +163,10 @@ public class DbSlashingProtection implements SlashingProtection {
           }
 
           lockForValidator(handle, LockType.ATTESTATION, validatorId);
+
+          if (!gvrValidator.checkGenesisValidatorsRootAndInsertIfEmpty(genesisValidatorsRoot)) {
+            return false;
+          }
 
           if (attestationValidator.directlyConflictsWithExistingEntry()
               || attestationValidator.isSurroundedByExistingAttestation()

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -13,6 +13,7 @@
 package tech.pegasys.web3signer.slashingprotection;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.FLUSH_AFTER_WRITE_VALUE;
+import static java.util.Collections.emptyMap;
 import static org.jdbi.v3.core.transaction.TransactionIsolationLevel.READ_COMMITTED;
 import static org.jdbi.v3.core.transaction.TransactionIsolationLevel.SERIALIZABLE;
 
@@ -79,7 +80,7 @@ public class DbSlashingProtection implements SlashingProtection {
         signedAttestationsDao,
         metadataDao,
         lowWatermarkDao,
-        new HashMap<>());
+        emptyMap());
   }
 
   public DbSlashingProtection(

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -17,6 +17,7 @@ import static java.util.Collections.emptyMap;
 import static org.jdbi.v3.core.transaction.TransactionIsolationLevel.READ_COMMITTED;
 import static org.jdbi.v3.core.transaction.TransactionIsolationLevel.SERIALIZABLE;
 
+import java.util.HashMap;
 import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
 import tech.pegasys.web3signer.slashingprotection.dao.MetadataDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
@@ -79,7 +80,7 @@ public class DbSlashingProtection implements SlashingProtection {
         signedAttestationsDao,
         metadataDao,
         lowWatermarkDao,
-        emptyMap());
+        new HashMap<>());
   }
 
   public DbSlashingProtection(

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -13,11 +13,9 @@
 package tech.pegasys.web3signer.slashingprotection;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.FLUSH_AFTER_WRITE_VALUE;
-import static java.util.Collections.emptyMap;
 import static org.jdbi.v3.core.transaction.TransactionIsolationLevel.READ_COMMITTED;
 import static org.jdbi.v3.core.transaction.TransactionIsolationLevel.SERIALIZABLE;
 
-import java.util.HashMap;
 import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
 import tech.pegasys.web3signer.slashingprotection.dao.MetadataDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
@@ -35,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionFactory.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionFactory.java
@@ -33,6 +33,10 @@ public class SlashingProtectionFactory {
 
   private static SlashingProtection createSlashingProtection(final Jdbi jdbi) {
     return new DbSlashingProtection(
-        jdbi, new ValidatorsDao(), new SignedBlocksDao(), new SignedAttestationsDao(), new LowWatermarkDao());
+        jdbi,
+        new ValidatorsDao(),
+        new SignedBlocksDao(),
+        new SignedAttestationsDao(),
+        new LowWatermarkDao());
   }
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionFactory.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionFactory.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.web3signer.slashingprotection;
 
+import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlocksDao;
 import tech.pegasys.web3signer.slashingprotection.dao.ValidatorsDao;
@@ -32,6 +33,6 @@ public class SlashingProtectionFactory {
 
   private static SlashingProtection createSlashingProtection(final Jdbi jdbi) {
     return new DbSlashingProtection(
-        jdbi, new ValidatorsDao(), new SignedBlocksDao(), new SignedAttestationsDao());
+        jdbi, new ValidatorsDao(), new SignedBlocksDao(), new SignedAttestationsDao(), new LowWatermarkDao());
   }
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Importer.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Importer.java
@@ -23,6 +23,7 @@ import tech.pegasys.web3signer.slashingprotection.interchange.model.SignedAttest
 import tech.pegasys.web3signer.slashingprotection.interchange.model.SignedBlock;
 import tech.pegasys.web3signer.slashingprotection.validator.AttestationValidator;
 import tech.pegasys.web3signer.slashingprotection.validator.BlockValidator;
+import tech.pegasys.web3signer.slashingprotection.validator.GenesisValidatorRootValidator;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,6 +37,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Manager.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Manager.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.web3signer.slashingprotection.interchange;
 
+import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlocksDao;
 import tech.pegasys.web3signer.slashingprotection.dao.ValidatorsDao;
@@ -33,13 +34,14 @@ public class InterchangeV5Manager implements InterchangeManager {
       final ValidatorsDao validatorsDao,
       final SignedBlocksDao signedBlocksDao,
       final SignedAttestationsDao signedAttestationsDao,
+      final LowWatermarkDao lowWatermarkDao,
       final ObjectMapper mapper) {
     exporter =
         new InterchangeV5Exporter(
             jdbi, validatorsDao, signedBlocksDao, signedAttestationsDao, mapper);
     importer =
         new InterchangeV5Importer(
-            jdbi, validatorsDao, signedBlocksDao, signedAttestationsDao, mapper);
+            jdbi, validatorsDao, signedBlocksDao, signedAttestationsDao, lowWatermarkDao, mapper);
   }
 
   @Override

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Manager.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Manager.java
@@ -43,7 +43,13 @@ public class InterchangeV5Manager implements InterchangeManager {
             jdbi, validatorsDao, signedBlocksDao, signedAttestationsDao, metadataDao, mapper);
     importer =
         new InterchangeV5Importer(
-            jdbi, validatorsDao, signedBlocksDao, signedAttestationsDao, metadataDao, lowWatermarkDao, mapper);
+            jdbi,
+            validatorsDao,
+            signedBlocksDao,
+            signedAttestationsDao,
+            metadataDao,
+            lowWatermarkDao,
+            mapper);
   }
 
   @Override

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/validator/AttestationValidator.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/validator/AttestationValidator.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.web3signer.slashingprotection.validator;
 
+import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestation;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
 
@@ -35,6 +36,7 @@ public class AttestationValidator {
   private final UInt64 targetEpoch;
   private final int validatorId;
   private final SignedAttestationsDao signedAttestationsDao;
+  private final LowWatermarkDao lowWatermarkDao;
 
   public AttestationValidator(
       final Handle handle,
@@ -43,7 +45,8 @@ public class AttestationValidator {
       final UInt64 sourceEpoch,
       final UInt64 targetEpoch,
       final int validatorId,
-      final SignedAttestationsDao signedAttestationsDao) {
+      final SignedAttestationsDao signedAttestationsDao,
+      final LowWatermarkDao lowWatermarkDao) {
     this.handle = handle;
     this.publicKey = publicKey;
     this.signingRoot = signingRoot;
@@ -51,6 +54,7 @@ public class AttestationValidator {
     this.targetEpoch = targetEpoch;
     this.validatorId = validatorId;
     this.signedAttestationsDao = signedAttestationsDao;
+    this.lowWatermarkDao = lowWatermarkDao;
   }
 
   public boolean sourceGreaterThanTargetEpoch() {
@@ -75,6 +79,9 @@ public class AttestationValidator {
     final SignedAttestation signedAttestation =
         new SignedAttestation(validatorId, sourceEpoch, targetEpoch, signingRoot);
     signedAttestationsDao.insertAttestation(handle, signedAttestation);
+
+    //update the watermark?
+
   }
 
   public boolean directlyConflictsWithExistingEntry() {

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/validator/AttestationValidator.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/validator/AttestationValidator.java
@@ -12,8 +12,6 @@
  */
 package tech.pegasys.web3signer.slashingprotection.validator;
 
-import com.google.common.base.Suppliers;
-import java.util.function.Supplier;
 import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestation;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
@@ -21,7 +19,9 @@ import tech.pegasys.web3signer.slashingprotection.dao.SigningWatermark;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
+import com.google.common.base.Suppliers;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -61,8 +61,8 @@ public class AttestationValidator {
     this.signedAttestationsDao = signedAttestationsDao;
     this.lowWatermarkDao = lowWatermarkDao;
 
-    watermarkSupplier = Suppliers.memoize(
-        () -> lowWatermarkDao.findLowWatermarkForValidator(handle, validatorId));
+    watermarkSupplier =
+        Suppliers.memoize(() -> lowWatermarkDao.findLowWatermarkForValidator(handle, validatorId));
   }
 
   public boolean sourceGreaterThanTargetEpoch() {
@@ -89,8 +89,9 @@ public class AttestationValidator {
     signedAttestationsDao.insertAttestation(handle, signedAttestation);
 
     // update the watermark if is otherwise blank (assumes database prevents xor on null for epochs)
-    if (watermarkSupplier.get().isEmpty() || (watermarkSupplier.get().get().getSourceEpoch() == null
-        && watermarkSupplier.get().get().getTargetEpoch() == null)) {
+    if (watermarkSupplier.get().isEmpty()
+        || (watermarkSupplier.get().get().getSourceEpoch() == null
+            && watermarkSupplier.get().get().getTargetEpoch() == null)) {
       lowWatermarkDao.updateEpochWatermarksFor(handle, validatorId, sourceEpoch, targetEpoch);
     }
   }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/validator/BlockValidator.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/validator/BlockValidator.java
@@ -12,8 +12,6 @@
  */
 package tech.pegasys.web3signer.slashingprotection.validator;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlock;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlocksDao;
@@ -21,6 +19,8 @@ import tech.pegasys.web3signer.slashingprotection.dao.SigningWatermark;
 
 import java.util.Optional;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/validator/BlockValidator.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/validator/BlockValidator.java
@@ -12,6 +12,8 @@
  */
 package tech.pegasys.web3signer.slashingprotection.validator;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlock;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlocksDao;
@@ -19,8 +21,6 @@ import tech.pegasys.web3signer.slashingprotection.dao.SigningWatermark;
 
 import java.util.Optional;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/validator/BlockValidator.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/validator/BlockValidator.java
@@ -12,6 +12,8 @@
  */
 package tech.pegasys.web3signer.slashingprotection.validator;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlock;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlocksDao;
@@ -36,7 +38,7 @@ public class BlockValidator {
   private final SignedBlocksDao signedBlocksDao;
   private final LowWatermarkDao lowWatermarkDao;
 
-  private final Optional<SigningWatermark> watermark;
+  private final Supplier<Optional<SigningWatermark>> watermarkSupplier;
 
   public BlockValidator(
       final Handle handle,
@@ -51,7 +53,8 @@ public class BlockValidator {
     this.validatorId = validatorId;
     this.signedBlocksDao = signedBlocksDao;
     this.lowWatermarkDao = lowWatermarkDao;
-    watermark = lowWatermarkDao.findLowWatermarkForValidator(handle, validatorId);
+    watermarkSupplier =
+        Suppliers.memoize(() -> lowWatermarkDao.findLowWatermarkForValidator(handle, validatorId));
   }
 
   public boolean directlyConflictsWithExistingEntry() {
@@ -67,7 +70,7 @@ public class BlockValidator {
   }
 
   public boolean isOlderThanWatermark() {
-    final Optional<UInt64> minimumSlot = watermark.map(SigningWatermark::getSlot);
+    final Optional<UInt64> minimumSlot = watermarkSupplier.get().map(SigningWatermark::getSlot);
     if (minimumSlot.map(slot -> blockSlot.compareTo(slot) <= 0).orElse(false)) {
       LOG.warn(
           "Block slot {} is below minimum existing block slot {}", blockSlot, minimumSlot.get());
@@ -81,7 +84,7 @@ public class BlockValidator {
     signedBlocksDao.insertBlockProposal(handle, signedBlock);
 
     // update the watermark if is otherwise blank
-    if (watermark.isEmpty() || (watermark.get().getSlot() == null)) {
+    if (watermarkSupplier.get().isEmpty() || (watermarkSupplier.get().get().getSlot() == null)) {
       lowWatermarkDao.updateSlotWatermarkFor(handle, validatorId, blockSlot);
     }
   }

--- a/slashing-protection/src/main/resources/migrations/postgresql/V5__xnor_source_target_low_watermark.sql
+++ b/slashing-protection/src/main/resources/migrations/postgresql/V5__xnor_source_target_low_watermark.sql
@@ -1,0 +1,6 @@
+ALTER TABLE low_watermarks
+ADD CONSTRAINT both_epochs_set_or_null
+CHECK (
+  (target_epoch IS NOT NULL and source_epoch IS NOT NULL)
+  OR (target_epoch IS NULL and source_epoch IS NULL)
+);

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
@@ -62,6 +62,7 @@ public class DbSlashingProtectionTest {
   private static final Bytes SIGNING_ROOT = Bytes.of(3);
   private static final UInt64 SOURCE_EPOCH = UInt64.valueOf(10);
   private static final UInt64 TARGET_EPOCH = UInt64.valueOf(20);
+  private static final Bytes32 GVR = Bytes32.leftPad(Bytes.of(100));
 
   @Mock private ValidatorsDao validatorsDao;
   @Mock private SignedBlocksDao signedBlocksDao;
@@ -132,7 +133,12 @@ public class DbSlashingProtectionTest {
   public void blockCannotSignWhenNoRegisteredValidator() {
     final DbSlashingProtection dbSlashingProtection =
         new DbSlashingProtection(
-            db.getJdbi(), validatorsDao, signedBlocksDao, signedAttestationsDao, metadataDao, lowWatermarkDao);
+            db.getJdbi(),
+            validatorsDao,
+            signedBlocksDao,
+            signedAttestationsDao,
+            metadataDao,
+            lowWatermarkDao);
 
     assertThatThrownBy(
             () -> dbSlashingProtection.maySignBlock(PUBLIC_KEY1, SIGNING_ROOT, SLOT, GVR))
@@ -246,7 +252,12 @@ public class DbSlashingProtectionTest {
   public void attestationCannotSignWhenNoRegisteredValidator() {
     final DbSlashingProtection dbSlashingProtection =
         new DbSlashingProtection(
-            db.getJdbi(), validatorsDao, signedBlocksDao, signedAttestationsDao, metadataDao, lowWatermarkDao);
+            db.getJdbi(),
+            validatorsDao,
+            signedBlocksDao,
+            signedAttestationsDao,
+            metadataDao,
+            lowWatermarkDao);
 
     assertThatThrownBy(
             () ->

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
@@ -61,16 +61,11 @@ public class DbSlashingProtectionTest {
   private static final UInt64 SOURCE_EPOCH = UInt64.valueOf(10);
   private static final UInt64 TARGET_EPOCH = UInt64.valueOf(20);
 
-  @Mock
-  private ValidatorsDao validatorsDao;
-  @Mock
-  private SignedBlocksDao signedBlocksDao;
-  @Mock
-  private SignedAttestationsDao signedAttestationsDao;
-  @Mock
-  private LowWatermarkDao lowWatermarkDao;
-  @Rule
-  public JdbiRule db = JdbiRule.embeddedPostgres();
+  @Mock private ValidatorsDao validatorsDao;
+  @Mock private SignedBlocksDao signedBlocksDao;
+  @Mock private SignedAttestationsDao signedAttestationsDao;
+  @Mock private LowWatermarkDao lowWatermarkDao;
+  @Rule public JdbiRule db = JdbiRule.embeddedPostgres();
 
   private DbSlashingProtection dbSlashingProtection;
 
@@ -147,14 +142,14 @@ public class DbSlashingProtectionTest {
     final SignedAttestation attestation =
         new SignedAttestation(VALIDATOR_ID, SOURCE_EPOCH, TARGET_EPOCH, SIGNING_ROOT);
     when(signedAttestationsDao.findAttestationsForEpochWithDifferentSigningRoot(
-        any(), anyInt(), any(), any()))
+            any(), anyInt(), any(), any()))
         .thenReturn(emptyList());
     when(signedAttestationsDao.findMatchingAttestation(any(), anyInt(), any(), eq(SIGNING_ROOT)))
         .thenReturn(Optional.of(attestation));
 
     assertThat(
-        dbSlashingProtection.maySignAttestation(
-            PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, TARGET_EPOCH))
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, TARGET_EPOCH))
         .isTrue();
     verify(signedAttestationsDao)
         .findAttestationsForEpochWithDifferentSigningRoot(
@@ -167,7 +162,7 @@ public class DbSlashingProtectionTest {
     final SignedAttestation attestation =
         new SignedAttestation(VALIDATOR_ID, SOURCE_EPOCH, TARGET_EPOCH, SIGNING_ROOT);
     when(signedAttestationsDao.findAttestationsForEpochWithDifferentSigningRoot(
-        any(), anyInt(), any(), any()))
+            any(), anyInt(), any(), any()))
         .thenReturn(emptyList());
     final SignedAttestation surroundingAttestation =
         new SignedAttestation(
@@ -176,8 +171,8 @@ public class DbSlashingProtectionTest {
         .thenReturn(List.of(surroundingAttestation));
 
     assertThat(
-        dbSlashingProtection.maySignAttestation(
-            PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, TARGET_EPOCH))
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, TARGET_EPOCH))
         .isFalse();
     verify(signedAttestationsDao)
         .findAttestationsForEpochWithDifferentSigningRoot(
@@ -192,7 +187,7 @@ public class DbSlashingProtectionTest {
     final SignedAttestation attestation =
         new SignedAttestation(VALIDATOR_ID, SOURCE_EPOCH, TARGET_EPOCH, SIGNING_ROOT);
     when(signedAttestationsDao.findAttestationsForEpochWithDifferentSigningRoot(
-        any(), anyInt(), any(), any()))
+            any(), anyInt(), any(), any()))
         .thenReturn(emptyList());
     when(signedAttestationsDao.findSurroundingAttestations(any(), anyInt(), any(), any()))
         .thenReturn(emptyList());
@@ -202,8 +197,8 @@ public class DbSlashingProtectionTest {
         .thenReturn(List.of(surroundedAttestation));
 
     assertThat(
-        dbSlashingProtection.maySignAttestation(
-            PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, TARGET_EPOCH))
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, TARGET_EPOCH))
         .isFalse();
     verify(signedAttestationsDao)
         .findAttestationsForEpochWithDifferentSigningRoot(
@@ -220,7 +215,7 @@ public class DbSlashingProtectionTest {
     final SignedAttestation attestation =
         new SignedAttestation(VALIDATOR_ID, SOURCE_EPOCH, TARGET_EPOCH, SIGNING_ROOT);
     when(signedAttestationsDao.findAttestationsForEpochWithDifferentSigningRoot(
-        any(), anyInt(), any(), any()))
+            any(), anyInt(), any(), any()))
         .thenReturn(emptyList());
     when(signedAttestationsDao.findSurroundingAttestations(any(), anyInt(), any(), any()))
         .thenReturn(emptyList());
@@ -228,8 +223,8 @@ public class DbSlashingProtectionTest {
         .thenReturn(emptyList());
 
     assertThat(
-        dbSlashingProtection.maySignAttestation(
-            PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, TARGET_EPOCH))
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, TARGET_EPOCH))
         .isTrue();
     verify(signedAttestationsDao)
         .findAttestationsForEpochWithDifferentSigningRoot(
@@ -248,9 +243,9 @@ public class DbSlashingProtectionTest {
             db.getJdbi(), validatorsDao, signedBlocksDao, signedAttestationsDao, lowWatermarkDao);
 
     assertThatThrownBy(
-        () ->
-            dbSlashingProtection.maySignAttestation(
-                PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, TARGET_EPOCH))
+            () ->
+                dbSlashingProtection.maySignAttestation(
+                    PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, TARGET_EPOCH))
         .hasMessage("Unregistered validator for " + PUBLIC_KEY1)
         .isInstanceOf(IllegalStateException.class);
     final SignedAttestation attestation =
@@ -265,8 +260,8 @@ public class DbSlashingProtectionTest {
         new SignedAttestation(VALIDATOR_ID, sourceEpoch, TARGET_EPOCH, SIGNING_ROOT);
 
     assertThat(
-        dbSlashingProtection.maySignAttestation(
-            PUBLIC_KEY1, SIGNING_ROOT, sourceEpoch, TARGET_EPOCH))
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, sourceEpoch, TARGET_EPOCH))
         .isFalse();
     verifyNoInteractions(signedAttestationsDao);
     verify(signedAttestationsDao, never()).insertAttestation(any(), refEq(attestation));
@@ -302,7 +297,7 @@ public class DbSlashingProtectionTest {
   @Test
   public void slashingProtectionEnactedIfAttestationWithNullSigningRootExists() {
     when(signedAttestationsDao.findAttestationsForEpochWithDifferentSigningRoot(
-        any(), anyInt(), any(), any()))
+            any(), anyInt(), any(), any()))
         .thenReturn(List.of(new SignedAttestation(1, UInt64.valueOf(1), UInt64.valueOf(2), null)));
 
     final boolean result =
@@ -339,39 +334,41 @@ public class DbSlashingProtectionTest {
 
   @Test
   public void slashingProtectionEnactedIfBlockWithSlotEqualToMinSlot() {
-    when(signedBlocksDao.minimumSlot(any(), anyInt())).thenReturn(Optional.of(SLOT));
+    when(lowWatermarkDao.findLowWatermarkForValidator(any(), anyInt()))
+        .thenReturn(Optional.of(new SigningWatermark(VALIDATOR_ID, SLOT, null, null)));
 
     assertThat(dbSlashingProtection.maySignBlock(PUBLIC_KEY1, SIGNING_ROOT, SLOT)).isFalse();
 
-    verify(signedBlocksDao).minimumSlot(any(), eq(VALIDATOR_ID));
+    verify(lowWatermarkDao).findLowWatermarkForValidator(any(), eq(VALIDATOR_ID));
     verify(signedBlocksDao, never()).insertBlockProposal(any(), any());
   }
 
   @Test
   public void slashingProtectionEnactedIfAttestationWithSourceEpochLessThanMin() {
-    when(signedAttestationsDao.minimumSourceEpoch(any(), anyInt()))
-        .thenReturn(Optional.of(UInt64.valueOf(2)));
+    when(lowWatermarkDao.findLowWatermarkForValidator(any(), anyInt()))
+        .thenReturn(
+            Optional.of(new SigningWatermark(1, null, UInt64.valueOf(2), UInt64.valueOf(3))));
 
     assertThat(
-        dbSlashingProtection.maySignAttestation(
-            PUBLIC_KEY1, SIGNING_ROOT, UInt64.ZERO, UInt64.ZERO))
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, UInt64.ZERO, UInt64.ZERO))
         .isFalse();
 
-    verify(signedAttestationsDao).minimumSourceEpoch(any(), eq(VALIDATOR_ID));
+    verify(lowWatermarkDao).findLowWatermarkForValidator(any(), eq(VALIDATOR_ID));
     verify(signedAttestationsDao, never()).insertAttestation(any(), any());
   }
 
   @Test
   public void attestationCanBeSignedWithSourceEpochEqualToMin() {
-    when(signedAttestationsDao.minimumSourceEpoch(any(), anyInt()))
-        .thenReturn(Optional.of(SOURCE_EPOCH));
+    when(lowWatermarkDao.findLowWatermarkForValidator(any(), anyInt()))
+        .thenReturn(Optional.of(new SigningWatermark(1, null, SOURCE_EPOCH, UInt64.valueOf(3))));
 
     assertThat(
-        dbSlashingProtection.maySignAttestation(
-            PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, TARGET_EPOCH))
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, TARGET_EPOCH))
         .isTrue();
 
-    verify(signedAttestationsDao).minimumSourceEpoch(any(), eq(VALIDATOR_ID));
+    verify(lowWatermarkDao).findLowWatermarkForValidator(any(), eq(VALIDATOR_ID));
     final SignedAttestation attestation =
         new SignedAttestation(VALIDATOR_ID, SOURCE_EPOCH, TARGET_EPOCH, SIGNING_ROOT);
     verify(signedAttestationsDao).insertAttestation(any(), refEq(attestation));
@@ -379,35 +376,33 @@ public class DbSlashingProtectionTest {
 
   @Test
   public void slashingProtectionEnactedIfAttestationWithTargetEpochLessThanMin() {
-    when(signedAttestationsDao.minimumSourceEpoch(any(), anyInt()))
-        .thenReturn(Optional.of(UInt64.valueOf(2)));
-    when(signedAttestationsDao.minimumTargetEpoch(any(), anyInt()))
-        .thenReturn(Optional.of(UInt64.valueOf(5)));
+    when(lowWatermarkDao.findLowWatermarkForValidator(any(), anyInt()))
+        .thenReturn(
+            Optional.of(
+                new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(1), UInt64.valueOf(5))));
 
     assertThat(
-        dbSlashingProtection.maySignAttestation(
-            PUBLIC_KEY1, SIGNING_ROOT, UInt64.valueOf(3), UInt64.valueOf(4)))
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, UInt64.valueOf(3), UInt64.valueOf(4)))
         .isFalse();
 
-    verify(signedAttestationsDao).minimumSourceEpoch(any(), eq(VALIDATOR_ID));
-    verify(signedAttestationsDao).minimumTargetEpoch(any(), eq(VALIDATOR_ID));
+    verify(lowWatermarkDao).findLowWatermarkForValidator(any(), eq(VALIDATOR_ID));
     verify(signedAttestationsDao, never()).insertAttestation(any(), any());
   }
 
   @Test
   public void slashingProtectionEnactedIfAttestationWithTargetEpochEqualToMin() {
-    when(signedAttestationsDao.minimumSourceEpoch(any(), anyInt()))
-        .thenReturn(Optional.of(UInt64.valueOf(2)));
-    when(signedAttestationsDao.minimumTargetEpoch(any(), anyInt()))
-        .thenReturn(Optional.of(UInt64.valueOf(4)));
+    when(lowWatermarkDao.findLowWatermarkForValidator(any(), anyInt()))
+        .thenReturn(
+            Optional.of(
+                new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(2), UInt64.valueOf(4))));
 
     assertThat(
-        dbSlashingProtection.maySignAttestation(
-            PUBLIC_KEY1, SIGNING_ROOT, UInt64.valueOf(3), UInt64.valueOf(4)))
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, UInt64.valueOf(3), UInt64.valueOf(4)))
         .isFalse();
 
-    verify(signedAttestationsDao).minimumSourceEpoch(any(), eq(VALIDATOR_ID));
-    verify(signedAttestationsDao).minimumTargetEpoch(any(), eq(VALIDATOR_ID));
+    verify(lowWatermarkDao).findLowWatermarkForValidator(any(), eq(VALIDATOR_ID));
     verify(signedAttestationsDao, never()).insertAttestation(any(), any());
   }
 
@@ -415,16 +410,18 @@ public class DbSlashingProtectionTest {
   public void cannotSignMatchingAttestationWhichIsSurroundedEvenIfMatchesExisting() {
     // NOTE: this is only possible in the production system when interchange import is enabled
     when(signedAttestationsDao.findAttestationsForEpochWithDifferentSigningRoot(
-        any(), anyInt(), any(), any()))
+            any(), anyInt(), any(), any()))
         .thenReturn(emptyList());
 
     when(signedAttestationsDao.findSurroundingAttestations(any(), anyInt(), any(), any()))
         .thenReturn(
-            List.of(new SignedAttestation(1, UInt64.valueOf(2), UInt64.valueOf(5), Bytes.of(11))));
+            List.of(
+                new SignedAttestation(
+                    VALIDATOR_ID, UInt64.valueOf(2), UInt64.valueOf(5), Bytes.of(11))));
 
     assertThat(
-        dbSlashingProtection.maySignAttestation(
-            PUBLIC_KEY1, SIGNING_ROOT, UInt64.valueOf(3), UInt64.valueOf(4)))
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, UInt64.valueOf(3), UInt64.valueOf(4)))
         .isFalse();
 
     verify(signedAttestationsDao, never()).findMatchingAttestation(any(), anyInt(), any(), any());
@@ -436,16 +433,18 @@ public class DbSlashingProtectionTest {
   public void cannotSignMatchingAttestationWhichIsSurroundingEvenIfMatchesExisting() {
     // NOTE: this is only possible in the production system when interchange import is enabled
     when(signedAttestationsDao.findAttestationsForEpochWithDifferentSigningRoot(
-        any(), anyInt(), any(), any()))
+            any(), anyInt(), any(), any()))
         .thenReturn(emptyList());
 
     when(signedAttestationsDao.findSurroundedAttestations(any(), anyInt(), any(), any()))
         .thenReturn(
-            List.of(new SignedAttestation(1, UInt64.valueOf(3), UInt64.valueOf(4), Bytes.of(11))));
+            List.of(
+                new SignedAttestation(
+                    VALIDATOR_ID, UInt64.valueOf(3), UInt64.valueOf(4), Bytes.of(11))));
 
     assertThat(
-        dbSlashingProtection.maySignAttestation(
-            PUBLIC_KEY1, SIGNING_ROOT, UInt64.valueOf(2), UInt64.valueOf(5)))
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, UInt64.valueOf(2), UInt64.valueOf(5)))
         .isFalse();
 
     verify(signedAttestationsDao, never()).findMatchingAttestation(any(), anyInt(), any(), any());

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/LowWatermarkDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/LowWatermarkDaoTest.java
@@ -13,7 +13,9 @@
 package tech.pegasys.web3signer.slashingprotection.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import tech.pegasys.web3signer.slashingprotection.DbConnection;
 
 import java.util.Optional;
@@ -143,6 +145,20 @@ public class LowWatermarkDaoTest {
     assertThat(secondValidator.get().getSlot()).isEqualTo(UInt64.valueOf(7));
     assertThat(secondValidator.get().getSourceEpoch()).isEqualTo(UInt64.valueOf(5));
     assertThat(secondValidator.get().getTargetEpoch()).isEqualTo(UInt64.valueOf(6));
+  }
+
+  @Test
+  public void ensureBothWatermarksMustBeNonNull() {
+    insertValidator(Bytes.of(100), 1);
+    assertThatThrownBy(
+        () -> lowWatermarkDao.updateEpochWatermarksFor(handle, 1, null, UInt64.valueOf(3)))
+        .isInstanceOf(
+            UnableToExecuteStatementException.class);
+    assertThatThrownBy(
+        () -> lowWatermarkDao.updateEpochWatermarksFor(handle, 1, UInt64.valueOf(2), null))
+        .isInstanceOf(
+            UnableToExecuteStatementException.class);
+
   }
 
   private void insertValidator(final Bytes publicKey, final int validatorId) {

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/LowWatermarkDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/LowWatermarkDaoTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.web3signer.slashingprotection.dao;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import tech.pegasys.web3signer.slashingprotection.DbConnection;
 
 import java.util.Optional;
@@ -23,6 +22,7 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.jdbi.v3.testing.JdbiRule;
 import org.jdbi.v3.testing.Migration;
 import org.junit.After;
@@ -151,14 +151,11 @@ public class LowWatermarkDaoTest {
   public void ensureBothWatermarksMustBeNonNull() {
     insertValidator(Bytes.of(100), 1);
     assertThatThrownBy(
-        () -> lowWatermarkDao.updateEpochWatermarksFor(handle, 1, null, UInt64.valueOf(3)))
-        .isInstanceOf(
-            UnableToExecuteStatementException.class);
+            () -> lowWatermarkDao.updateEpochWatermarksFor(handle, 1, null, UInt64.valueOf(3)))
+        .isInstanceOf(UnableToExecuteStatementException.class);
     assertThatThrownBy(
-        () -> lowWatermarkDao.updateEpochWatermarksFor(handle, 1, UInt64.valueOf(2), null))
-        .isInstanceOf(
-            UnableToExecuteStatementException.class);
-
+            () -> lowWatermarkDao.updateEpochWatermarksFor(handle, 1, UInt64.valueOf(2), null))
+        .isInstanceOf(UnableToExecuteStatementException.class);
   }
 
   private void insertValidator(final Bytes publicKey, final int validatorId) {


### PR DESCRIPTION
Rather than relying on the lowest-block/attestation to determine how far back Web3signer can safely sign, there is now a set of metadata which is set on first signing.

In future, this data will also be updated as part of the import logic.