### PR TITLE
Tweak loading of signers to not utilize concurrent maps

### DIFF
--- a/commandline/src/test/java/tech/pegasys/web3signer/commandline/CommandlineParserTest.java
+++ b/commandline/src/test/java/tech/pegasys/web3signer/commandline/CommandlineParserTest.java
@@ -28,8 +28,10 @@ import java.net.InetAddress;
 import java.util.Collections;
 import java.util.function.Supplier;
 
+import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 import org.apache.logging.log4j.Level;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
@@ -393,13 +395,13 @@ class CommandlineParserTest {
     public void run() {}
 
     @Override
-    protected ArtifactSignerProvider getArtifactSignerProvider(final Context context) {
+    protected ArtifactSignerProvider getArtifactSignerProvider(
+        final Vertx vertx, final MetricsSystem metricsSystem) {
       return null;
     }
 
     @Override
-    protected Router populateRouter(
-        final Context context, final ArtifactSignerProvider signerProvider) {
+    protected Router populateRouter(final Context context) {
       return null;
     }
 

--- a/commandline/src/test/java/tech/pegasys/web3signer/commandline/CommandlineParserTest.java
+++ b/commandline/src/test/java/tech/pegasys/web3signer/commandline/CommandlineParserTest.java
@@ -395,7 +395,7 @@ class CommandlineParserTest {
     public void run() {}
 
     @Override
-    protected ArtifactSignerProvider getArtifactSignerProvider(
+    protected ArtifactSignerProvider createArtifactSignerProvider(
         final Vertx vertx, final MetricsSystem metricsSystem) {
       return null;
     }

--- a/commandline/src/test/java/tech/pegasys/web3signer/commandline/CommandlineParserTest.java
+++ b/commandline/src/test/java/tech/pegasys/web3signer/commandline/CommandlineParserTest.java
@@ -20,6 +20,7 @@ import tech.pegasys.web3signer.commandline.subcommands.Eth2SubCommand;
 import tech.pegasys.web3signer.core.Context;
 import tech.pegasys.web3signer.core.Runner;
 import tech.pegasys.web3signer.core.config.Config;
+import tech.pegasys.web3signer.core.signing.ArtifactSignerProvider;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -392,7 +393,13 @@ class CommandlineParserTest {
     public void run() {}
 
     @Override
-    protected Router populateRouter(final Context context) {
+    protected ArtifactSignerProvider getArtifactSignerProvider(final Context context) {
+      return null;
+    }
+
+    @Override
+    protected Router populateRouter(
+        final Context context, final ArtifactSignerProvider signerProvider) {
       return null;
     }
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/Context.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Context.java
@@ -14,8 +14,6 @@ package tech.pegasys.web3signer.core;
 
 import tech.pegasys.web3signer.core.service.http.handlers.LogErrorHandler;
 
-import java.util.concurrent.ExecutorService;
-
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -25,19 +23,16 @@ public class Context {
   private final MetricsSystem metricsSystem;
   private final LogErrorHandler errorHandler;
   private final Vertx vertx;
-  private final ExecutorService reloadExecutorService;
 
   public Context(
       final OpenAPI3RouterFactory routerFactory,
       final MetricsSystem metricsSystem,
       final LogErrorHandler errorHandler,
-      final Vertx vertx,
-      final ExecutorService reloadExecutorService) {
+      final Vertx vertx) {
     this.routerFactory = routerFactory;
     this.metricsSystem = metricsSystem;
     this.errorHandler = errorHandler;
     this.vertx = vertx;
-    this.reloadExecutorService = reloadExecutorService;
   }
 
   public OpenAPI3RouterFactory getRouterFactory() {
@@ -54,9 +49,5 @@ public class Context {
 
   public Vertx getVertx() {
     return vertx;
-  }
-
-  public ExecutorService getReloadExecutorService() {
-    return reloadExecutorService;
   }
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Context.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Context.java
@@ -14,6 +14,8 @@ package tech.pegasys.web3signer.core;
 
 import tech.pegasys.web3signer.core.service.http.handlers.LogErrorHandler;
 
+import java.util.concurrent.ExecutorService;
+
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -23,16 +25,19 @@ public class Context {
   private final MetricsSystem metricsSystem;
   private final LogErrorHandler errorHandler;
   private final Vertx vertx;
+  private final ExecutorService reloadExecutorService;
 
   public Context(
       final OpenAPI3RouterFactory routerFactory,
       final MetricsSystem metricsSystem,
       final LogErrorHandler errorHandler,
-      final Vertx vertx) {
+      final Vertx vertx,
+      final ExecutorService reloadExecutorService) {
     this.routerFactory = routerFactory;
     this.metricsSystem = metricsSystem;
     this.errorHandler = errorHandler;
     this.vertx = vertx;
+    this.reloadExecutorService = reloadExecutorService;
   }
 
   public OpenAPI3RouterFactory getRouterFactory() {
@@ -49,5 +54,9 @@ public class Context {
 
   public Vertx getVertx() {
     return vertx;
+  }
+
+  public ExecutorService getReloadExecutorService() {
+    return reloadExecutorService;
   }
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Context.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Context.java
@@ -13,6 +13,7 @@
 package tech.pegasys.web3signer.core;
 
 import tech.pegasys.web3signer.core.service.http.handlers.LogErrorHandler;
+import tech.pegasys.web3signer.core.signing.ArtifactSignerProvider;
 
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
@@ -23,16 +24,19 @@ public class Context {
   private final MetricsSystem metricsSystem;
   private final LogErrorHandler errorHandler;
   private final Vertx vertx;
+  private final ArtifactSignerProvider artifactSignerProvider;
 
   public Context(
       final OpenAPI3RouterFactory routerFactory,
       final MetricsSystem metricsSystem,
       final LogErrorHandler errorHandler,
-      final Vertx vertx) {
+      final Vertx vertx,
+      final ArtifactSignerProvider artifactSignerProvider) {
     this.routerFactory = routerFactory;
     this.metricsSystem = metricsSystem;
     this.errorHandler = errorHandler;
     this.vertx = vertx;
+    this.artifactSignerProvider = artifactSignerProvider;
   }
 
   public OpenAPI3RouterFactory getRouterFactory() {
@@ -49,5 +53,9 @@ public class Context {
 
   public Vertx getVertx() {
     return vertx;
+  }
+
+  public ArtifactSignerProvider getArtifactSignerProvider() {
+    return artifactSignerProvider;
   }
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -37,6 +37,7 @@ import tech.pegasys.web3signer.core.signing.SecpArtifactSignature;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
@@ -59,7 +60,8 @@ public class Eth1Runner extends Runner {
 
   @Override
   protected Router populateRouter(final Context context) {
-    final ArtifactSignerProvider signerProvider = loadSigners(config, context.getVertx());
+    final ArtifactSignerProvider signerProvider =
+        loadSigners(config, context.getVertx(), context.getReloadExecutorService());
     incSignerLoadCount(context.getMetricsSystem(), signerProvider.availableIdentifiers().size());
 
     final OpenAPI3RouterFactory routerFactory = context.getRouterFactory();
@@ -83,7 +85,8 @@ public class Eth1Runner extends Runner {
     return context.getRouterFactory().getRouter();
   }
 
-  private ArtifactSignerProvider loadSigners(final Config config, final Vertx vertx) {
+  private ArtifactSignerProvider loadSigners(
+      final Config config, final Vertx vertx, final ExecutorService reloadExecutorService) {
     final ArtifactSignerProvider artifactSignerProvider =
         new DefaultArtifactSignerProvider(
             () -> {
@@ -109,7 +112,8 @@ public class Eth1Runner extends Runner {
                     "yaml",
                     new YamlSignerParser(List.of(ethSecpArtifactSignerFactory)));
               }
-            });
+            },
+            reloadExecutorService);
 
     try {
       artifactSignerProvider.load().get();

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -40,6 +40,7 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
 import io.vertx.ext.web.impl.BlockingHandlerDecorator;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 public class Eth1Runner extends Runner {
   public Eth1Runner(final Config config) {
@@ -52,10 +53,10 @@ public class Eth1Runner extends Runner {
   }
 
   @Override
-  protected Router populateRouter(
-      final Context context, final ArtifactSignerProvider signerProvider) {
+  protected Router populateRouter(final Context context) {
     final OpenAPI3RouterFactory routerFactory = context.getRouterFactory();
     final LogErrorHandler errorHandler = context.getErrorHandler();
+    final ArtifactSignerProvider signerProvider = context.getArtifactSignerProvider();
 
     addPublicKeysListHandler(
         routerFactory, signerProvider, ETH1_LIST.name(), context.getErrorHandler());
@@ -76,9 +77,8 @@ public class Eth1Runner extends Runner {
   }
 
   @Override
-  protected ArtifactSignerProvider getArtifactSignerProvider(final Context context) {
-    final Vertx vertx = context.getVertx();
-
+  protected ArtifactSignerProvider getArtifactSignerProvider(
+      final Vertx vertx, final MetricsSystem metricsSystem) {
     return new DefaultArtifactSignerProvider(
         () -> {
           final AzureKeyVaultSignerFactory azureFactory = new AzureKeyVaultSignerFactory();

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -36,13 +36,17 @@ import tech.pegasys.web3signer.core.signing.EthSecpArtifactSigner;
 import tech.pegasys.web3signer.core.signing.SecpArtifactSignature;
 
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
 import io.vertx.ext.web.impl.BlockingHandlerDecorator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class Eth1Runner extends Runner {
+  private static final Logger LOG = LogManager.getLogger();
 
   public Eth1Runner(final Config config) {
     super(config);
@@ -106,6 +110,12 @@ public class Eth1Runner extends Runner {
                     new YamlSignerParser(List.of(ethSecpArtifactSignerFactory)));
               }
             });
+
+    try {
+      artifactSignerProvider.load().get();
+    } catch (InterruptedException | ExecutionException e) {
+      LOG.error("Error invoking load", e);
+    }
 
     return artifactSignerProvider;
   }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -77,7 +77,7 @@ public class Eth1Runner extends Runner {
   }
 
   @Override
-  protected ArtifactSignerProvider getArtifactSignerProvider(
+  protected ArtifactSignerProvider createArtifactSignerProvider(
       final Vertx vertx, final MetricsSystem metricsSystem) {
     return new DefaultArtifactSignerProvider(
         () -> {

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -15,7 +15,6 @@ package tech.pegasys.web3signer.core;
 import static tech.pegasys.web3signer.core.service.http.OpenApiOperationsId.ETH2_LIST;
 import static tech.pegasys.web3signer.core.service.http.OpenApiOperationsId.ETH2_SIGN;
 import static tech.pegasys.web3signer.core.service.http.OpenApiOperationsId.RELOAD;
-import static tech.pegasys.web3signer.core.service.http.metrics.HttpApiMetrics.incSignerLoadCount;
 import static tech.pegasys.web3signer.core.signing.KeyType.BLS;
 
 import tech.pegasys.signers.azure.AzureKeyVault;

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -148,7 +148,7 @@ public class Eth2Runner extends Runner {
   }
 
   @Override
-  protected ArtifactSignerProvider getArtifactSignerProvider(
+  protected ArtifactSignerProvider createArtifactSignerProvider(
       final Vertx vertx, final MetricsSystem metricsSystem) {
     return new DefaultArtifactSignerProvider(
         () -> {

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -191,12 +191,11 @@ public class Eth2Runner extends Runner {
                       .map(Bytes::fromHexString)
                       .collect(Collectors.toList());
               if (validators.isEmpty()) {
-                LOG.warn(
-                    "No BLS keys configured. Check that the key store has BLS key config files");
+                LOG.warn("No BLS keys loaded. Check that the key store has BLS key config files");
+              } else {
+                slashingProtection.ifPresent(
+                    slashingProtection -> slashingProtection.registerValidators(validators));
               }
-
-              slashingProtection.ifPresent(
-                  slashingProtection -> slashingProtection.registerValidators(validators));
               return signers;
             });
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -50,8 +50,6 @@ import tech.pegasys.web3signer.slashingprotection.SlashingProtectionParameters;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
@@ -108,15 +106,7 @@ public class Eth2Runner extends Runner {
   }
 
   @Override
-  public Router populateRouter(final Context context) {
-    final ArtifactSignerProvider signerProvider =
-        loadSigners(
-            config,
-            context.getVertx(),
-            context.getMetricsSystem(),
-            context.getReloadExecutorService());
-    incSignerLoadCount(context.getMetricsSystem(), signerProvider.availableIdentifiers().size());
-
+  public Router populateRouter(final Context context, final ArtifactSignerProvider signerProvider) {
     registerEth2Routes(
         context.getRouterFactory(),
         signerProvider,
@@ -158,63 +148,53 @@ public class Eth2Runner extends Runner {
     addReloadHandler(routerFactory, blsSignerProvider, RELOAD.name(), errorHandler);
   }
 
-  private ArtifactSignerProvider loadSigners(
-      final Config config,
-      final Vertx vertx,
-      final MetricsSystem metricsSystem,
-      final ExecutorService reloadExecutorService) {
+  @Override
+  protected ArtifactSignerProvider getArtifactSignerProvider(final Context context) {
+    final Vertx vertx = context.getVertx();
+    final MetricsSystem metricsSystem = context.getMetricsSystem();
 
-    final DefaultArtifactSignerProvider artifactSignerProvider =
-        new DefaultArtifactSignerProvider(
-            () -> {
-              final List<ArtifactSigner> signers = Lists.newArrayList();
-              final HashicorpConnectionFactory hashicorpConnectionFactory =
-                  new HashicorpConnectionFactory(vertx);
+    return new DefaultArtifactSignerProvider(
+        () -> {
+          final List<ArtifactSigner> signers = Lists.newArrayList();
+          final HashicorpConnectionFactory hashicorpConnectionFactory =
+              new HashicorpConnectionFactory(vertx);
 
-              try (final InterlockKeyProvider interlockKeyProvider =
-                      new InterlockKeyProvider(vertx);
-                  final YubiHsmOpaqueDataProvider yubiHsmOpaqueDataProvider =
-                      new YubiHsmOpaqueDataProvider()) {
-                final AbstractArtifactSignerFactory artifactSignerFactory =
-                    new BlsArtifactSignerFactory(
-                        config.getKeyConfigPath(),
-                        metricsSystem,
-                        hashicorpConnectionFactory,
-                        interlockKeyProvider,
-                        yubiHsmOpaqueDataProvider,
-                        BlsArtifactSigner::new);
+          try (final InterlockKeyProvider interlockKeyProvider = new InterlockKeyProvider(vertx);
+              final YubiHsmOpaqueDataProvider yubiHsmOpaqueDataProvider =
+                  new YubiHsmOpaqueDataProvider()) {
+            final AbstractArtifactSignerFactory artifactSignerFactory =
+                new BlsArtifactSignerFactory(
+                    config.getKeyConfigPath(),
+                    metricsSystem,
+                    hashicorpConnectionFactory,
+                    interlockKeyProvider,
+                    yubiHsmOpaqueDataProvider,
+                    BlsArtifactSigner::new);
 
-                signers.addAll(
-                    SignerLoader.load(
-                        config.getKeyConfigPath(),
-                        "yaml",
-                        new YamlSignerParser(List.of(artifactSignerFactory))));
-              }
+            signers.addAll(
+                SignerLoader.load(
+                    config.getKeyConfigPath(),
+                    "yaml",
+                    new YamlSignerParser(List.of(artifactSignerFactory))));
+          }
 
-              if (azureKeyVaultParameters.isAzureKeyVaultEnabled()) {
-                signers.addAll(loadAzureSigners());
-              }
+          if (azureKeyVaultParameters.isAzureKeyVaultEnabled()) {
+            signers.addAll(loadAzureSigners());
+          }
 
-              final List<Bytes> validators =
-                  signers.stream()
-                      .map(ArtifactSigner::getIdentifier)
-                      .map(Bytes::fromHexString)
-                      .collect(Collectors.toList());
-              if (validators.isEmpty()) {
-                LOG.warn("No BLS keys loaded. Check that the key store has BLS key config files");
-              } else {
-                slashingProtection.ifPresent(
-                    slashingProtection1 -> slashingProtection1.registerValidators(validators));
-              }
-              return signers;
-            },
-            reloadExecutorService);
-    try {
-      artifactSignerProvider.load().get();
-    } catch (InterruptedException | ExecutionException e) {
-      LOG.error("Error invoking load", e);
-    }
-    return artifactSignerProvider;
+          final List<Bytes> validators =
+              signers.stream()
+                  .map(ArtifactSigner::getIdentifier)
+                  .map(Bytes::fromHexString)
+                  .collect(Collectors.toList());
+          if (validators.isEmpty()) {
+            LOG.warn("No BLS keys loaded. Check that the key store has BLS key config files");
+          } else {
+            slashingProtection.ifPresent(
+                slashingProtection1 -> slashingProtection1.registerValidators(validators));
+          }
+          return signers;
+        });
   }
 
   @Override

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -105,10 +105,10 @@ public class Eth2Runner extends Runner {
   }
 
   @Override
-  public Router populateRouter(final Context context, final ArtifactSignerProvider signerProvider) {
+  public Router populateRouter(final Context context) {
     registerEth2Routes(
         context.getRouterFactory(),
-        signerProvider,
+        context.getArtifactSignerProvider(),
         context.getErrorHandler(),
         context.getMetricsSystem(),
         slashingProtection);
@@ -148,10 +148,8 @@ public class Eth2Runner extends Runner {
   }
 
   @Override
-  protected ArtifactSignerProvider getArtifactSignerProvider(final Context context) {
-    final Vertx vertx = context.getVertx();
-    final MetricsSystem metricsSystem = context.getMetricsSystem();
-
+  protected ArtifactSignerProvider getArtifactSignerProvider(
+      final Vertx vertx, final MetricsSystem metricsSystem) {
     return new DefaultArtifactSignerProvider(
         () -> {
           final List<ArtifactSigner> signers = Lists.newArrayList();

--- a/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
@@ -63,13 +63,17 @@ public class FilecoinRunner extends Runner {
   }
 
   @Override
-  protected Router populateRouter(
-      final Context context, final ArtifactSignerProvider signerProvider) {
+  protected Router populateRouter(final Context context) {
     addReloadHandler(
-        context.getRouterFactory(), signerProvider, RELOAD.name(), context.getErrorHandler());
+        context.getRouterFactory(),
+        context.getArtifactSignerProvider(),
+        RELOAD.name(),
+        context.getErrorHandler());
 
     return registerFilecoinJsonRpcRoute(
-        context.getRouterFactory(), context.getMetricsSystem(), signerProvider);
+        context.getRouterFactory(),
+        context.getMetricsSystem(),
+        context.getArtifactSignerProvider());
   }
 
   private Router registerFilecoinJsonRpcRoute(
@@ -105,10 +109,8 @@ public class FilecoinRunner extends Runner {
   }
 
   @Override
-  protected ArtifactSignerProvider getArtifactSignerProvider(final Context context) {
-    final Vertx vertx = context.getVertx();
-    final MetricsSystem metricsSystem = context.getMetricsSystem();
-
+  protected ArtifactSignerProvider getArtifactSignerProvider(
+      final Vertx vertx, final MetricsSystem metricsSystem) {
     return new DefaultArtifactSignerProvider(
         () -> {
           final AzureKeyVaultSignerFactory azureFactory = new AzureKeyVaultSignerFactory();

--- a/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
@@ -40,6 +40,7 @@ import tech.pegasys.web3signer.core.signing.FcSecpArtifactSigner;
 import tech.pegasys.web3signer.core.signing.filecoin.FilecoinNetwork;
 
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.arteam.simplejsonrpc.server.JsonRpcServer;
@@ -47,9 +48,12 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
 import io.vertx.ext.web.handler.BodyHandler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 public class FilecoinRunner extends Runner {
+  private static final Logger LOG = LogManager.getLogger();
 
   private static final String FC_JSON_RPC_PATH = "/rpc/v0";
   private final FilecoinNetwork network;
@@ -149,7 +153,11 @@ public class FilecoinRunner extends Runner {
                         List.of(blsArtifactSignerFactory, secpArtifactSignerFactory)));
               }
             });
-
+    try {
+      artifactSignerProvider.load().get();
+    } catch (InterruptedException | ExecutionException e) {
+      LOG.error("Error invoking load", e);
+    }
     return artifactSignerProvider;
   }
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
@@ -109,7 +109,7 @@ public class FilecoinRunner extends Runner {
   }
 
   @Override
-  protected ArtifactSignerProvider getArtifactSignerProvider(
+  protected ArtifactSignerProvider createArtifactSignerProvider(
       final Vertx vertx, final MetricsSystem metricsSystem) {
     return new DefaultArtifactSignerProvider(
         () -> {

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -99,7 +99,7 @@ public abstract class Runner implements Runnable {
     final Vertx vertx = Vertx.vertx(createVertxOptions(metricsSystem));
     final LogErrorHandler errorHandler = new LogErrorHandler();
     final ArtifactSignerProvider artifactSignerProvider =
-        getArtifactSignerProvider(vertx, metricsSystem);
+        createArtifactSignerProvider(vertx, metricsSystem);
 
     try {
       metricsEndpoint.start(vertx);
@@ -152,7 +152,7 @@ public abstract class Runner implements Runnable {
                 .setFactory(new VertxMetricsAdapterFactory(metricsSystem)));
   }
 
-  protected abstract ArtifactSignerProvider getArtifactSignerProvider(
+  protected abstract ArtifactSignerProvider createArtifactSignerProvider(
       final Vertx vertx, final MetricsSystem metricsSystem);
 
   protected abstract Router populateRouter(final Context context);

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -181,12 +181,10 @@ public abstract class Runner implements Runnable {
       final LogErrorHandler errorHandler) {
     openAPI3RouterFactory.addHandlerByOperationId(
         operationId,
-        new BlockingHandlerDecorator(
-            routingContext -> {
-              artifactSignerProvider.reload();
-              routingContext.response().setStatusCode(200).end();
-            },
-            false));
+        routingContext -> {
+          artifactSignerProvider.asyncLoad();
+          routingContext.response().setStatusCode(200).end();
+        });
     openAPI3RouterFactory.addFailureHandlerByOperationId(operationId, errorHandler);
   }
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -182,7 +182,7 @@ public abstract class Runner implements Runnable {
     openAPI3RouterFactory.addHandlerByOperationId(
         operationId,
         routingContext -> {
-          artifactSignerProvider.asyncLoad();
+          artifactSignerProvider.load();
           routingContext.response().setStatusCode(200).end();
         });
     openAPI3RouterFactory.addFailureHandlerByOperationId(operationId, errorHandler);

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -113,7 +113,7 @@ public abstract class Runner implements Runnable {
       try {
         artifactSignerProvider.load().get();
       } catch (InterruptedException | ExecutionException e) {
-        LOG.error("Error invoking load", e);
+        LOG.error("Error loading signers", e);
       }
       incSignerLoadCount(
           context.getMetricsSystem(), artifactSignerProvider.availableIdentifiers().size());

--- a/core/src/main/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProvider.java
@@ -44,26 +44,22 @@ public class DefaultArtifactSignerProvider implements ArtifactSignerProvider {
 
   @Override
   public void reload() {
-    LOG.trace("Reloading Artifact Signers");
+    LOG.debug("Signer keys pre-loaded in memory {}", signers.size());
 
-    final Map<String, ArtifactSigner> signerMap =
-        artifactSignerCollectionSupplier
-            .get()
-            .parallelStream()
-            .collect(
-                Collectors.toMap(
-                    ArtifactSigner::getIdentifier,
-                    Function.identity(),
-                    (signer1, signer2) -> {
-                      LOG.warn(
-                          "Duplicate keys were found while loading. {}", signer1.getIdentifier());
-                      return signer1;
-                    }));
+    artifactSignerCollectionSupplier.get().stream()
+        .collect(
+            Collectors.toMap(
+                ArtifactSigner::getIdentifier,
+                Function.identity(),
+                (signer1, signer2) -> {
+                  LOG.warn("Duplicate keys were found while loading. {}", Function.identity());
+                  return signer1;
+                }))
+        .forEach(signers::putIfAbsent);
 
-    signerMap.forEach(signers::putIfAbsent);
     identifiers = Set.copyOf(signers.keySet());
 
-    LOG.info("Total signers (keys) loaded in memory {}", signers.size());
+    LOG.info("Total signers (keys) currently loaded in memory: {}", signers.size());
   }
 
   @Override

--- a/core/src/main/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProvider.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -37,11 +36,13 @@ public class DefaultArtifactSignerProvider implements ArtifactSignerProvider {
   private final Supplier<Collection<ArtifactSigner>> artifactSignerCollectionSupplier;
   private final Map<String, ArtifactSigner> signers = new HashMap<>();
   private Set<String> identifiers = Collections.emptySet();
-  private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+  private final ExecutorService executorService;
 
   public DefaultArtifactSignerProvider(
-      final Supplier<Collection<ArtifactSigner>> artifactSignerCollectionSupplier) {
+      final Supplier<Collection<ArtifactSigner>> artifactSignerCollectionSupplier,
+      final ExecutorService executorService) {
     this.artifactSignerCollectionSupplier = artifactSignerCollectionSupplier;
+    this.executorService = executorService;
   }
 
   @Override

--- a/core/src/main/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProvider.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -43,12 +42,6 @@ public class DefaultArtifactSignerProvider implements ArtifactSignerProvider {
   public DefaultArtifactSignerProvider(
       final Supplier<Collection<ArtifactSigner>> artifactSignerCollectionSupplier) {
     this.artifactSignerCollectionSupplier = artifactSignerCollectionSupplier;
-
-    try {
-      load().get();
-    } catch (InterruptedException | ExecutionException e) {
-      LOG.error("Error invoking load", e);
-    }
   }
 
   @Override

--- a/core/src/main/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProvider.java
@@ -16,6 +16,7 @@ import tech.pegasys.web3signer.core.signing.ArtifactSigner;
 import tech.pegasys.web3signer.core.signing.ArtifactSignerProvider;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -31,7 +32,8 @@ public class DefaultArtifactSignerProvider implements ArtifactSignerProvider {
 
   private static final Logger LOG = LogManager.getLogger();
   private final Supplier<Collection<ArtifactSigner>> artifactSignerCollectionSupplier;
-  private Map<String, ArtifactSigner> signers = new HashMap<>();
+  private final Map<String, ArtifactSigner> signers = new HashMap<>();
+  private Set<String> identifiers = Collections.emptySet();
 
   public DefaultArtifactSignerProvider(
       final Supplier<Collection<ArtifactSigner>> artifactSignerCollectionSupplier) {
@@ -44,7 +46,7 @@ public class DefaultArtifactSignerProvider implements ArtifactSignerProvider {
   public void reload() {
     LOG.trace("Reloading Artifact Signers");
 
-    signers =
+    final Map<String, ArtifactSigner> signerMap =
         artifactSignerCollectionSupplier
             .get()
             .parallelStream()
@@ -57,6 +59,9 @@ public class DefaultArtifactSignerProvider implements ArtifactSignerProvider {
                           "Duplicate keys were found while loading. {}", signer1.getIdentifier());
                       return signer1;
                     }));
+
+    signers.putAll(signerMap);
+    identifiers = Set.copyOf(signers.keySet());
 
     LOG.info("Total signers (keys) loaded in memory {}", signers.size());
   }
@@ -73,6 +78,6 @@ public class DefaultArtifactSignerProvider implements ArtifactSignerProvider {
 
   @Override
   public Set<String> availableIdentifiers() {
-    return signers.keySet();
+    return identifiers;
   }
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProvider.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -36,13 +37,11 @@ public class DefaultArtifactSignerProvider implements ArtifactSignerProvider {
   private final Supplier<Collection<ArtifactSigner>> artifactSignerCollectionSupplier;
   private final Map<String, ArtifactSigner> signers = new HashMap<>();
   private Set<String> identifiers = Collections.emptySet();
-  private final ExecutorService executorService;
+  private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
   public DefaultArtifactSignerProvider(
-      final Supplier<Collection<ArtifactSigner>> artifactSignerCollectionSupplier,
-      final ExecutorService executorService) {
+      final Supplier<Collection<ArtifactSigner>> artifactSignerCollectionSupplier) {
     this.artifactSignerCollectionSupplier = artifactSignerCollectionSupplier;
-    this.executorService = executorService;
   }
 
   @Override
@@ -83,5 +82,10 @@ public class DefaultArtifactSignerProvider implements ArtifactSignerProvider {
   @Override
   public Set<String> availableIdentifiers() {
     return identifiers;
+  }
+
+  @Override
+  public void close() {
+    executorService.shutdownNow();
   }
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProvider.java
@@ -60,7 +60,7 @@ public class DefaultArtifactSignerProvider implements ArtifactSignerProvider {
                       return signer1;
                     }));
 
-    signers.putAll(signerMap);
+    signerMap.forEach(signers::putIfAbsent);
     identifiers = Set.copyOf(signers.keySet());
 
     LOG.info("Total signers (keys) loaded in memory {}", signers.size());

--- a/core/src/main/java/tech/pegasys/web3signer/core/multikey/metadata/parser/SignerParser.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/multikey/metadata/parser/SignerParser.java
@@ -15,10 +15,9 @@ package tech.pegasys.web3signer.core.multikey.metadata.parser;
 import tech.pegasys.web3signer.core.multikey.metadata.SigningMetadataException;
 import tech.pegasys.web3signer.core.signing.ArtifactSigner;
 
-import java.nio.file.Path;
 import java.util.List;
 
 public interface SignerParser {
 
-  List<ArtifactSigner> parse(Path file) throws SigningMetadataException;
+  List<ArtifactSigner> parse(String yamlMetadata) throws SigningMetadataException;
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/multikey/metadata/parser/SignerParser.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/multikey/metadata/parser/SignerParser.java
@@ -19,5 +19,5 @@ import java.util.List;
 
 public interface SignerParser {
 
-  List<ArtifactSigner> parse(String yamlMetadata) throws SigningMetadataException;
+  List<ArtifactSigner> parse(String fileContent) throws SigningMetadataException;
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/multikey/metadata/parser/YamlSignerParser.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/multikey/metadata/parser/YamlSignerParser.java
@@ -19,9 +19,7 @@ import tech.pegasys.web3signer.core.multikey.metadata.SigningMetadata;
 import tech.pegasys.web3signer.core.multikey.metadata.SigningMetadataException;
 import tech.pegasys.web3signer.core.signing.ArtifactSigner;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -45,10 +43,10 @@ public class YamlSignerParser implements SignerParser {
   }
 
   @Override
-  public List<ArtifactSigner> parse(final Path metadataPath) {
+  public List<ArtifactSigner> parse(final String yamlMetadata) {
     try {
       final SigningMetadata metaDataInfo =
-          OBJECT_MAPPER.readValue(metadataPath.toFile(), SigningMetadata.class);
+          OBJECT_MAPPER.readValue(yamlMetadata, SigningMetadata.class);
 
       return signerFactories.stream()
           .filter(factory -> factory.getKeyType() == metaDataInfo.getKeyType())
@@ -56,8 +54,6 @@ public class YamlSignerParser implements SignerParser {
           .collect(Collectors.toList());
     } catch (final JsonParseException | JsonMappingException e) {
       throw new SigningMetadataException("Invalid signing metadata file format", e);
-    } catch (final FileNotFoundException e) {
-      throw new SigningMetadataException("File not found", e);
     } catch (final IOException e) {
       throw new SigningMetadataException(
           "Unexpected IO error while reading signing metadata file", e);

--- a/core/src/main/java/tech/pegasys/web3signer/core/multikey/metadata/parser/YamlSignerParser.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/multikey/metadata/parser/YamlSignerParser.java
@@ -43,10 +43,10 @@ public class YamlSignerParser implements SignerParser {
   }
 
   @Override
-  public List<ArtifactSigner> parse(final String yamlMetadata) {
+  public List<ArtifactSigner> parse(final String fileContent) {
     try {
       final SigningMetadata metaDataInfo =
-          OBJECT_MAPPER.readValue(yamlMetadata, SigningMetadata.class);
+          OBJECT_MAPPER.readValue(fileContent, SigningMetadata.class);
 
       return signerFactories.stream()
           .filter(factory -> factory.getKeyType() == metaDataInfo.getKeyType())

--- a/core/src/main/java/tech/pegasys/web3signer/core/signing/ArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/signing/ArtifactSignerProvider.java
@@ -14,12 +14,11 @@ package tech.pegasys.web3signer.core.signing;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Future;
 
 public interface ArtifactSignerProvider {
 
-  void load();
-
-  void asyncLoad();
+  Future<Void> load();
 
   Optional<ArtifactSigner> getSigner(final String identifier);
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/signing/ArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/signing/ArtifactSignerProvider.java
@@ -17,7 +17,9 @@ import java.util.Set;
 
 public interface ArtifactSignerProvider {
 
-  void reload();
+  void load();
+
+  void asyncLoad();
 
   Optional<ArtifactSigner> getSigner(final String identifier);
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/signing/ArtifactSignerProvider.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/signing/ArtifactSignerProvider.java
@@ -12,15 +12,19 @@
  */
 package tech.pegasys.web3signer.core.signing;
 
+import java.io.Closeable;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Future;
 
-public interface ArtifactSignerProvider {
+public interface ArtifactSignerProvider extends Closeable {
 
   Future<Void> load();
 
   Optional<ArtifactSigner> getSigner(final String identifier);
 
   Set<String> availableIdentifiers();
+
+  @Override
+  void close();
 }

--- a/core/src/main/resources/openapi/web3signer-eth1.yaml
+++ b/core/src/main/resources/openapi/web3signer-eth1.yaml
@@ -82,12 +82,12 @@ paths:
     post:
       tags:
         - 'Reload Signer Keys'
-      summary: 'Reload signer keys'
-      description: 'Reload signer keys'
+      summary: 'Reload signer keys asynchronously'
+      description: 'Reload signer keys asynchronously'
       operationId: 'RELOAD'
       responses:
         '200':
-          description: 'Reload successful'
+          description: 'Call is successful'
         '500':
           description: 'Internal Web3Signer server error'
 

--- a/core/src/main/resources/openapi/web3signer-eth2.yaml
+++ b/core/src/main/resources/openapi/web3signer-eth2.yaml
@@ -94,12 +94,12 @@ paths:
     post:
       tags:
         - 'Reload Signer Keys'
-      summary: 'Reload signer keys'
-      description: 'Reload signer keys'
+      summary: 'Reload signer keys asynchronously'
+      description: 'Reload signer keys asynchronously'
       operationId: 'RELOAD'
       responses:
         '200':
-          description: 'Reload successful'
+          description: 'Call is successful'
         '500':
           description: 'Internal Web3Signer server error'
 

--- a/core/src/main/resources/openapi/web3signer-filecoin.yaml
+++ b/core/src/main/resources/openapi/web3signer-filecoin.yaml
@@ -16,12 +16,12 @@ paths:
     post:
       tags:
         - 'Reload Signer Keys'
-      summary: 'Reload signer keys'
-      description: 'Reload signer keys'
+      summary: 'Reload signer keys asynchronously'
+      description: 'Reload signer keys asynchronously'
       operationId: 'RELOAD'
       responses:
         '200':
-          description: 'Reload successful'
+          description: 'Call is successful'
         '500':
           description: 'Internal Web3Signer server error'
   /upcheck:

--- a/core/src/test/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProviderTest.java
@@ -22,10 +22,8 @@ import tech.pegasys.web3signer.core.signing.ArtifactSignerProvider;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class DefaultArtifactSignerProviderTest {
@@ -34,11 +32,14 @@ class DefaultArtifactSignerProviderTest {
       "989d34725a2bfc3f15105f3f5fc8741f436c25ee1ee4f948e425d6bcb8c56bce6e06c269635b7e985a7ffa639e2409bf";
   private static final String PUBLIC_KEY2 =
       "a99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c";
-  private static final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
-  @AfterAll
-  static void cleanup() {
-    executorService.shutdownNow();
+  private ArtifactSignerProvider signerProvider;
+
+  @AfterEach
+  void cleanup() {
+    if (signerProvider != null) {
+      signerProvider.close();
+    }
   }
 
   @Test
@@ -46,8 +47,7 @@ class DefaultArtifactSignerProviderTest {
     final ArtifactSigner mockSigner = mock(ArtifactSigner.class);
     when(mockSigner.getIdentifier()).thenReturn(PUBLIC_KEY1);
 
-    final ArtifactSignerProvider signerProvider =
-        new DefaultArtifactSignerProvider(() -> List.of(mockSigner), executorService);
+    signerProvider = new DefaultArtifactSignerProvider(() -> List.of(mockSigner));
     assertThatCode(() -> signerProvider.load().get()).doesNotThrowAnyException();
 
     final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY1);
@@ -62,8 +62,7 @@ class DefaultArtifactSignerProviderTest {
     final ArtifactSigner mockSigner2 = mock(ArtifactSigner.class);
     when(mockSigner2.getIdentifier()).thenReturn(PUBLIC_KEY1);
 
-    final ArtifactSignerProvider signerProvider =
-        new DefaultArtifactSignerProvider(() -> List.of(mockSigner1, mockSigner2), executorService);
+    signerProvider = new DefaultArtifactSignerProvider(() -> List.of(mockSigner1, mockSigner2));
     assertThatCode(() -> signerProvider.load().get()).doesNotThrowAnyException();
 
     assertThat(signerProvider.availableIdentifiers()).hasSize(1);
@@ -77,8 +76,7 @@ class DefaultArtifactSignerProviderTest {
     final ArtifactSigner mockSigner2 = mock(ArtifactSigner.class);
     when(mockSigner2.getIdentifier()).thenReturn(PUBLIC_KEY2);
 
-    final ArtifactSignerProvider signerProvider =
-        new DefaultArtifactSignerProvider(() -> List.of(mockSigner1, mockSigner2), executorService);
+    signerProvider = new DefaultArtifactSignerProvider(() -> List.of(mockSigner1, mockSigner2));
     assertThatCode(() -> signerProvider.load().get()).doesNotThrowAnyException();
     assertThat(signerProvider.availableIdentifiers()).hasSize(2);
     assertThat(signerProvider.availableIdentifiers()).containsOnly(PUBLIC_KEY1, PUBLIC_KEY2);

--- a/core/src/test/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProviderTest.java
@@ -13,6 +13,7 @@
 package tech.pegasys.web3signer.core.multikey;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,6 +39,7 @@ class DefaultArtifactSignerProviderTest {
 
     final ArtifactSignerProvider signerProvider =
         new DefaultArtifactSignerProvider(() -> List.of(mockSigner));
+    assertThatCode(() -> signerProvider.load().get()).doesNotThrowAnyException();
 
     final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY1);
     assertThat(signer).isNotEmpty();
@@ -53,6 +55,7 @@ class DefaultArtifactSignerProviderTest {
 
     final ArtifactSignerProvider signerProvider =
         new DefaultArtifactSignerProvider(() -> List.of(mockSigner1, mockSigner2));
+    assertThatCode(() -> signerProvider.load().get()).doesNotThrowAnyException();
 
     assertThat(signerProvider.availableIdentifiers()).hasSize(1);
     assertThat(signerProvider.availableIdentifiers()).containsOnly(PUBLIC_KEY1);
@@ -67,7 +70,7 @@ class DefaultArtifactSignerProviderTest {
 
     final ArtifactSignerProvider signerProvider =
         new DefaultArtifactSignerProvider(() -> List.of(mockSigner1, mockSigner2));
-
+    assertThatCode(() -> signerProvider.load().get()).doesNotThrowAnyException();
     assertThat(signerProvider.availableIdentifiers()).hasSize(2);
     assertThat(signerProvider.availableIdentifiers()).containsOnly(PUBLIC_KEY1, PUBLIC_KEY2);
   }

--- a/core/src/test/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProviderTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/multikey/DefaultArtifactSignerProviderTest.java
@@ -22,7 +22,10 @@ import tech.pegasys.web3signer.core.signing.ArtifactSignerProvider;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 class DefaultArtifactSignerProviderTest {
@@ -31,6 +34,12 @@ class DefaultArtifactSignerProviderTest {
       "989d34725a2bfc3f15105f3f5fc8741f436c25ee1ee4f948e425d6bcb8c56bce6e06c269635b7e985a7ffa639e2409bf";
   private static final String PUBLIC_KEY2 =
       "a99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c";
+  private static final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+  @AfterAll
+  static void cleanup() {
+    executorService.shutdownNow();
+  }
 
   @Test
   void signerReturnedForMatchingIdentifer() {
@@ -38,7 +47,7 @@ class DefaultArtifactSignerProviderTest {
     when(mockSigner.getIdentifier()).thenReturn(PUBLIC_KEY1);
 
     final ArtifactSignerProvider signerProvider =
-        new DefaultArtifactSignerProvider(() -> List.of(mockSigner));
+        new DefaultArtifactSignerProvider(() -> List.of(mockSigner), executorService);
     assertThatCode(() -> signerProvider.load().get()).doesNotThrowAnyException();
 
     final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY1);
@@ -54,7 +63,7 @@ class DefaultArtifactSignerProviderTest {
     when(mockSigner2.getIdentifier()).thenReturn(PUBLIC_KEY1);
 
     final ArtifactSignerProvider signerProvider =
-        new DefaultArtifactSignerProvider(() -> List.of(mockSigner1, mockSigner2));
+        new DefaultArtifactSignerProvider(() -> List.of(mockSigner1, mockSigner2), executorService);
     assertThatCode(() -> signerProvider.load().get()).doesNotThrowAnyException();
 
     assertThat(signerProvider.availableIdentifiers()).hasSize(1);
@@ -69,7 +78,7 @@ class DefaultArtifactSignerProviderTest {
     when(mockSigner2.getIdentifier()).thenReturn(PUBLIC_KEY2);
 
     final ArtifactSignerProvider signerProvider =
-        new DefaultArtifactSignerProvider(() -> List.of(mockSigner1, mockSigner2));
+        new DefaultArtifactSignerProvider(() -> List.of(mockSigner1, mockSigner2), executorService);
     assertThatCode(() -> signerProvider.load().get()).doesNotThrowAnyException();
     assertThat(signerProvider.availableIdentifiers()).hasSize(2);
     assertThat(signerProvider.availableIdentifiers()).containsOnly(PUBLIC_KEY1, PUBLIC_KEY2);

--- a/core/src/test/java/tech/pegasys/web3signer/core/multikey/SignerLoaderTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/multikey/SignerLoaderTest.java
@@ -131,7 +131,6 @@ class SignerLoaderTest {
   @Test
   void failedParserReturnsEmptySigner() throws IOException {
     createFileInConfigsDirectory(PUBLIC_KEY1 + "." + FILE_EXTENSION, "NOT_A_VALID_KEY");
-    // when(signerParser.parse(any())).thenThrow(SigningMetadataException.class);
 
     final List<ArtifactSigner> signerList =
         Lists.newArrayList(SignerLoader.load(configsDirectory, FILE_EXTENSION, signerParser));

--- a/core/src/test/java/tech/pegasys/web3signer/core/multikey/SignerLoaderTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/multikey/SignerLoaderTest.java
@@ -103,7 +103,6 @@ class SignerLoaderTest {
   }
 
   @Test
-  // @SuppressWarnings("ResultOfMethodCallIgnored")
   void signerReturnedWhenFileExtensionIsUpperCase() throws IOException {
     final String filename = PUBLIC_KEY1 + ".YAML";
     final Path metadataFile = createFileInConfigsDirectory(filename, PRIVATE_KEY1);

--- a/core/src/test/java/tech/pegasys/web3signer/core/multikey/metadata/parser/YamlSignerParserTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/multikey/metadata/parser/YamlSignerParserTest.java
@@ -162,7 +162,6 @@ class YamlSignerParserTest {
 
   @Test
   void keyStoreMetaDataInfoWithMissingKeystoreFilesFails() throws IOException {
-    // final Path filename = configDir.resolve("keystore." + YAML_FILE_EXTENSION);
     final Path passwordFile = configDir.resolve("keystore.password");
 
     final Map<String, String> keystoreMetadataFile = new HashMap<>();
@@ -177,7 +176,6 @@ class YamlSignerParserTest {
 
   @Test
   void keyStoreMetaDataInfoWithMissingPasswordFilesFails() throws IOException {
-    // final Path filename = configDir.resolve("keystore." + YAML_FILE_EXTENSION);
     final Path keystoreFile = configDir.resolve("keystore.json");
 
     final Map<String, String> keystoreMetadataFile = new HashMap<>();
@@ -198,7 +196,6 @@ class YamlSignerParserTest {
     when(blsArtifactSignerFactory.create(any(FileKeyStoreMetadata.class)))
         .thenReturn(artifactSigner);
 
-    // final Path filename = configDir.resolve("keystore." + YAML_FILE_EXTENSION);
     final Path keystoreFile = configDir.resolve("keystore.json");
     final Path passwordFile = configDir.resolve("keystore.password");
 
@@ -216,7 +213,6 @@ class YamlSignerParserTest {
   @Test
   void aSignerIsCreatedForEachMatchingFactory() throws IOException {
     lenient().when(otherBlsArtifactSignerFactory.getKeyType()).thenReturn(KeyType.BLS);
-    // final Path filename = configDir.resolve("bls_unencrypted." + YAML_FILE_EXTENSION);
     final Map<String, String> unencryptedKeyMetadataFile = new HashMap<>();
     unencryptedKeyMetadataFile.put("type", "file-raw");
     unencryptedKeyMetadataFile.put("privateKey", "0x" + PRIVATE_KEY);
@@ -274,8 +270,6 @@ class YamlSignerParserTest {
     when(blsArtifactSignerFactory.create(any(AzureSecretSigningMetadata.class)))
         .thenReturn(artifactSigner);
 
-    // final Path filename = configDir.resolve("azure." + YAML_FILE_EXTENSION);
-
     final Map<String, String> azureMetaDataMap = new HashMap<>();
     azureMetaDataMap.put("type", "azure-secret");
     azureMetaDataMap.put("clientId", "sample-client-id");
@@ -300,8 +294,6 @@ class YamlSignerParserTest {
     when(blsArtifactSignerFactory.create(any(AzureSecretSigningMetadata.class)))
         .thenReturn(artifactSigner);
 
-    // final Path filename = configDir.resolve("azure." + YAML_FILE_EXTENSION);
-
     final Map<String, String> azureMetaDataMap = new HashMap<>();
     azureMetaDataMap.put("type", "azure-secret");
     azureMetaDataMap.put("vaultName", "sample-vault-name");
@@ -318,8 +310,6 @@ class YamlSignerParserTest {
 
   @Test
   void validationFailsForInvalidAzureAuthenticationMode() throws IOException {
-    // final Path filename = configDir.resolve("azure." + YAML_FILE_EXTENSION);
-
     final Map<String, String> azureMetaDataMap = new HashMap<>();
     azureMetaDataMap.put("type", "azure-secret");
     azureMetaDataMap.put("clientId", "sample-client-id");
@@ -338,8 +328,6 @@ class YamlSignerParserTest {
 
   @Test
   void validationFailsForMissingRequiredOptionsForClientSecretMode() throws IOException {
-    // final Path filename = configDir.resolve("azure." + YAML_FILE_EXTENSION);
-
     final Map<String, String> azureMetaDataMap = new HashMap<>();
     azureMetaDataMap.put("type", "azure-secret");
     azureMetaDataMap.put("vaultName", "sample-vault-name");


### PR DESCRIPTION
 -- allows reloading of signers (keys) to not consume excessive CPU while unnecessary locking of map

Signed-off-by: Usman Saleem <usman@usmans.info>