### PR TITLE
Warn if no key config files exist

### DIFF
--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -187,7 +187,7 @@ public class Eth2Runner extends Runner {
             .map(Bytes::fromHexString)
             .collect(Collectors.toList());
     if (validators.isEmpty()) {
-      LOG.warn("No keys configured. Check that the key store has key configure files");
+      LOG.warn("No BLS keys configured. Check that the key store has BLS key config files");
     }
     slashingProtection.ifPresent(
         slashingProtection -> slashingProtection.registerValidators(validators));

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -186,6 +186,9 @@ public class Eth2Runner extends Runner {
             .map(ArtifactSigner::getIdentifier)
             .map(Bytes::fromHexString)
             .collect(Collectors.toList());
+    if (validators.isEmpty()) {
+      LOG.warn("No keys configured. Check that the key store has key configure files");
+    }
     slashingProtection.ifPresent(
         slashingProtection -> slashingProtection.registerValidators(validators));
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -215,6 +215,10 @@ public class DbSlashingProtection implements SlashingProtection {
 
   @Override
   public void registerValidators(final List<Bytes> validators) {
+    if (validators.isEmpty()) {
+      return;
+    }
+
     jdbi.useTransaction(
         SERIALIZABLE,
         h -> {


### PR DESCRIPTION
Log a warning message if there are no key config files and guard against registering the empty list of validator keys as this fails with JDBI.