### PR TITLE
Add unique constraints on attestations and blocks being inserted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Upgraded gradle and various plugin versions. Switched to new dependency license reporting plugin. Project can now be compiled against JDK 16.
 - Introduced --network cli option for Eth2 mode. Defaults to mainnet. Should match the option used by Teku at runtime.
 - Upgraded Teku libraries.
+- Eth2 slashing protection now has an additional safeguard that prevents multiple signed blocks or attestations being inserted using database constraints.
 
 ## 21.3.0
 

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeImportConflictsIntegrationTestBase.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeImportConflictsIntegrationTestBase.java
@@ -46,12 +46,12 @@ public class InterchangeImportConflictsIntegrationTestBase extends IntegrationTe
   }
 
   @Test
-  void canLoadConflictingBlocksInSameSlot() throws IOException {
+  void conflictingBlocksInSameSlotAreNotInsertedToDatabase() throws IOException {
     final URL importFile = Resources.getResource("interchange/conflictingBlocks.json");
     slashingProtection.importData(importFile.openStream());
 
     final List<SignedBlock> blocksInDb = findAllBlocks();
-    assertThat(blocksInDb).hasSize(2);
+    assertThat(blocksInDb).hasSize(1);
     assertThat(blocksInDb.get(0).getSlot()).isEqualTo(UInt64.valueOf(12345));
     assertThat(blocksInDb.get(0).getValidatorId()).isEqualTo(1);
     assertThat(blocksInDb.get(0).getSigningRoot())
@@ -59,14 +59,6 @@ public class InterchangeImportConflictsIntegrationTestBase extends IntegrationTe
             Optional.of(
                 Bytes.fromHexString(
                     "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b")));
-
-    assertThat(blocksInDb.get(1).getSlot()).isEqualTo(UInt64.valueOf(12345));
-    assertThat(blocksInDb.get(1).getValidatorId()).isEqualTo(1);
-    assertThat(blocksInDb.get(1).getSigningRoot())
-        .isEqualTo(
-            Optional.of(
-                Bytes.fromHexString(
-                    "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850c")));
   }
 
   @Test

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionFactory.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionFactory.java
@@ -23,7 +23,7 @@ import org.jdbi.v3.core.Jdbi;
 
 public class SlashingProtectionFactory {
 
-  public static final int EXPECTED_DATABASE_VERSION = 7;
+  public static final int EXPECTED_DATABASE_VERSION = 8;
 
   public static SlashingProtection createSlashingProtection(
       final SlashingProtectionParameters slashingProtectionParameters) {

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/AttestationImporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/AttestationImporter.java
@@ -94,10 +94,9 @@ public class AttestationImporter {
           }
         } else {
           if (attestationValidator.directlyConflictsWithExistingEntry()) {
-            LOG.warn("{} - conflicts with an existing entry", attestationIdentifierString);
-          }
-
-          if (attestationValidator.alreadyExists()) {
+            LOG.warn(
+                "{} - conflicts with an existing entry, not imported", attestationIdentifierString);
+          } else if (attestationValidator.alreadyExists()) {
             LOG.debug("{} - already exists in database, not imported", attestationIdentifierString);
           } else {
             persist(jsonAttestation);

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/BlockImporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/BlockImporter.java
@@ -77,10 +77,8 @@ public class BlockImporter {
         }
       } else {
         if (blockValidator.directlyConflictsWithExistingEntry()) {
-          LOG.warn("{} - conflicts with an existing entry", blockIdentifierString);
-        }
-
-        if (blockValidator.alreadyExists()) {
+          LOG.warn("{} - conflicts with an existing entry, not imported", blockIdentifierString);
+        } else if (blockValidator.alreadyExists()) {
           LOG.debug("{} - already exists in database, not imported", blockIdentifierString);
         } else {
           persist(jsonBlock);

--- a/slashing-protection/src/main/resources/migrations/postgresql/V8__signed_data_unique_constraints.sql
+++ b/slashing-protection/src/main/resources/migrations/postgresql/V8__signed_data_unique_constraints.sql
@@ -1,0 +1,9 @@
+ALTER TABLE signed_blocks
+ADD CONSTRAINT unique_signed_block
+UNIQUE (validator_id, slot);
+
+ALTER TABLE signed_attestations
+ADD CONSTRAINT unique_signed_attestation
+UNIQUE (validator_id, target_epoch);
+
+UPDATE database_version SET version = 8 WHERE id = 1;

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/DatabaseVersionDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/DatabaseVersionDaoTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import tech.pegasys.web3signer.slashingprotection.DbConnection;
+import tech.pegasys.web3signer.slashingprotection.SlashingProtectionFactory;
 
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.testing.JdbiRule;
@@ -49,7 +50,7 @@ public class DatabaseVersionDaoTest {
   @Test
   public void migratedDatabaseReturnsValue() {
     final int version = databaseVersionDao.findDatabaseVersion(handle);
-    assertThat(version).isEqualTo(7);
+    assertThat(version).isEqualTo(SlashingProtectionFactory.EXPECTED_DATABASE_VERSION);
   }
 
   @Test

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDaoTest.java
@@ -194,8 +194,6 @@ public class SignedAttestationsDaoTest {
   @Test
   public void findAttestationsNotMatchingSigningRootThrowsIfNullRequested() {
     insertValidator(Bytes.of(100), 1);
-    insertAttestation(1, Bytes.of(10), UInt64.valueOf(2), UInt64.valueOf(3));
-    insertAttestation(1, Bytes.of(11), UInt64.valueOf(2), UInt64.valueOf(3));
     insertAttestation(1, null, UInt64.valueOf(2), UInt64.valueOf(3));
     assertThatThrownBy(
             () ->

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
@@ -126,8 +126,6 @@ public class SignedBlocksDaoTest {
   @Test
   public void throwsIfMatchingAgainstNull() {
     insertValidator(Bytes.of(100), 1);
-    insertBlock(1, 3, Bytes.of(10));
-    insertBlock(1, 3, Bytes.of(11));
     insertBlock(1, 3, null);
 
     assertThatThrownBy(


### PR DESCRIPTION
Add unique constraints on database tables to ensure that conflicting blocks and attestations cannot be inserted into the slashing protection database.