### PR TITLE
Config file for nested subcommands

### DIFF
--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/valueprovider/YamlConfigFileDefaultProvider.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/valueprovider/YamlConfigFileDefaultProvider.java
@@ -19,8 +19,10 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -33,9 +35,11 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.logging.log4j.util.Strings;
 import picocli.CommandLine;
 import picocli.CommandLine.IDefaultValueProvider;
 import picocli.CommandLine.Model.ArgSpec;
+import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Model.OptionSpec;
 import picocli.CommandLine.ParameterException;
 
@@ -111,9 +115,9 @@ public class YamlConfigFileDefaultProvider implements IDefaultValueProvider {
 
     // subcommands options
     final Set<String> subCommandsOptions =
-        commandLine.getSubcommands().values().stream()
-            .flatMap(YamlConfigFileDefaultProvider::subCommandOptions)
-            .map(YamlConfigFileDefaultProvider::buildQualifiedOptionName)
+        subCommandValues(commandLine)
+            .flatMap(YamlConfigFileDefaultProvider::allSubCommandOptions)
+            .map(optionSpec -> buildQualifiedOptionName(optionSpec, commandLine.getCommandSpec()))
             .collect(Collectors.toSet());
 
     picoCliOptionsKeys.addAll(mainCommandOptions);
@@ -146,7 +150,7 @@ public class YamlConfigFileDefaultProvider implements IDefaultValueProvider {
       keyName = buildOptionName(optionSpec);
     } else {
       // subcommand option
-      keyName = buildQualifiedOptionName(optionSpec);
+      keyName = buildQualifiedOptionName(optionSpec, commandLine.getCommandSpec());
     }
 
     final Object value = result.get(keyName);
@@ -162,12 +166,29 @@ public class YamlConfigFileDefaultProvider implements IDefaultValueProvider {
     return String.valueOf(value);
   }
 
-  private static Stream<OptionSpec> subCommandOptions(final CommandLine subcommand) {
-    return subcommand.getCommandSpec().options().stream();
+  private static Stream<CommandLine> subCommandValues(final CommandLine c) {
+    return c.getSubcommands().values().stream();
   }
 
-  private static String buildQualifiedOptionName(final OptionSpec optionSpec) {
-    return optionSpec.command().name() + "." + buildOptionName(optionSpec);
+  private static Stream<OptionSpec> allSubCommandOptions(final CommandLine subcommand) {
+    return Stream.concat(
+        subcommand.getCommandSpec().options().stream(),
+        subCommandValues(subcommand).flatMap(YamlConfigFileDefaultProvider::allSubCommandOptions));
+  }
+
+  private static String buildQualifiedOptionName(
+      final OptionSpec optionSpec, final CommandSpec baseCommandSpec) {
+    final List<String> parents = new ArrayList<>();
+    CommandSpec command = optionSpec.command();
+    do {
+      if (!command.equals(baseCommandSpec)) {
+        parents.add(command.name());
+      }
+      command = command.parent();
+    } while (command != null);
+    Collections.reverse(parents);
+
+    return Strings.join(parents, '.') + "." + buildOptionName(optionSpec);
   }
 
   private static String buildOptionName(final OptionSpec optionSpec) {

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/valueprovider/YamlConfigFileDefaultProvider.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/valueprovider/YamlConfigFileDefaultProvider.java
@@ -22,6 +22,7 @@ import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -117,7 +118,7 @@ public class YamlConfigFileDefaultProvider implements IDefaultValueProvider {
     final Set<String> subCommandsOptions =
         subCommandValues(commandLine)
             .flatMap(YamlConfigFileDefaultProvider::allSubCommandOptions)
-            .map(optionSpec -> buildQualifiedOptionName(optionSpec, commandLine.getCommandSpec()))
+            .map(YamlConfigFileDefaultProvider::buildQualifiedOptionName)
             .collect(Collectors.toSet());
 
     picoCliOptionsKeys.addAll(mainCommandOptions);
@@ -150,7 +151,7 @@ public class YamlConfigFileDefaultProvider implements IDefaultValueProvider {
       keyName = buildOptionName(optionSpec);
     } else {
       // subcommand option
-      keyName = buildQualifiedOptionName(optionSpec, commandLine.getCommandSpec());
+      keyName = buildQualifiedOptionName(optionSpec);
     }
 
     final Object value = result.get(keyName);
@@ -176,16 +177,13 @@ public class YamlConfigFileDefaultProvider implements IDefaultValueProvider {
         subCommandValues(subcommand).flatMap(YamlConfigFileDefaultProvider::allSubCommandOptions));
   }
 
-  private static String buildQualifiedOptionName(
-      final OptionSpec optionSpec, final CommandSpec baseCommandSpec) {
+  private static String buildQualifiedOptionName(final OptionSpec optionSpec) {
     final List<String> parents = new ArrayList<>();
     CommandSpec command = optionSpec.command();
     do {
-      if (!command.equals(baseCommandSpec)) {
-        parents.add(command.name());
-      }
+      parents.add(command.name());
       command = command.parent();
-    } while (command != null);
+    } while (command.parent() != null);
     Collections.reverse(parents);
 
     return Strings.join(parents, '.') + "." + buildOptionName(optionSpec);

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/valueprovider/YamlConfigFileDefaultProvider.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/valueprovider/YamlConfigFileDefaultProvider.java
@@ -22,7 +22,6 @@ import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/commandline/src/test/java/tech/pegasys/web3signer/commandline/valueprovider/YamlConfigFileDefaultProviderTest.java
+++ b/commandline/src/test/java/tech/pegasys/web3signer/commandline/valueprovider/YamlConfigFileDefaultProviderTest.java
@@ -77,7 +77,7 @@ class YamlConfigFileDefaultProviderTest {
   }
 
   @Test
-  void valuesFromConfigFileWithSubSubcommandArePopulated(@TempDir final Path tempDir)
+  void valuesFromConfigFileWithNestedSubcommandArePopulated(@TempDir final Path tempDir)
       throws IOException {
     final String subcommandOptions =
         String.join(


### PR DESCRIPTION
Config file now allows for nested subcommands to specify value in the config file.

e.g. For the eth2 slashing export you could have config with
```
eth2.slashing-protection-db-url: "jdbc:postgresql://localhost/web3signer"
eth2.export.to: "tmp/export.json"
```
