### PR TITLE
Update dependency versions

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -30,7 +30,6 @@ dependencies {
   implementation 'org.web3j:core'
 
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-  implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor'
 
   implementation 'com.github.ipld:java-cid'
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -13,9 +13,8 @@
 
 dependencyManagement {
   dependencies {
-    dependency 'com.fasterxml.jackson.core:jackson-databind:2.10.1'
-    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1'
-    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1'
+    dependency 'com.fasterxml.jackson.core:jackson-databind:2.11.2'
+    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.2'
 
     dependencySet(group: 'com.google.errorprone', version: '2.4.0') {
       entry 'error_prone_annotation'
@@ -76,7 +75,7 @@ dependencyManagement {
     dependency 'org.hyperledger.besu.internal:metrics-core:1.4.0'
     dependency 'org.hyperledger.besu:plugin-api:1.4.0'
 
-    dependencySet(group: 'tech.pegasys.teku.internal', version: '0.12.14-SNAPSHOT') {
+    dependencySet(group: 'tech.pegasys.teku.internal', version: '20.11.0') {
       entry 'bls'
       entry 'core'
       entry 'datastructures'


### PR DESCRIPTION
Update jackson to 2.11.2 (to remove duplicate jackson versions in
   released product).

Update Teku from SNAPSHOT to 20.11.0.