### PR TITLE
Move slashing protection cli options into a mixin

### DIFF
--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
@@ -12,9 +12,11 @@
  */
 package tech.pegasys.web3signer.commandline;
 
+import tech.pegasys.web3signer.core.config.SlashingProtectionParameters;
+
 import picocli.CommandLine.Option;
 
-public class SlashingProtectionParameters {
+public class PicoCliSlashingProtectionParameters implements SlashingProtectionParameters {
   @Option(
       names = {"--slashing-protection-enabled"},
       description =
@@ -44,18 +46,22 @@ public class SlashingProtectionParameters {
       paramLabel = "<jdbc password>")
   String slashingProtectionDbPassword;
 
+  @Override
   public boolean isEnabled() {
     return slashingProtectionEnabled;
   }
 
+  @Override
   public String getDbUrl() {
     return slashingProtectionDbUrl;
   }
 
+  @Override
   public String getDbUsername() {
     return slashingProtectionDbUsername;
   }
 
+  @Override
   public String getDbPassword() {
     return slashingProtectionDbPassword;
   }

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/SlashingProtectionParameters.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/SlashingProtectionParameters.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.commandline;
+
+import picocli.CommandLine.Option;
+
+public class SlashingProtectionParameters {
+  @Option(
+      names = {"--slashing-protection-enabled"},
+      description =
+          "Set to true if all Eth2 signing operations should be validated against historic data, "
+              + "prior to responding with signatures"
+              + "(default: ${DEFAULT-VALUE})",
+      paramLabel = "<BOOL>",
+      arity = "1")
+  boolean slashingProtectionEnabled = true;
+
+  @Option(
+      names = {"--slashing-protection-db-url"},
+      description = "The jdbc url to use to connect to the slashing protection database",
+      paramLabel = "<jdbc url>",
+      arity = "1")
+  String slashingProtectionDbUrl;
+
+  @Option(
+      names = {"--slashing-protection-db-username"},
+      description = "The username to use when connecting to the slashing protection database",
+      paramLabel = "<jdbc user>")
+  String slashingProtectionDbUsername;
+
+  @Option(
+      names = {"--slashing-protection-db-password"},
+      description = "The password to use when connecting to the slashing protection database",
+      paramLabel = "<jdbc password>")
+  String slashingProtectionDbPassword;
+
+  public boolean isEnabled() {
+    return slashingProtectionEnabled;
+  }
+
+  public String getDbUrl() {
+    return slashingProtectionDbUrl;
+  }
+
+  public String getDbUsername() {
+    return slashingProtectionDbUsername;
+  }
+
+  public String getDbPassword() {
+    return slashingProtectionDbPassword;
+  }
+}

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ExportSubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ExportSubCommand.java
@@ -54,7 +54,7 @@ public class Eth2ExportSubCommand implements Runnable {
     if (output == null) {
       throw new MissingParameterException(
           spec.commandLine(), spec.findOption("--to"), "--to has not been specified");
-    } else if (StringUtils.isEmpty(eth2Config.slashingProtectionDbUrl)) {
+    } else if (StringUtils.isEmpty(eth2Config.slashingProtectionParameters.getDbUrl())) {
       throw new MissingParameterException(
           spec.parent().commandLine(),
           spec.findOption("--slashing-protection-db-url"),
@@ -64,9 +64,9 @@ public class Eth2ExportSubCommand implements Runnable {
     try (final OutputStream outStream = new FileOutputStream(output)) {
       final SlashingProtection slashingProtection =
           createSlashingProtection(
-              eth2Config.slashingProtectionDbUrl,
-              eth2Config.slashingProtectionDbUsername,
-              eth2Config.slashingProtectionDbPassword);
+              eth2Config.slashingProtectionParameters.getDbUrl(),
+              eth2Config.slashingProtectionParameters.getDbUsername(),
+              eth2Config.slashingProtectionParameters.getDbPassword());
 
       slashingProtection.export(outStream);
     } catch (final IOException e) {

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ExportSubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ExportSubCommand.java
@@ -54,7 +54,7 @@ public class Eth2ExportSubCommand implements Runnable {
     if (output == null) {
       throw new MissingParameterException(
           spec.commandLine(), spec.findOption("--to"), "--to has not been specified");
-    } else if (StringUtils.isEmpty(eth2Config.slashingProtectionParameters.getDbUrl())) {
+    } else if (StringUtils.isEmpty(eth2Config.getSlashingProtectionParameters().getDbUrl())) {
       throw new MissingParameterException(
           spec.parent().commandLine(),
           spec.findOption("--slashing-protection-db-url"),
@@ -64,9 +64,9 @@ public class Eth2ExportSubCommand implements Runnable {
     try (final OutputStream outStream = new FileOutputStream(output)) {
       final SlashingProtection slashingProtection =
           createSlashingProtection(
-              eth2Config.slashingProtectionParameters.getDbUrl(),
-              eth2Config.slashingProtectionParameters.getDbUsername(),
-              eth2Config.slashingProtectionParameters.getDbPassword());
+              eth2Config.getSlashingProtectionParameters().getDbUrl(),
+              eth2Config.getSlashingProtectionParameters().getDbUsername(),
+              eth2Config.getSlashingProtectionParameters().getDbPassword());
 
       slashingProtection.export(outStream);
     } catch (final IOException e) {

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ImportSubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ImportSubCommand.java
@@ -54,7 +54,7 @@ public class Eth2ImportSubCommand implements Runnable {
     if (from == null) {
       throw new MissingParameterException(
           spec.commandLine(), spec.findOption("--from"), "--from has not been specified");
-    } else if (StringUtils.isEmpty(eth2Config.slashingProtectionParameters.getDbUrl())) {
+    } else if (StringUtils.isEmpty(eth2Config.getSlashingProtectionParameters().getDbUrl())) {
       throw new MissingParameterException(
           spec.parent().commandLine(),
           spec.findOption("--slashing-protection-db-url"),
@@ -64,9 +64,9 @@ public class Eth2ImportSubCommand implements Runnable {
     try (final InputStream inStream = new FileInputStream(from)) {
       final SlashingProtection slashingProtection =
           createSlashingProtection(
-              eth2Config.slashingProtectionParameters.getDbUrl(),
-              eth2Config.slashingProtectionParameters.getDbUsername(),
-              eth2Config.slashingProtectionParameters.getDbPassword());
+              eth2Config.getSlashingProtectionParameters().getDbUrl(),
+              eth2Config.getSlashingProtectionParameters().getDbUsername(),
+              eth2Config.getSlashingProtectionParameters().getDbPassword());
 
       slashingProtection.importData(inStream);
     } catch (final IOException e) {

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ImportSubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ImportSubCommand.java
@@ -54,7 +54,7 @@ public class Eth2ImportSubCommand implements Runnable {
     if (from == null) {
       throw new MissingParameterException(
           spec.commandLine(), spec.findOption("--from"), "--from has not been specified");
-    } else if (StringUtils.isEmpty(eth2Config.slashingProtectionDbUrl)) {
+    } else if (StringUtils.isEmpty(eth2Config.slashingProtectionParameters.getDbUrl())) {
       throw new MissingParameterException(
           spec.parent().commandLine(),
           spec.findOption("--slashing-protection-db-url"),
@@ -64,9 +64,9 @@ public class Eth2ImportSubCommand implements Runnable {
     try (final InputStream inStream = new FileInputStream(from)) {
       final SlashingProtection slashingProtection =
           createSlashingProtection(
-              eth2Config.slashingProtectionDbUrl,
-              eth2Config.slashingProtectionDbUsername,
-              eth2Config.slashingProtectionDbPassword);
+              eth2Config.slashingProtectionParameters.getDbUrl(),
+              eth2Config.slashingProtectionParameters.getDbUsername(),
+              eth2Config.slashingProtectionParameters.getDbPassword());
 
       slashingProtection.importData(inStream);
     } catch (final IOException e) {

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
@@ -16,7 +16,7 @@ import static tech.pegasys.web3signer.core.config.AzureAuthenticationMode.CLIENT
 import static tech.pegasys.web3signer.core.config.AzureAuthenticationMode.USER_ASSIGNED_MANAGED_IDENTITY;
 
 import tech.pegasys.web3signer.commandline.PicoCliAzureKeyVaultParameters;
-import tech.pegasys.web3signer.commandline.SlashingProtectionParameters;
+import tech.pegasys.web3signer.commandline.PicoCliSlashingProtectionParameters;
 import tech.pegasys.web3signer.core.Eth2Runner;
 import tech.pegasys.web3signer.core.Runner;
 
@@ -41,18 +41,12 @@ public class Eth2SubCommand extends ModeSubCommand {
 
   @Spec CommandSpec spec;
 
-  @Mixin public SlashingProtectionParameters slashingProtectionParameters;
+  @Mixin public PicoCliSlashingProtectionParameters slashingProtectionParameters;
   @Mixin public PicoCliAzureKeyVaultParameters azureKeyVaultParameters;
 
   @Override
   public Runner createRunner() {
-    return new Eth2Runner(
-        config,
-        slashingProtectionParameters.isEnabled(),
-        slashingProtectionParameters.getDbUrl(),
-        slashingProtectionParameters.getDbUsername(),
-        slashingProtectionParameters.getDbPassword(),
-        azureKeyVaultParameters);
+    return new Eth2Runner(config, slashingProtectionParameters, azureKeyVaultParameters);
   }
 
   @Override

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
@@ -19,6 +19,7 @@ import tech.pegasys.web3signer.commandline.PicoCliAzureKeyVaultParameters;
 import tech.pegasys.web3signer.commandline.PicoCliSlashingProtectionParameters;
 import tech.pegasys.web3signer.core.Eth2Runner;
 import tech.pegasys.web3signer.core.Runner;
+import tech.pegasys.web3signer.core.config.SlashingProtectionParameters;
 
 import java.util.List;
 
@@ -41,8 +42,8 @@ public class Eth2SubCommand extends ModeSubCommand {
 
   @Spec CommandSpec spec;
 
-  @Mixin public PicoCliSlashingProtectionParameters slashingProtectionParameters;
-  @Mixin public PicoCliAzureKeyVaultParameters azureKeyVaultParameters;
+  @Mixin private PicoCliSlashingProtectionParameters slashingProtectionParameters;
+  @Mixin private PicoCliAzureKeyVaultParameters azureKeyVaultParameters;
 
   @Override
   public Runner createRunner() {
@@ -99,5 +100,9 @@ public class Eth2SubCommand extends ModeSubCommand {
   @Override
   public String getCommandName() {
     return COMMAND_NAME;
+  }
+
+  public SlashingProtectionParameters getSlashingProtectionParameters() {
+    return slashingProtectionParameters;
   }
 }

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
@@ -16,6 +16,7 @@ import static tech.pegasys.web3signer.core.config.AzureAuthenticationMode.CLIENT
 import static tech.pegasys.web3signer.core.config.AzureAuthenticationMode.USER_ASSIGNED_MANAGED_IDENTITY;
 
 import tech.pegasys.web3signer.commandline.PicoCliAzureKeyVaultParameters;
+import tech.pegasys.web3signer.commandline.SlashingProtectionParameters;
 import tech.pegasys.web3signer.core.Eth2Runner;
 import tech.pegasys.web3signer.core.Runner;
 
@@ -26,7 +27,6 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Option;
 import picocli.CommandLine.ParameterException;
 import picocli.CommandLine.Spec;
 
@@ -41,51 +41,24 @@ public class Eth2SubCommand extends ModeSubCommand {
 
   @Spec CommandSpec spec;
 
-  @Option(
-      names = {"--slashing-protection-enabled"},
-      description =
-          "Set to true if all Eth2 signing operations should be validated against historic data, "
-              + "prior to responding with signatures"
-              + "(default: ${DEFAULT-VALUE})",
-      paramLabel = "<BOOL>",
-      arity = "1")
-  boolean slashingProtectionEnabled = true;
-
-  @Option(
-      names = {"--slashing-protection-db-url"},
-      description = "The jdbc url to use to connect to the slashing protection database",
-      paramLabel = "<jdbc url>",
-      arity = "1")
-  String slashingProtectionDbUrl;
-
-  @Option(
-      names = {"--slashing-protection-db-username"},
-      description = "The username to use when connecting to the slashing protection database",
-      paramLabel = "<jdbc user>")
-  String slashingProtectionDbUsername;
-
-  @Option(
-      names = {"--slashing-protection-db-password"},
-      description = "The password to use when connecting to the slashing protection database",
-      paramLabel = "<jdbc password>")
-  String slashingProtectionDbPassword;
-
+  @Mixin public SlashingProtectionParameters slashingProtectionParameters;
   @Mixin public PicoCliAzureKeyVaultParameters azureKeyVaultParameters;
 
   @Override
   public Runner createRunner() {
     return new Eth2Runner(
         config,
-        slashingProtectionEnabled,
-        slashingProtectionDbUrl,
-        slashingProtectionDbUsername,
-        slashingProtectionDbPassword,
+        slashingProtectionParameters.isEnabled(),
+        slashingProtectionParameters.getDbUrl(),
+        slashingProtectionParameters.getDbUsername(),
+        slashingProtectionParameters.getDbPassword(),
         azureKeyVaultParameters);
   }
 
   @Override
   protected void validateArgs() {
-    if (slashingProtectionEnabled && slashingProtectionDbUrl == null) {
+    if (slashingProtectionParameters.isEnabled()
+        && slashingProtectionParameters.getDbUrl() == null) {
       throw new ParameterException(spec.commandLine(), "Missing slashing protection database url");
     }
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.bls.BLSSecretKey;
 import tech.pegasys.web3signer.core.config.AzureKeyVaultFactory;
 import tech.pegasys.web3signer.core.config.AzureKeyVaultParameters;
 import tech.pegasys.web3signer.core.config.Config;
+import tech.pegasys.web3signer.core.config.SlashingProtectionParameters;
 import tech.pegasys.web3signer.core.metrics.SlashingProtectionMetrics;
 import tech.pegasys.web3signer.core.multikey.DefaultArtifactSignerProvider;
 import tech.pegasys.web3signer.core.multikey.SignerLoader;
@@ -73,31 +74,22 @@ public class Eth2Runner extends Runner {
 
   public Eth2Runner(
       final Config config,
-      final boolean slashingProtectionEnabled,
-      final String slashingProtectionDbUrl,
-      final String slashingProtectionDbUser,
-      final String slashingProtectionDbPassword,
+      final SlashingProtectionParameters slashingProtectionParameters,
       final AzureKeyVaultParameters azureKeyVaultParameters) {
     super(config);
-    this.slashingProtection =
-        createSlashingProtection(
-            slashingProtectionEnabled,
-            slashingProtectionDbUrl,
-            slashingProtectionDbUser,
-            slashingProtectionDbPassword);
+    this.slashingProtection = createSlashingProtection(slashingProtectionParameters);
     this.azureKeyVaultParameters = azureKeyVaultParameters;
   }
 
   private Optional<SlashingProtection> createSlashingProtection(
-      final boolean slashingProtectionEnabled,
-      final String slashingProtectionDbUrl,
-      final String slashingProtectionDbUser,
-      final String slashingProtectionDbPassword) {
-    if (slashingProtectionEnabled) {
+      SlashingProtectionParameters slashingProtectionParameters) {
+    if (slashingProtectionParameters.isEnabled()) {
       try {
         return Optional.of(
             SlashingProtectionFactory.createSlashingProtection(
-                slashingProtectionDbUrl, slashingProtectionDbUser, slashingProtectionDbPassword));
+                slashingProtectionParameters.getDbUrl(),
+                slashingProtectionParameters.getDbUrl(),
+                slashingProtectionParameters.getDbPassword()));
       } catch (final IllegalStateException e) {
         throw new InitializationException(e.getMessage(), e);
       }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -82,13 +82,13 @@ public class Eth2Runner extends Runner {
   }
 
   private Optional<SlashingProtection> createSlashingProtection(
-      SlashingProtectionParameters slashingProtectionParameters) {
+      final SlashingProtectionParameters slashingProtectionParameters) {
     if (slashingProtectionParameters.isEnabled()) {
       try {
         return Optional.of(
             SlashingProtectionFactory.createSlashingProtection(
                 slashingProtectionParameters.getDbUrl(),
-                slashingProtectionParameters.getDbUrl(),
+                slashingProtectionParameters.getDbUsername(),
                 slashingProtectionParameters.getDbPassword()));
       } catch (final IllegalStateException e) {
         throw new InitializationException(e.getMessage(), e);

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/SlashingProtectionParameters.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/SlashingProtectionParameters.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.config;
+
+public interface SlashingProtectionParameters {
+
+  boolean isEnabled();
+
+  String getDbUrl();
+
+  String getDbUsername();
+
+  String getDbPassword();
+}


### PR DESCRIPTION
Move slashing protection cli options into a mixin to cleanup config code.