### PR TITLE
Support building from shallow clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Publish binaries to Cloudsmith
 - Resolve Signers from Cloudsmith
 
+### Bugs Fixed
+- Fixed build failure when checked out as a shallow clone. Shallow clones are still not recommended as the version number cannot be determined correctly.
+
 ## 21.1.0
 
 ### Features Added

--- a/build.gradle
+++ b/build.gradle
@@ -511,6 +511,9 @@ def calculateVersion() {
     return 'UNKNOWN'
   }
   String version = grgit.describe(tags: true)
+  if (version == null) {
+    return "UNKNOWN+g${grgit.head().abbreviatedId}"
+  }
   def versionPattern = ~/^(?<lastVersion>.*)-(?<devVersion>[0-9]+-g[a-z0-9]+)$/
   def matcher = version =~ versionPattern
   if (matcher.find()) {


### PR DESCRIPTION
Fix version detection when building from a shallow clone.  Same as the change in teku: https://github.com/ConsenSys/teku/pull/3687