### PR TITLE
Fix errors in openAPI spec

### DIFF
--- a/core/src/main/resources/openapi/web3signer-eth2.yaml
+++ b/core/src/main/resources/openapi/web3signer-eth2.yaml
@@ -163,8 +163,6 @@ components:
           properties:
             attestation:
               $ref: "#/components/schemas/AttestationData"
-            fork:
-              $ref: '#/components/schemas/AttestationData'
           required:
             - attestation
     BlockSigning:
@@ -314,9 +312,9 @@ components:
     ProposerSlashing:
       type: "object"
       properties:
-        header_1:
+        signed_header_1:
           "$ref": "#/components/schemas/SignedBeaconBlockHeader"
-        header_2":
+        signed_header_2:
           "$ref": "#/components/schemas/SignedBeaconBlockHeader"
     AttesterSlashing:
       type: "object"


### PR DESCRIPTION
Fixes some errors in the openapi spec.

* The Attestation had fork as property at top level but we don’t send it at that level. It is included as part of ForkInfo. See https://github.com/ConsenSys/teku/blob/master/validator/client/src/main/java/tech/pegasys/teku/validator/client/signer/ExternalSigner.java#L94
* ProposerSlashing slashing fields had the wrong field names it should match these https://github.com/ConsenSys/teku/blob/master/data/serializer/src/main/java/tech/pegasys/teku/api/schema/ProposerSlashing.java#L21. This is included in the BeaconBlockBody for block signings data/serializer/src/main/java/tech/pegasys/teku/api/schema/ProposerSlashing.java:21