### PR TITLE
Slashing rules enforced - return status code 412

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/slashing/SlashingAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/slashing/SlashingAcceptanceTest.java
@@ -39,6 +39,7 @@ public class SlashingAcceptanceTest extends AcceptanceTestBase {
   public static final String DB_USERNAME = "postgres";
   public static final String DB_PASSWORD = "postgres";
   protected final BLSKeyPair keyPair = BLSKeyPair.random(0);
+  static final int SLASHING_PROTECTION_ENFORCED = 412;
 
   final List<String> attestationSlashingMetrics =
       List.of(
@@ -109,7 +110,7 @@ public class SlashingAcceptanceTest extends AcceptanceTestBase {
 
     final Response secondResponse =
         signer.eth2Sign(keyPair.getPublicKey().toString(), secondRequest);
-    assertThat(secondResponse.getStatusCode()).isEqualTo(403);
+    assertThat(secondResponse.getStatusCode()).isEqualTo(SLASHING_PROTECTION_ENFORCED);
 
     assertThat(signer.getMetricsMatching(attestationSlashingMetrics))
         .containsOnly(
@@ -131,7 +132,7 @@ public class SlashingAcceptanceTest extends AcceptanceTestBase {
 
     final Response surroundedResponse =
         signer.eth2Sign(keyPair.getPublicKey().toString(), surroundedRequest);
-    assertThat(surroundedResponse.getStatusCode()).isEqualTo(403);
+    assertThat(surroundedResponse.getStatusCode()).isEqualTo(SLASHING_PROTECTION_ENFORCED);
   }
 
   @Test
@@ -149,7 +150,7 @@ public class SlashingAcceptanceTest extends AcceptanceTestBase {
 
     final Response surroundingResponse =
         signer.eth2Sign(keyPair.getPublicKey().toString(), surroundingRequest);
-    assertThat(surroundingResponse.getStatusCode()).isEqualTo(403);
+    assertThat(surroundingResponse.getStatusCode()).isEqualTo(SLASHING_PROTECTION_ENFORCED);
   }
 
   @Test
@@ -176,7 +177,7 @@ public class SlashingAcceptanceTest extends AcceptanceTestBase {
   }
 
   @Test
-  void signingBlockWithDifferentSigningRootForPreviousSlotFailsWith403(@TempDir Path testDirectory)
+  void signingBlockWithDifferentSigningRootForPreviousSlotFailsWith412(@TempDir Path testDirectory)
       throws JsonProcessingException {
     setupSigner(testDirectory, true);
 
@@ -200,7 +201,7 @@ public class SlashingAcceptanceTest extends AcceptanceTestBase {
 
     final Response secondResponse =
         signer.eth2Sign(keyPair.getPublicKey().toString(), secondRequest);
-    assertThat(secondResponse.getStatusCode()).isEqualTo(403);
+    assertThat(secondResponse.getStatusCode()).isEqualTo(SLASHING_PROTECTION_ENFORCED);
     assertThat(signer.getMetricsMatching(blockSlashingMetrics))
         .containsOnly(blockSlashingMetrics.get(0) + " 1.0", blockSlashingMetrics.get(1) + " 1.0");
   }

--- a/core/src/main/resources/openapi/web3signer-eth2.yaml
+++ b/core/src/main/resources/openapi/web3signer-eth2.yaml
@@ -60,8 +60,8 @@ paths:
               schema:
                 type: string
               example: '0xb3baa751d0a9132cfe93e4e3d5ff9075111100e3789dca219ade5a24d27e19d16b3353149da1833e9b691bb38634e8dc04469be7032132906c927d7e1a49b414730612877bc6b2810c8f202daf793d1ab0d6b5cb21d52f9e52e883859887a5d9'
-        '403':
-          description: 'Signing operation forbidden due to slashing protection'
+        '412':
+          description: 'Signing operation failed due to slashing protection rules'
         '404':
           description: 'Public Key not found'
         '400':


### PR DESCRIPTION
Return status code 412 instead of 403 as 403 is often interpreted by reverse proxy (such as nginx) as authorization failure.

Signed-off-by: Usman Saleem <usman@usmans.info>