### PR TITLE
Fix openapi spec for deposit data

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/BlsSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/BlsSigningAcceptanceTest.java
@@ -146,8 +146,9 @@ public class BlsSigningAcceptanceTest extends SigningAcceptanceTestBase {
     signAndVerifySignature(ArtifactType.BLOCK);
   }
 
-  @Test
-  public void failsIfSigningRootDoesNotMatchSigningData() throws JsonProcessingException {
+  @ParameterizedTest
+  @EnumSource(ArtifactType.class)
+  public void failsIfSigningRootDoesNotMatchSigningData(final ArtifactType artifactType) throws JsonProcessingException {
     final String configFilename = publicKey.toString().substring(2);
 
     final Path keyConfigFile = testDirectory.resolve(configFilename + ".yaml");
@@ -155,7 +156,7 @@ public class BlsSigningAcceptanceTest extends SigningAcceptanceTestBase {
 
     setupSigner("eth2", null);
 
-    final Eth2SigningRequestBody request = Eth2RequestUtils.createBlockRequest();
+    final Eth2SigningRequestBody request = Eth2RequestUtils.createCannedRequest(artifactType);
     final Eth2SigningRequestBody requestWithMismatchedSigningRoot =
         new Eth2SigningRequestBody(
             request.getType(),

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/BlsSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/BlsSigningAcceptanceTest.java
@@ -148,7 +148,8 @@ public class BlsSigningAcceptanceTest extends SigningAcceptanceTestBase {
 
   @ParameterizedTest
   @EnumSource(ArtifactType.class)
-  public void failsIfSigningRootDoesNotMatchSigningData(final ArtifactType artifactType) throws JsonProcessingException {
+  public void failsIfSigningRootDoesNotMatchSigningData(final ArtifactType artifactType)
+      throws JsonProcessingException {
     final String configFilename = publicKey.toString().substring(2);
 
     final Path keyConfigFile = testDirectory.resolve(configFilename + ".yaml");

--- a/core/src/main/resources/openapi/web3signer-eth2.yaml
+++ b/core/src/main/resources/openapi/web3signer-eth2.yaml
@@ -181,6 +181,9 @@ components:
       properties:
         type:
           type: "string"
+        signingRoot:
+          description: 'signing root for optional verification if field present'
+          type: "string"
         deposit:
           type: object
           properties:
@@ -189,9 +192,6 @@ components:
             withdrawal_credentials:
               type: "string"
             amount:
-              type: "string"
-            signingRoot:
-              description: 'signing root for optional verification if field present'
               type: "string"
             genesis_fork_version:
               type: "string"


### PR DESCRIPTION
Signing root was declared incorrectly for the deposit data openapi spec.

Fixes #344