### PR TITLE
Switch to tag based releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,49 +258,67 @@ workflows:
     jobs:
       - build:
           context:
-            - dockerhub-quorumengineering-ro              
+            - dockerhub-quorumengineering-ro
+          filters:
+            tags: &filters-release-tags
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?/
       - acceptanceTests:
           requires:
             - build
           context:
-            - dockerhub-quorumengineering-ro                    
+            - dockerhub-quorumengineering-ro
+          filters:
+            tags:
+              <<: *filters-release-tags
       - performanceTests:
           requires:
             - build
           context:
-            - dockerhub-quorumengineering-ro                    
+            - dockerhub-quorumengineering-ro
+          filters:
+            tags:
+              <<: *filters-release-tags
       - buildDocker:
           requires:
             - build
           context:
-            - dockerhub-quorumengineering-ro                    
+            - dockerhub-quorumengineering-ro
+          filters:
+            tags:
+              <<: *filters-release-tags
       - publishOpenApiSpec:
           filters:
             branches:
               only:
                 - master
                 - /^release-.*/
+            tags:
+              <<: *filters-release-tags
           requires:
             - acceptanceTests
           context:
-            - dockerhub-quorumengineering-ro                    
+            - dockerhub-quorumengineering-ro
       - publish:
           filters:
             branches:
               only:
                 - master
                 - /^release-.*/
+              tags:
+                <<: *filters-release-tags
           requires:
             - acceptanceTests
           context:
-            - dockerhub-quorumengineering-ro     
-            - quorum-gradle               
+            - dockerhub-quorumengineering-ro
+            - quorum-gradle
       - publishDocker:
           filters:
             branches:
               only:
                 - master
                 - /^release-.*/
+            tags:
+              <<: *filters-release-tags
           requires:
             - acceptanceTests
             - buildDocker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,8 +304,8 @@ workflows:
               only:
                 - master
                 - /^release-.*/
-              tags:
-                <<: *filters-release-tags
+            tags:
+              <<: *filters-release-tags
           requires:
             - acceptanceTests
           context:

--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,17 @@ plugins {
   id 'me.champeau.gradle.jmh' version '0.5.0' apply false
   id 'net.ltgt.errorprone' version '1.1.1'
   id 'net.researchgate.release' version '2.8.1'
+  id 'org.ajoberstar.grgit' version '4.0.2'
 }
 
 if (!JavaVersion.current().java11Compatible) {
   throw new GradleException("Java 11 or later is required to build Web3Signer.\n" +
   "  Detected version ${JavaVersion.current()}")
 }
+
+rootProject.version = calculatePublishVersion()
+def specificVersion = calculateVersion()
+def isDevelopBuild = rootProject.version.contains('develop')
 
 def bintrayUser = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
 def bintrayKey = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_KEY')
