### PR TITLE
Use custom ForkJoinPool when processing configuration files

### DIFF
--- a/core/src/main/java/tech/pegasys/web3signer/core/multikey/SignerLoader.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/multikey/SignerLoader.java
@@ -13,6 +13,7 @@
 package tech.pegasys.web3signer.core.multikey;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 
 import tech.pegasys.web3signer.core.multikey.metadata.parser.SignerParser;
 import tech.pegasys.web3signer.core.signing.ArtifactSigner;
@@ -21,11 +22,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -40,47 +39,23 @@ public class SignerLoader {
 
   private static final Logger LOG = LogManager.getLogger();
   private static final long FILES_PROCESSED_TO_REPORT = 10;
+  private static final int MAX_FORK_JOIN_THREADS = 10;
 
   public static Collection<ArtifactSigner> load(
       final Path configsDirectory, final String fileExtension, final SignerParser signerParser) {
-
     LOG.info("Loading signer configuration files from {}", configsDirectory);
-    final AtomicLong configFilesHandled = new AtomicLong();
+    final List<Path> configFilesList = getConfigFilesList(configsDirectory, fileExtension);
+    return processMetadataFilesInParallel(configFilesList, signerParser);
+  }
 
-    final List<Path> configFilesList = getConfigFilesList(configsDirectory);
-    LOG.info("Processing {} files from configuration directory", configFilesList.size());
-
-    // use custom ForkJoin with limited number of threads if default is greater than 10
-    Set<ArtifactSigner> artifactSigners = Collections.emptySet();
+  private static Collection<ArtifactSigner> processMetadataFilesInParallel(
+      final List<Path> configFilesList, final SignerParser signerParser) {
+    // use custom fork-join pool instead of common. Limit number of threads to avoid Azure bug
     ForkJoinPool forkJoinPool = null;
     try {
       forkJoinPool = new ForkJoinPool(numberOfThreads());
-      artifactSigners =
-          forkJoinPool
-              .submit(
-                  () ->
-                      configFilesList.stream()
-                          .parallel()
-                          .filter(path -> matchesFileExtension(fileExtension, path))
-                          .flatMap(
-                              signerConfigFile -> {
-                                final long filesProcessed = configFilesHandled.incrementAndGet();
-                                if (filesProcessed % FILES_PROCESSED_TO_REPORT == 0) {
-                                  LOG.info(
-                                      "{} files processed from configuration directory",
-                                      filesProcessed);
-                                }
-                                try {
-                                  return signerParser.parse(signerConfigFile).stream();
-                                } catch (final Exception e) {
-                                  renderException(e, signerConfigFile.getFileName().toString());
-                                  return null;
-                                }
-                              })
-                          .filter(Objects::nonNull)
-                          .collect(Collectors.toSet()))
-              .get();
-    } catch (final InterruptedException | ExecutionException e) {
+      return forkJoinPool.submit(() -> parseMetadataFiles(configFilesList, signerParser)).get();
+    } catch (final Exception e) {
       LOG.error(
           "Unexpected error in processing configuration files in parallel: {}", e.getMessage(), e);
     } finally {
@@ -89,19 +64,46 @@ public class SignerLoader {
       }
     }
 
-    LOG.info("Total signers loaded from configuration files: {}", artifactSigners.size());
-
-    return artifactSigners;
+    return emptySet();
   }
 
-  private static List<Path> getConfigFilesList(final Path configsDirectory) {
+  private static List<Path> getConfigFilesList(
+      final Path configsDirectory, final String fileExtension) {
     try (final Stream<Path> fileStream = Files.list(configsDirectory)) {
-      return fileStream.collect(Collectors.toList());
+      return fileStream
+          .filter(path -> matchesFileExtension(fileExtension, path))
+          .collect(Collectors.toList());
     } catch (final IOException e) {
       LOG.error("Unable to access the supplied key directory", e);
     }
 
     return emptyList();
+  }
+
+  private static Set<ArtifactSigner> parseMetadataFiles(
+      final List<Path> configFilesList, final SignerParser signerParser) {
+    final AtomicLong configFilesHandled = new AtomicLong();
+    final Set<ArtifactSigner> artifactSigners =
+        configFilesList.stream()
+            .parallel()
+            .flatMap(
+                signerConfigFile -> {
+                  final long filesProcessed = configFilesHandled.incrementAndGet();
+                  if (filesProcessed % FILES_PROCESSED_TO_REPORT == 0) {
+                    LOG.info("{} files processed from configuration directory", filesProcessed);
+                  }
+                  try {
+                    return signerParser.parse(signerConfigFile).stream();
+                  } catch (final Exception e) {
+                    renderException(e, signerConfigFile.getFileName().toString());
+                    return null;
+                  }
+                })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+    LOG.info("Total files processed from configuration directory: {}", configFilesHandled.get());
+    LOG.info("Total signers loaded from configuration files: {}", artifactSigners.size());
+    return artifactSigners;
   }
 
   private static boolean matchesFileExtension(
@@ -121,9 +123,8 @@ public class SignerLoader {
 
   private static int numberOfThreads() {
     int defaultNumberOfThreads = Runtime.getRuntime().availableProcessors() - 1;
-    // we only want to use 10 threads at max
-    if (defaultNumberOfThreads >= 10) {
-      return 10;
+    if (defaultNumberOfThreads >= MAX_FORK_JOIN_THREADS) {
+      return MAX_FORK_JOIN_THREADS;
     } else if (defaultNumberOfThreads < 1) {
       return 1;
     }

--- a/core/src/test/java/tech/pegasys/web3signer/core/multikey/SignerLoaderTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/multikey/SignerLoaderTest.java
@@ -34,10 +34,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
@@ -250,8 +252,14 @@ class SignerLoaderTest {
       createFileInConfigsDirectory(PUBLIC_KEY1);
       SignerLoader.load(configsDirectory, FILE_EXTENSION, signerParser);
 
-      assertThat(logAppender.getLogMessagesReceived().get(1).getMessage().getFormattedMessage())
-          .contains(rootCause.getMessage());
+      final Optional<LogEvent> event =
+          logAppender.getLogMessagesReceived().stream()
+              .filter(
+                  logEvent ->
+                      logEvent.getMessage().getFormattedMessage().contains(rootCause.getMessage()))
+              .findFirst();
+      assertThat(event).isPresent().as("Log should contain message {}", rootCause.getMessage());
+
     } finally {
       logger.removeAppender(logAppender);
       logAppender.stop();


### PR DESCRIPTION
 -- This fixes issue with Azure configuration files which can be processed in a batch of 10 due to a bug in Azure libraries

Signed-off-by: Usman Saleem <usman@usmans.info>