### PR TITLE
Use genesis fork version on deposit message request

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/Eth2RequestUtils.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/Eth2RequestUtils.java
@@ -176,7 +176,8 @@ public class Eth2RequestUtils {
             BLSPubKey.fromHexString(
                 "0x8f82597c919c056571a05dfe83e6a7d32acf9ad8931be04d11384e95468cd68b40129864ae12745f774654bbac09b057"),
             Bytes32.random(new Random(2)),
-            UInt64.valueOf(32));
+            UInt64.valueOf(32),
+            Bytes4.fromHexString("0x00"));
     final Bytes signingRoot =
         compute_signing_root(
             depositMessage.asInternalDepositMessage(), compute_domain(DOMAIN_DEPOSIT));

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/Eth2RequestUtils.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/Eth2RequestUtils.java
@@ -177,7 +177,7 @@ public class Eth2RequestUtils {
                 "0x8f82597c919c056571a05dfe83e6a7d32acf9ad8931be04d11384e95468cd68b40129864ae12745f774654bbac09b057"),
             Bytes32.random(new Random(2)),
             UInt64.valueOf(32),
-            Bytes4.fromHexString("0x00"));
+            Bytes4.fromHexString("0x00000001"));
     final Bytes signingRoot =
         compute_signing_root(
             depositMessage.asInternalDepositMessage(), compute_domain(DOMAIN_DEPOSIT));

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/DepositMessage.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/DepositMessage.java
@@ -14,6 +14,7 @@ package tech.pegasys.web3signer.core.service.http.handlers.signing.eth2;
 
 import tech.pegasys.teku.api.schema.BLSPubKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.ssz.SSZTypes.Bytes4;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.tuweni.bytes.Bytes32;
@@ -22,15 +23,18 @@ public class DepositMessage {
   private final BLSPubKey pubkey;
   private final Bytes32 withdrawalCredentials;
   private final UInt64 amount;
+  private final Bytes4 genesisForkVersion;
 
   public DepositMessage(
       @JsonProperty(value = "pubkey", required = true) final BLSPubKey pubkey,
       @JsonProperty(value = "withdrawal_credentials", required = true)
           final Bytes32 withdrawalCredentials,
-      @JsonProperty(value = "amount", required = true) final UInt64 amount) {
+      @JsonProperty(value = "amount", required = true) final UInt64 amount,
+      @JsonProperty(value = "genesis_fork_version", required = true) Bytes4 genesisForkVersion) {
     this.pubkey = pubkey;
     this.withdrawalCredentials = withdrawalCredentials;
     this.amount = amount;
+    this.genesisForkVersion = genesisForkVersion;
   }
 
   @JsonProperty("pubkey")
@@ -46,6 +50,11 @@ public class DepositMessage {
   @JsonProperty("amount")
   public UInt64 getAmount() {
     return amount;
+  }
+
+  @JsonProperty("genesis_fork_version")
+  public Bytes4 getGenesisForkVersion() {
+    return genesisForkVersion;
   }
 
   public tech.pegasys.teku.datastructures.operations.DepositMessage asInternalDepositMessage() {

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/Eth2SignForIdentifierHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/Eth2SignForIdentifierHandler.java
@@ -44,6 +44,7 @@ import io.vertx.ext.web.api.RequestParameters;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer.TimingContext;
 
@@ -215,7 +216,9 @@ public class Eth2SignForIdentifierHandler implements Handler<RoutingContext> {
       case DEPOSIT:
         checkArgument(body.getDeposit() != null, "deposit must be specified");
         return compute_signing_root(
-            body.getDeposit().asInternalDepositMessage(), compute_domain(DOMAIN_DEPOSIT));
+            body.getDeposit().asInternalDepositMessage(),
+            compute_domain(
+                DOMAIN_DEPOSIT, body.getDeposit().getGenesisForkVersion(), Bytes32.ZERO));
       default:
         throw new IllegalStateException("Signing root unimplemented for type " + body.getType());
     }

--- a/core/src/main/resources/openapi/web3signer-eth2.yaml
+++ b/core/src/main/resources/openapi/web3signer-eth2.yaml
@@ -378,6 +378,9 @@ components:
           type: "string"
         signature:
           type: "string"
+        genesis_fork_version:
+          type: "string"
+          description: Bytes4 hexadecimal
     VoluntaryExit:
       type: object
       properties:


### PR DESCRIPTION
The Eth2 signing for deposits assumes a genesis fork version of 0x00000001 which is correct for medalla. This does not work for testnets or mainnet as the genesis fork version is different.

We need to add the genesis fork version as another value in the deposit API.

#314