### PR TITLE
Move null-queries into import

### DIFF
--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDao.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDao.java
@@ -21,7 +21,6 @@ import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.jdbi.v3.core.Handle;
-import org.jdbi.v3.core.statement.Query;
 
 public class SignedAttestationsDao {
 
@@ -34,11 +33,14 @@ public class SignedAttestationsDao {
     return handle
         .createQuery(
             "SELECT validator_id, source_epoch, target_epoch, signing_root "
-                + "FROM signed_attestations WHERE (validator_id = ? AND target_epoch = ?) AND (signing_root <> ? OR signing_root IS NULL)")
+                + "FROM signed_attestations "
+                + "WHERE (validator_id = ? AND target_epoch = ?) AND "
+                + "(signing_root <> ? OR signing_root IS NULL)")
         .bind(0, validatorId)
         .bind(1, targetEpoch)
         .bind(2, signingRoot)
-        .mapToBean(SignedAttestation.class).list();
+        .mapToBean(SignedAttestation.class)
+        .list();
   }
 
   public Optional<SignedAttestation> findMatchingAttestation(
@@ -47,14 +49,16 @@ public class SignedAttestationsDao {
       final UInt64 targetEpoch,
       final Bytes signingRoot) {
     checkNotNull(signingRoot, "This function only accepts queries where the signing root is known");
-    handle
+    return handle
         .createQuery(
             "SELECT validator_id, source_epoch, target_epoch, signing_root "
-                + "FROM signed_attestations WHERE validator_id = ? AND target_epoch = ? AND signing_root = ?")
+                + "FROM signed_attestations "
+                + "WHERE validator_id = ? AND target_epoch = ? AND signing_root = ?")
         .bind(0, validatorId)
         .bind(1, targetEpoch)
         .bind(2, signingRoot)
-        .mapToBean(SignedAttestation.class).findFirst();
+        .mapToBean(SignedAttestation.class)
+        .findFirst();
   }
 
   public List<SignedAttestation> findSurroundingAttestations(

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDao.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDao.java
@@ -29,7 +29,7 @@ public class SignedAttestationsDao {
       final int validatorId,
       final UInt64 targetEpoch,
       final Bytes signingRoot) {
-    checkNotNull(signingRoot, "This function only accepts queries where the signing root is known");
+    checkNotNull(signingRoot, "Signing root must not be null");
     return handle
         .createQuery(
             "SELECT validator_id, source_epoch, target_epoch, signing_root "
@@ -48,7 +48,7 @@ public class SignedAttestationsDao {
       final int validatorId,
       final UInt64 targetEpoch,
       final Bytes signingRoot) {
-    checkNotNull(signingRoot, "This function only accepts queries where the signing root is known");
+    checkNotNull(signingRoot, "Signing root must not be null");
     return handle
         .createQuery(
             "SELECT validator_id, source_epoch, target_epoch, signing_root "

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDao.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDao.java
@@ -12,6 +12,8 @@
  */
 package tech.pegasys.web3signer.slashingprotection.dao;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -28,28 +30,15 @@ public class SignedAttestationsDao {
       final int validatorId,
       final UInt64 targetEpoch,
       final Bytes signingRoot) {
-
-    final Query query;
-    if (signingRoot == null) {
-      query =
-          handle
-              .createQuery(
-                  "SELECT validator_id, source_epoch, target_epoch, signing_root "
-                      + "FROM signed_attestations WHERE (validator_id = ? AND target_epoch = ?) AND (signing_root IS NOT NULL)")
-              .bind(0, validatorId)
-              .bind(1, targetEpoch);
-    } else {
-      query =
-          handle
-              .createQuery(
-                  "SELECT validator_id, source_epoch, target_epoch, signing_root "
-                      + "FROM signed_attestations WHERE (validator_id = ? AND target_epoch = ?) AND (signing_root <> ? OR signing_root IS NULL)")
-              .bind(0, validatorId)
-              .bind(1, targetEpoch)
-              .bind(2, signingRoot);
-    }
-
-    return query.mapToBean(SignedAttestation.class).list();
+    checkNotNull(signingRoot, "This function only accepts queries where the signing root is known");
+    return handle
+        .createQuery(
+            "SELECT validator_id, source_epoch, target_epoch, signing_root "
+                + "FROM signed_attestations WHERE (validator_id = ? AND target_epoch = ?) AND (signing_root <> ? OR signing_root IS NULL)")
+        .bind(0, validatorId)
+        .bind(1, targetEpoch)
+        .bind(2, signingRoot)
+        .mapToBean(SignedAttestation.class).list();
   }
 
   public Optional<SignedAttestation> findMatchingAttestation(
@@ -57,27 +46,15 @@ public class SignedAttestationsDao {
       final int validatorId,
       final UInt64 targetEpoch,
       final Bytes signingRoot) {
-    final Query query;
-    if (signingRoot == null) {
-      query =
-          handle
-              .createQuery(
-                  "SELECT validator_id, source_epoch, target_epoch, signing_root "
-                      + "FROM signed_attestations WHERE validator_id = ? AND target_epoch = ? AND signing_root IS NULL")
-              .bind(0, validatorId)
-              .bind(1, targetEpoch);
-    } else {
-      query =
-          handle
-              .createQuery(
-                  "SELECT validator_id, source_epoch, target_epoch, signing_root "
-                      + "FROM signed_attestations WHERE validator_id = ? AND target_epoch = ? AND signing_root = ?")
-              .bind(0, validatorId)
-              .bind(1, targetEpoch)
-              .bind(2, signingRoot);
-    }
-
-    return query.mapToBean(SignedAttestation.class).findFirst();
+    checkNotNull(signingRoot, "This function only accepts queries where the signing root is known");
+    handle
+        .createQuery(
+            "SELECT validator_id, source_epoch, target_epoch, signing_root "
+                + "FROM signed_attestations WHERE validator_id = ? AND target_epoch = ? AND signing_root = ?")
+        .bind(0, validatorId)
+        .bind(1, targetEpoch)
+        .bind(2, signingRoot)
+        .mapToBean(SignedAttestation.class).findFirst();
   }
 
   public List<SignedAttestation> findSurroundingAttestations(

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDao.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDao.java
@@ -21,7 +21,6 @@ import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.jdbi.v3.core.Handle;
-import org.jdbi.v3.core.statement.Query;
 
 public class SignedBlocksDao {
 
@@ -37,7 +36,8 @@ public class SignedBlocksDao {
         .bind(0, validatorId)
         .bind(1, slot)
         .bind(2, signingRoot)
-        .mapToBean(SignedBlock.class).list();
+        .mapToBean(SignedBlock.class)
+        .list();
   }
 
   public Optional<SignedBlock> findMatchingBlock(
@@ -50,7 +50,8 @@ public class SignedBlocksDao {
         .bind(0, validatorId)
         .bind(1, slot)
         .bind(2, signingRoot)
-        .mapToBean(SignedBlock.class).findFirst();
+        .mapToBean(SignedBlock.class)
+        .findFirst();
   }
 
   public void insertBlockProposal(final Handle handle, final SignedBlock signedBlock) {

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDao.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDao.java
@@ -26,7 +26,7 @@ public class SignedBlocksDao {
 
   public List<SignedBlock> findBlockForSlotWithDifferentSigningRoot(
       final Handle handle, final int validatorId, final UInt64 slot, final Bytes signingRoot) {
-    checkNotNull(signingRoot, "This function only accepts queries where the signing root is known");
+    checkNotNull(signingRoot, "Signing root must not be null");
 
     return handle
         .createQuery(
@@ -42,7 +42,7 @@ public class SignedBlocksDao {
 
   public Optional<SignedBlock> findMatchingBlock(
       final Handle handle, final int validatorId, final UInt64 slot, final Bytes signingRoot) {
-    checkNotNull(signingRoot, "This function only accepts queries where the signing root is known");
+    checkNotNull(signingRoot, "Signing root must not be null");
     return handle
         .createQuery(
             "SELECT validator_id, slot, signing_root FROM signed_blocks "

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/AttestationImporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/AttestationImporter.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.slashingprotection.interchange;
+
+import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
+import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
+import tech.pegasys.web3signer.slashingprotection.dao.SigningWatermark;
+import tech.pegasys.web3signer.slashingprotection.dao.Validator;
+import tech.pegasys.web3signer.slashingprotection.interchange.model.SignedAttestation;
+import tech.pegasys.web3signer.slashingprotection.validator.AttestationValidator;
+
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.units.bigints.UInt64;
+import org.jdbi.v3.core.Handle;
+
+public class AttestationImporter {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  final OptionalMinValueTracker minSourceTracker = new OptionalMinValueTracker();
+  final OptionalMinValueTracker minTargetTracker = new OptionalMinValueTracker();
+
+  private final LowWatermarkDao lowWatermarkDao;
+  private final SignedAttestationsDao signedAttestationsDao;
+
+  private final Validator validator;
+  private final Handle handle;
+  private final ObjectMapper mapper;
+
+  public AttestationImporter(
+      final Validator validator,
+      final Handle handle,
+      final ObjectMapper mapper,
+      final LowWatermarkDao lowWatermarkDao,
+      final SignedAttestationsDao signedAttestationsDao) {
+    this.validator = validator;
+    this.handle = handle;
+    this.mapper = mapper;
+    this.lowWatermarkDao = lowWatermarkDao;
+    this.signedAttestationsDao = signedAttestationsDao;
+  }
+
+  public void importFrom(final ArrayNode signedAttestationNode) throws JsonProcessingException {
+
+    for (int i = 0; i < signedAttestationNode.size(); i++) {
+      final SignedAttestation jsonAttestation =
+          mapper.treeToValue(signedAttestationNode.get(i), SignedAttestation.class);
+      final AttestationValidator attestationValidator =
+          new AttestationValidator(
+              handle,
+              validator.getPublicKey(),
+              jsonAttestation.getSigningRoot(),
+              jsonAttestation.getSourceEpoch(),
+              jsonAttestation.getTargetEpoch(),
+              validator.getId(),
+              signedAttestationsDao,
+              lowWatermarkDao);
+
+      // if the attestation is illegal formatted, it cannot be imported
+      final String attesationIdentiferString =
+          String.format("Attestation with index %d for validator %s", i, validator.getPublicKey());
+      if (attestationValidator.sourceGreaterThanTargetEpoch()) {
+        LOG.warn("{} - source is greater than target epoch", attesationIdentiferString);
+      } else {
+
+        if (attestationValidator.isSurroundedByExistingAttestation()) {
+          LOG.warn("{} - is surrounded by existing entries", attesationIdentiferString);
+        }
+
+        if (attestationValidator.surroundsExistingAttestation()) {
+          LOG.warn("{} - surrounds an existing entry", attesationIdentiferString);
+        }
+
+        if (jsonAttestation.getSigningRoot() == null) {
+          if (!nullAttestationAlreadyExistsInTargetEpoch(jsonAttestation.getTargetEpoch())) {
+            persist(jsonAttestation);
+          }
+        } else {
+          if (attestationValidator.directlyConflictsWithExistingEntry()) {
+            LOG.warn("{} - conflicts with an existing entry", attesationIdentiferString);
+          }
+
+          if (attestationValidator.alreadyExists()) {
+            LOG.debug("{} - already exists in database, not imported", attesationIdentiferString);
+          } else {
+            persist(jsonAttestation);
+          }
+        }
+      }
+    }
+    persistAttestationWatermark(handle, validator, minSourceTracker, minTargetTracker);
+  }
+
+  private void persist(final SignedAttestation jsonAttestation) {
+    signedAttestationsDao.insertAttestation(
+        handle,
+        new tech.pegasys.web3signer.slashingprotection.dao.SignedAttestation(
+            validator.getId(),
+            jsonAttestation.getSourceEpoch(),
+            jsonAttestation.getTargetEpoch(),
+            jsonAttestation.getSigningRoot()));
+    minSourceTracker.trackValue(jsonAttestation.getSourceEpoch());
+    minTargetTracker.trackValue(jsonAttestation.getTargetEpoch());
+  }
+
+  private void persistAttestationWatermark(
+      final Handle handle,
+      final Validator validator,
+      final OptionalMinValueTracker minSourceTracker,
+      final OptionalMinValueTracker minTargetTracker) {
+    final Optional<SigningWatermark> existingWatermark =
+        lowWatermarkDao.findLowWatermarkForValidator(handle, validator.getId());
+
+    final Optional<UInt64> newSourceWatermark =
+        findBestEpochWatermark(
+            minSourceTracker,
+            existingWatermark.flatMap(
+                watermark -> Optional.ofNullable(watermark.getSourceEpoch())));
+    final Optional<UInt64> newTargetWatermark =
+        findBestEpochWatermark(
+            minTargetTracker,
+            existingWatermark.flatMap(
+                watermark -> Optional.ofNullable(watermark.getTargetEpoch())));
+
+    if (newSourceWatermark.isPresent() && newTargetWatermark.isPresent()) {
+      LOG.info(
+          "Updating validator {} source epoch to {}",
+          validator.getPublicKey(),
+          newSourceWatermark.get());
+      LOG.info(
+          "Updating validator {} target epoch to {}",
+          validator.getPublicKey(),
+          newTargetWatermark.get());
+      lowWatermarkDao.updateEpochWatermarksFor(
+          handle, validator.getId(), newSourceWatermark.get(), newTargetWatermark.get());
+    } else if (newSourceWatermark.isPresent() != newTargetWatermark.isPresent()) {
+      throw new RuntimeException(
+          "Inconsistent data - no existing attestation watermark, "
+              + "and import only sets one epoch");
+    }
+  }
+
+  private Optional<UInt64> findBestEpochWatermark(
+      final OptionalMinValueTracker importedMin, final Optional<UInt64> currentWatermark) {
+    if (importedMin.compareTrackedValueTo(currentWatermark) > 0) {
+      return importedMin.getTrackedMinValue();
+    } else {
+      return currentWatermark;
+    }
+  }
+
+  private boolean nullAttestationAlreadyExistsInTargetEpoch(final UInt64 targetEpoch) {
+    return handle
+        .createQuery(
+            "SELECT validator_id, source_epoch, target_epoch, signing_root "
+                + "FROM signed_attestations "
+                + "WHERE validator_id = ? AND target_epoch = ? AND signing_root IS NULL")
+        .bind(0, validator.getId())
+        .bind(1, targetEpoch)
+        .mapToBean(tech.pegasys.web3signer.slashingprotection.dao.SignedAttestation.class)
+        .findFirst()
+        .isPresent();
+  }
+}

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/AttestationImporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/AttestationImporter.java
@@ -168,14 +168,14 @@ public class AttestationImporter {
 
   private boolean nullAttestationAlreadyExistsInTargetEpoch(final UInt64 targetEpoch) {
     return handle
-        .createQuery(
-            "SELECT validator_id, source_epoch, target_epoch, signing_root "
-                + "FROM signed_attestations "
-                + "WHERE validator_id = ? AND target_epoch = ? AND signing_root IS NULL")
-        .bind(0, validator.getId())
-        .bind(1, targetEpoch)
-        .mapToBean(tech.pegasys.web3signer.slashingprotection.dao.SignedAttestation.class)
-        .findFirst()
-        .isPresent();
+            .createQuery(
+                "SELECT count(*) "
+                    + "FROM signed_attestations "
+                    + "WHERE validator_id = ? AND target_epoch = ? AND signing_root IS NULL")
+            .bind(0, validator.getId())
+            .bind(1, targetEpoch)
+            .mapTo(Integer.class)
+            .first()
+        == 1;
   }
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/BlockImporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/BlockImporter.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.slashingprotection.interchange;
+
+import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
+import tech.pegasys.web3signer.slashingprotection.dao.SignedBlocksDao;
+import tech.pegasys.web3signer.slashingprotection.dao.SigningWatermark;
+import tech.pegasys.web3signer.slashingprotection.dao.Validator;
+import tech.pegasys.web3signer.slashingprotection.interchange.model.SignedBlock;
+import tech.pegasys.web3signer.slashingprotection.validator.BlockValidator;
+
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.units.bigints.UInt64;
+import org.jdbi.v3.core.Handle;
+
+public class BlockImporter {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  final OptionalMinValueTracker minSlotTracker = new OptionalMinValueTracker();
+
+  private final LowWatermarkDao lowWatermarkDao;
+  private final SignedBlocksDao signedBlocksDao;
+
+  private final Validator validator;
+  private final Handle handle;
+  private final ObjectMapper mapper;
+
+  public BlockImporter(
+      final Validator validator,
+      final Handle handle,
+      final ObjectMapper mapper,
+      final LowWatermarkDao lowWatermarkDao,
+      final SignedBlocksDao signedBlocksDao) {
+    this.validator = validator;
+    this.handle = handle;
+    this.mapper = mapper;
+    this.lowWatermarkDao = lowWatermarkDao;
+    this.signedBlocksDao = signedBlocksDao;
+  }
+
+  public void importFrom(final ArrayNode signedBlocksNode) throws JsonProcessingException {
+
+    for (int i = 0; i < signedBlocksNode.size(); i++) {
+      final SignedBlock jsonBlock = mapper.treeToValue(signedBlocksNode.get(i), SignedBlock.class);
+      final BlockValidator blockValidator =
+          new BlockValidator(
+              handle,
+              jsonBlock.getSigningRoot(),
+              jsonBlock.getSlot(),
+              validator.getId(),
+              signedBlocksDao,
+              lowWatermarkDao);
+
+      if (jsonBlock.getSigningRoot() == null) {
+        if (!nullBlockAlreadyExistsInSlot(jsonBlock.getSlot())) {
+          persist(jsonBlock);
+        }
+      } else {
+
+        if (blockValidator.directlyConflictsWithExistingEntry()) {
+          LOG.debug(
+              "Block {} for validator {} conflicts with on slot {} in database",
+              i,
+              validator.getPublicKey(),
+              jsonBlock.getSlot());
+        }
+
+        if (blockValidator.alreadyExists()) {
+          LOG.debug(
+              "Block {} for validator {} already exists in database, not imported",
+              i,
+              validator.getPublicKey());
+        } else {
+          persist(jsonBlock);
+        }
+      }
+    }
+
+    final Optional<SigningWatermark> watermark =
+        lowWatermarkDao.findLowWatermarkForValidator(handle, validator.getId());
+
+    if (minSlotTracker.compareTrackedValueTo(watermark.map(SigningWatermark::getSlot)) > 0) {
+      LOG.warn(
+          "Updating Block slot low watermark to {}", minSlotTracker.getTrackedMinValue().get());
+      lowWatermarkDao.updateSlotWatermarkFor(
+          handle, validator.getId(), minSlotTracker.getTrackedMinValue().get());
+    }
+  }
+
+  private void persist(final SignedBlock jsonBlock) {
+    signedBlocksDao.insertBlockProposal(
+        handle,
+        new tech.pegasys.web3signer.slashingprotection.dao.SignedBlock(
+            validator.getId(), jsonBlock.getSlot(), jsonBlock.getSigningRoot()));
+    minSlotTracker.trackValue(jsonBlock.getSlot());
+  }
+
+  private boolean nullBlockAlreadyExistsInSlot(final UInt64 slot) {
+    return handle
+        .createQuery(
+            "SELECT validator_id, slot, signing_root "
+                + "FROM signed_blocks "
+                + "WHERE validator_id = ? AND slot = ? AND signing_root IS NULL")
+        .bind(0, validator.getId())
+        .bind(1, slot)
+        .mapToBean(tech.pegasys.web3signer.slashingprotection.dao.SignedBlock.class)
+        .findFirst()
+        .isPresent();
+  }
+}

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/BlockImporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/BlockImporter.java
@@ -109,14 +109,14 @@ public class BlockImporter {
 
   private boolean nullBlockAlreadyExistsInSlot(final UInt64 slot) {
     return handle
-        .createQuery(
-            "SELECT validator_id, slot, signing_root "
-                + "FROM signed_blocks "
-                + "WHERE validator_id = ? AND slot = ? AND signing_root IS NULL")
-        .bind(0, validator.getId())
-        .bind(1, slot)
-        .mapToBean(tech.pegasys.web3signer.slashingprotection.dao.SignedBlock.class)
-        .findFirst()
-        .isPresent();
+            .createQuery(
+                "SELECT COUNT(*) "
+                    + "FROM signed_blocks "
+                    + "WHERE validator_id = ? AND slot = ? AND signing_root IS NULL")
+            .bind(0, validator.getId())
+            .bind(1, slot)
+            .mapTo(Integer.class)
+            .first()
+        == 1;
   }
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Importer.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Importer.java
@@ -16,19 +16,13 @@ import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
 import tech.pegasys.web3signer.slashingprotection.dao.MetadataDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlocksDao;
-import tech.pegasys.web3signer.slashingprotection.dao.SigningWatermark;
 import tech.pegasys.web3signer.slashingprotection.dao.Validator;
 import tech.pegasys.web3signer.slashingprotection.dao.ValidatorsDao;
 import tech.pegasys.web3signer.slashingprotection.interchange.model.Metadata;
-import tech.pegasys.web3signer.slashingprotection.interchange.model.SignedAttestation;
-import tech.pegasys.web3signer.slashingprotection.interchange.model.SignedBlock;
-import tech.pegasys.web3signer.slashingprotection.validator.AttestationValidator;
-import tech.pegasys.web3signer.slashingprotection.validator.BlockValidator;
 import tech.pegasys.web3signer.slashingprotection.validator.GenesisValidatorRootValidator;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -40,7 +34,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt64;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 
@@ -133,154 +126,18 @@ public class InterchangeV5Importer {
       final Handle handle, final Validator validator, final ArrayNode signedBlocksNode)
       throws JsonProcessingException {
 
-    final OptionalMinValueTracker minSlotTracker = new OptionalMinValueTracker();
-
-    for (int i = 0; i < signedBlocksNode.size(); i++) {
-      final SignedBlock jsonBlock = mapper.treeToValue(signedBlocksNode.get(i), SignedBlock.class);
-      final BlockValidator blockValidator =
-          new BlockValidator(
-              handle,
-              jsonBlock.getSigningRoot(),
-              jsonBlock.getSlot(),
-              validator.getId(),
-              signedBlocksDao,
-              lowWatermarkDao);
-
-      if (blockValidator.directlyConflictsWithExistingEntry()) {
-        LOG.debug(
-            "Block {} for validator {} conflicts with on slot {} in database",
-            i,
-            validator.getPublicKey(),
-            jsonBlock.getSlot());
-      }
-
-      if (blockValidator.alreadyExists()) {
-        LOG.debug(
-            "Block {} for validator {} already exists in database, not imported",
-            i,
-            validator.getPublicKey());
-      } else {
-        signedBlocksDao.insertBlockProposal(
-            handle,
-            new tech.pegasys.web3signer.slashingprotection.dao.SignedBlock(
-                validator.getId(), jsonBlock.getSlot(), jsonBlock.getSigningRoot()));
-
-        minSlotTracker.trackValue(jsonBlock.getSlot());
-      }
-    }
-
-    final Optional<SigningWatermark> watermark =
-        lowWatermarkDao.findLowWatermarkForValidator(handle, validator.getId());
-
-    if (minSlotTracker.compareTrackedValueTo(watermark.map(SigningWatermark::getSlot)) > 0) {
-      LOG.warn(
-          "Updating Block slot low watermark to {}", minSlotTracker.getTrackedMinValue().get());
-      lowWatermarkDao.updateSlotWatermarkFor(
-          handle, validator.getId(), minSlotTracker.getTrackedMinValue().get());
-    }
+    final BlockImporter importer =
+        new BlockImporter(validator, handle, mapper, lowWatermarkDao, signedBlocksDao);
+    importer.importFrom(signedBlocksNode);
   }
 
   private void importAttestations(
       final Handle handle, final Validator validator, final ArrayNode signedAttestationNode)
       throws JsonProcessingException {
 
-    final OptionalMinValueTracker minSourceTracker = new OptionalMinValueTracker();
-    final OptionalMinValueTracker minTargetTracker = new OptionalMinValueTracker();
+    final AttestationImporter attestationImporter =
+        new AttestationImporter(validator, handle, mapper, lowWatermarkDao, signedAttestationsDao);
 
-    for (int i = 0; i < signedAttestationNode.size(); i++) {
-      final SignedAttestation jsonAttestation =
-          mapper.treeToValue(signedAttestationNode.get(i), SignedAttestation.class);
-      final AttestationValidator attestationValidator =
-          new AttestationValidator(
-              handle,
-              validator.getPublicKey(),
-              jsonAttestation.getSigningRoot(),
-              jsonAttestation.getSourceEpoch(),
-              jsonAttestation.getTargetEpoch(),
-              validator.getId(),
-              signedAttestationsDao,
-              lowWatermarkDao);
-
-      // if the attestation is illegal formatted, it cannot be imported
-      final String attesationIdentiferString =
-          String.format("Attestation with index %d for validator %s", i, validator.getPublicKey());
-      if (attestationValidator.sourceGreaterThanTargetEpoch()) {
-        LOG.warn("{} - source is greater than target epoch", attesationIdentiferString);
-      } else {
-
-        if (attestationValidator.directlyConflictsWithExistingEntry()) {
-          LOG.warn("{} - conflicts with an existing entry", attesationIdentiferString);
-        }
-
-        if (attestationValidator.isSurroundedByExistingAttestation()) {
-          LOG.warn("{} - is surrounded by existing entries", attesationIdentiferString);
-        }
-
-        if (attestationValidator.surroundsExistingAttestation()) {
-          LOG.warn("{} - surrounds an existing entry", attesationIdentiferString);
-        }
-
-        if (attestationValidator.alreadyExists()) {
-          LOG.debug("{} - already exists in database, not imported", attesationIdentiferString);
-        } else {
-          signedAttestationsDao.insertAttestation(
-              handle,
-              new tech.pegasys.web3signer.slashingprotection.dao.SignedAttestation(
-                  validator.getId(),
-                  jsonAttestation.getSourceEpoch(),
-                  jsonAttestation.getTargetEpoch(),
-                  jsonAttestation.getSigningRoot()));
-          minSourceTracker.trackValue(jsonAttestation.getSourceEpoch());
-          minTargetTracker.trackValue(jsonAttestation.getTargetEpoch());
-        }
-      }
-    }
-    persistAttestationWatermark(handle, validator, minSourceTracker, minTargetTracker);
-  }
-
-  public void persistAttestationWatermark(
-      final Handle handle,
-      final Validator validator,
-      final OptionalMinValueTracker minSourceTracker,
-      final OptionalMinValueTracker minTargetTracker) {
-    final Optional<SigningWatermark> existingWatermark =
-        lowWatermarkDao.findLowWatermarkForValidator(handle, validator.getId());
-
-    final Optional<UInt64> newSourceWatermark =
-        findBestEpochWatermark(
-            minSourceTracker,
-            existingWatermark.flatMap(
-                watermark -> Optional.ofNullable(watermark.getSourceEpoch())));
-    final Optional<UInt64> newTargetWatermark =
-        findBestEpochWatermark(
-            minTargetTracker,
-            existingWatermark.flatMap(
-                watermark -> Optional.ofNullable(watermark.getTargetEpoch())));
-
-    if (newSourceWatermark.isPresent() && newTargetWatermark.isPresent()) {
-      LOG.info(
-          "Updating validator {} source epoch to {}",
-          validator.getPublicKey(),
-          newSourceWatermark.get());
-      LOG.info(
-          "Updating validator {} target epoch to {}",
-          validator.getPublicKey(),
-          newTargetWatermark.get());
-      lowWatermarkDao.updateEpochWatermarksFor(
-          handle, validator.getId(), newSourceWatermark.get(), newTargetWatermark.get());
-    } else if (newSourceWatermark.isPresent() != newTargetWatermark.isPresent()) {
-      throw new RuntimeException(
-          "Inconsistent data - no existing attestation watermark, "
-              + "and import only sets one epoch");
-    }
-  }
-
-  private Optional<UInt64> findBestEpochWatermark(
-      final OptionalMinValueTracker importedMin, final Optional<UInt64> currentWatermark) {
-    if (importedMin.compareTrackedValueTo(currentWatermark) > 0) {
-      return importedMin.getTrackedMinValue();
-    } else {
-      return currentWatermark;
-    }
+    attestationImporter.importFrom(signedAttestationNode);
   }
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Importer.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Importer.java
@@ -126,9 +126,9 @@ public class InterchangeV5Importer {
       final Handle handle, final Validator validator, final ArrayNode signedBlocksNode)
       throws JsonProcessingException {
 
-    final BlockImporter importer =
+    final BlockImporter blockImporter =
         new BlockImporter(validator, handle, mapper, lowWatermarkDao, signedBlocksDao);
-    importer.importFrom(signedBlocksNode);
+    blockImporter.importFrom(signedBlocksNode);
   }
 
   private void importAttestations(

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDaoTest.java
@@ -13,6 +13,7 @@
 package tech.pegasys.web3signer.slashingprotection.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import tech.pegasys.web3signer.slashingprotection.DbConnection;
 
@@ -186,37 +187,25 @@ public class SignedAttestationsDaoTest {
   }
 
   @Test
-  public void existingCheckMatchesOnNullSigningRoot() {
+  public void existingCheckMatchesOnNullSigningRootThrowsException() {
     insertValidator(Bytes.of(100), 1);
     insertAttestation(1, null, UInt64.valueOf(2), UInt64.valueOf(3));
-    assertThat(signedAttestationsDao.findMatchingAttestation(handle, 1, UInt64.valueOf(3), null))
-        .isNotEmpty();
+    assertThatThrownBy(
+            () -> signedAttestationsDao.findMatchingAttestation(handle, 1, UInt64.valueOf(3), null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
-  public void nullSigningRootInDatabaseDoesNotExactMatchARealValue() {
-    insertValidator(Bytes.of(100), 1);
-    insertAttestation(1, Bytes.of(10), UInt64.valueOf(2), UInt64.valueOf(3));
-    assertThat(signedAttestationsDao.findMatchingAttestation(handle, 1, UInt64.valueOf(3), null))
-        .isEmpty();
-    assertThat(
-            signedAttestationsDao.findMatchingAttestation(
-                handle, 1, UInt64.valueOf(3), Bytes.of(10)))
-        .isNotEmpty();
-  }
-
-  @Test
-  public void allNonNullEntriesAtTargetEpochAreReturnedIfCheckingAgainstNull() {
+  public void findAttesationsNotMatchingSigningRootThrowsIfNullRequested() {
     insertValidator(Bytes.of(100), 1);
     insertAttestation(1, Bytes.of(10), UInt64.valueOf(2), UInt64.valueOf(3));
     insertAttestation(1, Bytes.of(11), UInt64.valueOf(2), UInt64.valueOf(3));
     insertAttestation(1, null, UInt64.valueOf(2), UInt64.valueOf(3));
-
-    final List<SignedAttestation> nonMatchingAttestations =
-        signedAttestationsDao.findAttestationsForEpochWithDifferentSigningRoot(
-            handle, 1, UInt64.valueOf(3), null);
-
-    assertThat(nonMatchingAttestations).hasSize(2);
+    assertThatThrownBy(
+            () ->
+                signedAttestationsDao.findAttestationsForEpochWithDifferentSigningRoot(
+                    handle, 1, UInt64.valueOf(3), null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   private void insertValidator(final Bytes publicKey, final int validatorId) {

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
@@ -13,6 +13,7 @@
 package tech.pegasys.web3signer.slashingprotection.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import tech.pegasys.web3signer.slashingprotection.DbConnection;
 
@@ -122,24 +123,25 @@ public class SignedBlocksDaoTest {
   }
 
   @Test
-  public void allNonNullEntriesAtTargetEpochAreReturnedIfCheckingAgainstNull() {
+  public void throwsIfMatchingAgainstNull() {
     insertValidator(Bytes.of(100), 1);
     insertBlock(1, 3, Bytes.of(10));
     insertBlock(1, 3, Bytes.of(11));
     insertBlock(1, 3, null);
 
-    final List<SignedBlock> nonMatchingAttestations =
-        signedBlocksDao.findBlockForSlotWithDifferentSigningRoot(
-            handle, 1, UInt64.valueOf(3), null);
-
-    assertThat(nonMatchingAttestations).hasSize(2);
+    assertThatThrownBy(
+            () ->
+                signedBlocksDao.findBlockForSlotWithDifferentSigningRoot(
+                    handle, 1, UInt64.valueOf(3), null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
-  public void existingCheckMatchesOnNullSigningRoot() {
+  public void fidnMatchingBlockThrowsIfMatchingOnNull() {
     insertValidator(Bytes.of(100), 1);
     insertBlock(1, 3, null);
-    assertThat(signedBlocksDao.findMatchingBlock(handle, 1, UInt64.valueOf(3), null)).isNotEmpty();
+    assertThatThrownBy(() -> signedBlocksDao.findMatchingBlock(handle, 1, UInt64.valueOf(3), null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   private void insertBlock(final int validatorId, final int slot, final Bytes signingRoot) {

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
@@ -137,7 +137,7 @@ public class SignedBlocksDaoTest {
   }
 
   @Test
-  public void fidnMatchingBlockThrowsIfMatchingOnNull() {
+  public void findMatchingBlockThrowsIfMatchingOnNull() {
     insertValidator(Bytes.of(100), 1);
     insertBlock(1, 3, null);
     assertThatThrownBy(() -> signedBlocksDao.findMatchingBlock(handle, 1, UInt64.valueOf(3), null))


### PR DESCRIPTION
This cleans up the SignedAttestationDao and SignedBlocksDao such that checking for null-ness of requested signing root can be removed (and thus, sign-time code is greatly simplified).

This in turn required the importer to be split into block/attestation components to simplify each class.