### PR TITLE
Fix the external link for documentation on OpenAPI documentation

### DIFF
--- a/core/src/main/resources/openapi/web3signer-eth1.yaml
+++ b/core/src/main/resources/openapi/web3signer-eth1.yaml
@@ -98,4 +98,4 @@ paths:
 
 externalDocs:
   description: 'Web3Signer User Documentation'
-  url: 'https://doc.web3signer.pegasys.tech/'
+  url: 'https://docs.web3signer.consensys.net/'

--- a/core/src/main/resources/openapi/web3signer-eth2.yaml
+++ b/core/src/main/resources/openapi/web3signer-eth2.yaml
@@ -421,4 +421,4 @@ components:
 
 externalDocs:
   description: 'Web3Signer User Documentation'
-  url: 'https://doc.web3signer.pegasys.tech/'
+  url: 'https://docs.web3signer.consensys.net/'

--- a/core/src/main/resources/openapi/web3signer-filecoin.yaml
+++ b/core/src/main/resources/openapi/web3signer-filecoin.yaml
@@ -32,4 +32,4 @@ paths:
 
 externalDocs:
   description: 'Web3Signer User Documentation'
-  url: 'https://doc.web3signer.pegasys.tech/'
+  url: 'https://docs.web3signer.consensys.net/'


### PR DESCRIPTION
Url https://doc.web3signer.pegasys.tech is no longer valid and updated to correct url https://docs.web3signer.consensys.net