### PR TITLE
fix pruning deleting too much data

### DIFF
--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDao.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDao.java
@@ -120,11 +120,13 @@ public class SignedAttestationsDao {
   }
 
   public void deleteAttestationsBelowWatermark(final Handle handle, final int validatorId) {
-    handle.execute(
-        "DELETE FROM signed_attestations a "
-            + "USING low_watermarks w "
-            + "WHERE a.validator_id = ? AND a.target_epoch < w.target_epoch",
-        validatorId);
+    handle
+        .createUpdate(
+            "DELETE FROM signed_attestations "
+                + "WHERE validator_id = :validator_id "
+                + "AND target_epoch < (SELECT target_epoch FROM low_watermarks where validator_id = :validator_id)")
+        .bind("validator_id", validatorId)
+        .execute();
   }
 
   public Optional<UInt64> findMaxTargetEpoch(final Handle handle, final int validatorId) {

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDao.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDao.java
@@ -72,11 +72,13 @@ public class SignedBlocksDao {
   }
 
   public void deleteBlocksBelowWatermark(final Handle handle, final int validatorId) {
-    handle.execute(
-        "DELETE FROM signed_blocks b "
-            + "USING low_watermarks w "
-            + "WHERE b.validator_id = ? AND b.slot < w.slot",
-        validatorId);
+    handle
+        .createUpdate(
+            "DELETE FROM signed_blocks "
+                + "WHERE validator_id = :validator_id "
+                + "AND slot < (SELECT slot FROM low_watermarks WHERE validator_id = :validator_id)")
+        .bind("validator_id", validatorId)
+        .execute();
   }
 
   public Optional<UInt64> findMaxSlot(final Handle handle, final int validatorId) {

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDaoTest.java
@@ -213,7 +213,7 @@ public class SignedAttestationsDaoTest {
     insertAttestation(1, Bytes.of(1), UInt64.valueOf(4), UInt64.valueOf(5));
     insertAttestation(2, Bytes.of(1), UInt64.valueOf(2), UInt64.valueOf(3));
     lowWatermarkDao.updateEpochWatermarksFor(handle, 1, UInt64.valueOf(4), UInt64.valueOf(4));
-    lowWatermarkDao.updateEpochWatermarksFor(handle, 2, UInt64.valueOf(4), UInt64.valueOf(4));
+    lowWatermarkDao.updateEpochWatermarksFor(handle, 2, UInt64.valueOf(5), UInt64.valueOf(6));
 
     signedAttestationsDao.deleteAttestationsBelowWatermark(handle, 1);
     final Map<Integer, List<SignedAttestation>> attestations =

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.web3signer.slashingprotection.dao;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.jdbi.v3.core.result.ResultIterable;
 import tech.pegasys.web3signer.slashingprotection.DbConnection;
 
 import java.util.List;
@@ -167,14 +166,12 @@ public class SignedBlocksDaoTest {
   public void deletingBlocksDoesNotAffectAfterValidatorBlocks() {
     insertValidator(Bytes.of(1), 1);
     insertValidator(Bytes.of(2), 2);
-    insertValidator(Bytes.of(3), 3);
     insertBlock(1, 3, Bytes.of(1));
     insertBlock(1, 4, Bytes.of(1));
     insertBlock(2, 3, Bytes.of(1));
     insertBlock(2, 4, Bytes.of(1));
     lowWatermarkDao.updateSlotWatermarkFor(handle, 1, UInt64.valueOf(4));
     lowWatermarkDao.updateSlotWatermarkFor(handle, 2, UInt64.valueOf(5));
-    lowWatermarkDao.updateSlotWatermarkFor(handle, 3, UInt64.valueOf(6));
 
     signedBlocksDao.deleteBlocksBelowWatermark(handle, 1);
     final Map<Integer, List<SignedBlock>> blocks =
@@ -185,7 +182,6 @@ public class SignedBlocksDaoTest {
     assertThat(blocks.get(1)).hasSize(1);
     assertThat(blocks.get(1).get(0)).isEqualToComparingFieldByField(block(4, 1));
     assertThat(blocks.get(2)).hasSize(2);
-    assertThat(blocks.get(3)).isNull();
   }
 
   @Test

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.web3signer.slashingprotection.dao;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.jdbi.v3.core.result.ResultIterable;
 import tech.pegasys.web3signer.slashingprotection.DbConnection;
 
 import java.util.List;
@@ -148,13 +149,32 @@ public class SignedBlocksDaoTest {
   @Test
   public void deletesBlocksBelowWatermark() {
     insertValidator(Bytes.of(100), 1);
-    insertValidator(Bytes.of(200), 2);
+    insertBlock(1, 3, Bytes.of(1));
+    insertBlock(1, 4, Bytes.of(1));
+    lowWatermarkDao.updateSlotWatermarkFor(handle, 1, UInt64.valueOf(4));
+
+    signedBlocksDao.deleteBlocksBelowWatermark(handle, 1);
+    final Map<Integer, List<SignedBlock>> blocks =
+        handle.createQuery("SELECT * FROM signed_blocks ORDER BY validator_id")
+            .mapToBean(SignedBlock.class).stream()
+            .collect(Collectors.groupingBy(SignedBlock::getValidatorId));
+
+    assertThat(blocks.get(1)).hasSize(1);
+    assertThat(blocks.get(1).get(0)).isEqualToComparingFieldByField(block(4, 1));
+  }
+
+  @Test
+  public void deletingBlocksDoesNotAffectAfterValidatorBlocks() {
+    insertValidator(Bytes.of(1), 1);
+    insertValidator(Bytes.of(2), 2);
+    insertValidator(Bytes.of(3), 3);
     insertBlock(1, 3, Bytes.of(1));
     insertBlock(1, 4, Bytes.of(1));
     insertBlock(2, 3, Bytes.of(1));
     insertBlock(2, 4, Bytes.of(1));
     lowWatermarkDao.updateSlotWatermarkFor(handle, 1, UInt64.valueOf(4));
-    lowWatermarkDao.updateSlotWatermarkFor(handle, 2, UInt64.valueOf(4));
+    lowWatermarkDao.updateSlotWatermarkFor(handle, 2, UInt64.valueOf(5));
+    lowWatermarkDao.updateSlotWatermarkFor(handle, 3, UInt64.valueOf(6));
 
     signedBlocksDao.deleteBlocksBelowWatermark(handle, 1);
     final Map<Integer, List<SignedBlock>> blocks =
@@ -165,6 +185,7 @@ public class SignedBlocksDaoTest {
     assertThat(blocks.get(1)).hasSize(1);
     assertThat(blocks.get(1).get(0)).isEqualToComparingFieldByField(block(4, 1));
     assertThat(blocks.get(2)).hasSize(2);
+    assertThat(blocks.get(3)).isNull();
   }
 
   @Test


### PR DESCRIPTION
Fix issue with pruning where the delete would derive the watermark incorrectly in the delete below watermark query. This resulted too much data being deleted. Changed the delete to use a subquery also fixing the issue.

Also added some more logging so the progress of pruning can be seen.