### PR TITLE
Logging around loading and parsing of signer configuration files

### DIFF
--- a/core/src/test/java/tech/pegasys/web3signer/core/multikey/SignerLoaderTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/multikey/SignerLoaderTest.java
@@ -250,7 +250,7 @@ class SignerLoaderTest {
       createFileInConfigsDirectory(PUBLIC_KEY1);
       SignerLoader.load(configsDirectory, FILE_EXTENSION, signerParser);
 
-      assertThat(logAppender.getLogMessagesReceived().get(0).getMessage().getFormattedMessage())
+      assertThat(logAppender.getLogMessagesReceived().get(1).getMessage().getFormattedMessage())
           .contains(rootCause.getMessage());
     } finally {
       logger.removeAppender(logAppender);


### PR DESCRIPTION
Fixes #305 

The logs will look like:
~~~
./web3signer --key-store-path=/Users/-/dev/large_keys eth2 --slashing-protection-enabled=false
2020-11-17 11:17:46.403+10:00 | main | INFO  | Web3SignerApp | Web3Signer has started with args --key-store-path=/Users/-/dev/large_keys,eth2,--slashing-protection-enabled=false
2020-11-17 11:17:46.411+10:00 | main | INFO  | Web3SignerApp | Version = web3signer/v0.2.1-dev-4e3f18c5/osx-x86_64/adoptopenjdk-java-15
2020-11-17 11:17:46.883+10:00 | main | INFO  | SignerLoader | Loading signer configuration files from /Users/-/dev/large_keys
2020-11-17 11:17:46.903+10:00 | ForkJoinPool.commonPool-worker-21 | INFO  | SignerLoader | 10 signer configuration files processed
2020-11-17 11:17:52.350+10:00 | ForkJoinPool.commonPool-worker-5 | INFO  | BLS | BLS: loaded BLST library
2020-11-17 11:17:52.362+10:00 | ForkJoinPool.commonPool-worker-9 | INFO  | SignerLoader | 20 signer configuration files processed
2020-11-17 11:17:54.852+10:00 | ForkJoinPool.commonPool-worker-31 | INFO  | SignerLoader | 30 signer configuration files processed
2020-11-17 11:17:57.257+10:00 | ForkJoinPool.commonPool-worker-7 | INFO  | SignerLoader | 40 signer configuration files processed
~~~