@@ -280,7 +285,7 @@ subprojects {
       key = bintrayKey
 
       publications = ['mavenJava']
-      override = version.endsWith('SNAPSHOT')
+      override = isDevelopBuild
 
       publish = true
 
@@ -461,7 +466,7 @@ tasks.register("dockerDistUntar") {
 
 task distDocker(type: Exec) {
   dependsOn dockerDistUntar
-  def dockerBuildVersion = project.hasProperty('release.releaseVersion') ? project.property('release.releaseVersion') : "${rootProject.version}"
+  def dockerBuildVersion = rootProject.version
   def imageName = "consensys/web3signer"
   def image = project.hasProperty('release.releaseVersion') ? "${imageName}:" + project.property('release.releaseVersion') : "${imageName}:${project.version}"
   def dockerBuildDir = "build/docker-web3signer/"
@@ -495,7 +500,7 @@ task testDocker(type: Exec) {
 
 task dockerUpload(type: Exec) {
   dependsOn distDocker
-  def dockerBuildVersion = project.hasProperty('release.releaseVersion') ? project.property('release.releaseVersion') : "${rootProject.version}"
+  def dockerBuildVersion = rootProject.version
   def imageName = "consensys/web3signer"
   def image = "${imageName}:${dockerBuildVersion}"
   def cmd = "docker push '${image}'"
@@ -510,7 +515,7 @@ task dockerUpload(type: Exec) {
     additionalTags.add('develop')
   }
 
-  if (!(version ==~ /.*-SNAPSHOT/)) {
+  if (!isDevelopBuild) {
     additionalTags.add('latest')
     additionalTags.add(version.split(/\./)[0..1].join('.'))
   }
@@ -558,37 +563,48 @@ def buildTime() {
   return df.format(new Date())
 }
 
-// Takes the version, and if -SNAPSHOT is part of it replaces SNAPSHOT
-// with the git commit version.
+// Calculate the version that this build would be published under (if it is published)
+// If this exact commit is tagged, use the tag
+// If this is on a release-* branch, use the most recent tag appended with +develop (e.g. 0.1.1-RC1+develop)
+// Otherwise, use develop
+def calculatePublishVersion() {
+  if (!grgit) {
+    return 'UNKNOWN'
+  }
+  def specificVersion = calculateVersion()
+  def isReleaseBranch = grgit.branch.current().name.startsWith('release-')
+  if (specificVersion.contains('+')) {
+    return isReleaseBranch ? "${specificVersion.substring(0, specificVersion.indexOf('+'))}+develop" : "develop"
+  }
+  return specificVersion
+}
+
+// Calculate the version that teku --version will report (among other places)
+// If this exact commit is tagged, use the tag
+// Otherwise use git describe --tags and replace the - after the tag with a +
 @Memoized
 def calculateVersion() {
-  String version = rootProject.version
-  if (version.endsWith("-SNAPSHOT")) {
-    version = version.replace("-SNAPSHOT", "-dev-" + getCheckedOutGitCommitHash())
+  if (!grgit) {
+    return 'UNKNOWN'
+  }
+  String version = grgit.describe(tags: true)
+  def versionPattern = ~/^(?<lastVersion>.*)-(?<devVersion>[0-9]+-g[a-z0-9]+)$/
+  def matcher = version =~ versionPattern
+  if (matcher.find()) {
+    return "${matcher.group("lastVersion")}+${matcher.group("devVersion")}"
   }
   return version
 }
 
-def getCheckedOutGitCommitHash() {
-  def gitFolder = "$projectDir/.git/"
-  if (!file(gitFolder).isDirectory()) {
-    // We are in a submodule.  The file's contents are `gitdir: <gitFolder>\n`.
-    // Read the file, cut off the front, and trim the whitespace.
-    gitFolder = file(gitFolder).text.substring(8).trim() + "/"
+task printVersion() {
+  doFirst {
+    print "Specific version: ${specificVersion}  Publish version: ${project.version}"
   }
+}
+
+def getCheckedOutGitCommitHash() {
   def takeFromHash = 8
-  /*
-   * '.git/HEAD' contains either
-   *      in case of detached head: the currently checked out commit hash
-   *      otherwise: a reference to a file containing the current commit hash
-   */
-  def head = new File(gitFolder + "HEAD").text.split(":") // .git/HEAD
-  def isCommit = head.length == 1 // e5a7c79edabbf7dd39888442df081b1c9d8e88fd
-
-  if(isCommit) return head[0].trim().take(takeFromHash) // e5a7c79edabb
-
-  def refHead = new File(gitFolder + head[1].trim()) // .git/refs/heads/master
-  refHead.text.trim().take takeFromHash
+  grgit ? grgit.head().id.take(takeFromHash) : 'UNKNOWN'
 }
 
 apply plugin: 'net.researchgate.release'
@@ -635,7 +651,7 @@ bintray {
   }
 
   publish = true
-  override = version.endsWith('SNAPSHOT')
+  override = isDevelopBuild
 
   pkg = bintrayPackage
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1g
-version=0.2.1-SNAPSHOT
 hashicorpVaultVersion=1.4.3
 hashicorpVaultUrl=https://releases.hashicorp.com/vault


### PR DESCRIPTION
Switch to using a tag based release system rather than having to commit the release version to the repository.

Version number is now calculated based on the most recent tag using `git describe`.  So the current latest master is `0.2.0+28-g03e8904` - last release was `0.2.0` and this is 28 commits after that tag with the git hash 03e8904 (git prefixes with the -g).  Builds from master are published under the `develop` version (ie `web3signer-develop.tar.gz`) which provides a stable download URL for the latest binaries inline with the docker `develop` tag.

Releases are performed by tagging a commit in the repo and the name of the tag is used as the version number.

Also switched to using grgit plugin to work with git during the build instead of parsing the git data files manually.