### PR TITLE
Update docker base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Introduced --network cli option for Eth2 mode. Defaults to mainnet. Should match the option used by Teku at runtime.
 - Upgraded Teku libraries.
 - Eth2 slashing protection now has an additional safeguard that prevents multiple signed blocks or attestations being inserted using database constraints.
-- Use openjdk:11.0.11-jdk-oraclelinux8 as docker base image (recommended by docker image scanning tool Synk). 
+- Use adoptopenjdk/openjdk11:x86_64-ubuntu-jre-11.0.11_9 as docker base image. 
 
 ## 21.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Introduced --network cli option for Eth2 mode. Defaults to mainnet. Should match the option used by Teku at runtime.
 - Upgraded Teku libraries.
 - Eth2 slashing protection now has an additional safeguard that prevents multiple signed blocks or attestations being inserted using database constraints.
+- Use openjdk:11.0.11-jdk-oraclelinux8 as docker base image (recommended by docker image scanning tool Synk). 
 
 ## 21.3.0
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM openjdk:11-jre-slim-buster
+FROM openjdk:11.0.11-jdk-oraclelinux8
 
 COPY web3signer /opt/web3signer/
 WORKDIR /opt/web3signer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 
 FROM adoptopenjdk/openjdk11:x86_64-ubuntu-jre-11.0.11_9
 
-# RUN apt-get update && apt-get upgrade -y
 COPY web3signer /opt/web3signer/
 WORKDIR /opt/web3signer
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 
-FROM openjdk:11.0.11-jdk-oraclelinux8
+FROM adoptopenjdk/openjdk11:x86_64-ubuntu-jre-11.0.11_9
 
+# RUN apt-get update && apt-get upgrade -y
 COPY web3signer /opt/web3signer/
 WORKDIR /opt/web3signer
 


### PR DESCRIPTION
To get clear scan report.
~~~
❯ docker scan -f docker/Dockerfile consensys/web3signer:develop --severity high

Testing consensys/web3signer:develop...

Package manager:   deb
Target file:       docker/Dockerfile
Project name:      docker-image|consensys/web3signer
Docker image:      consensys/web3signer:develop
Platform:          linux/amd64
Base image:        adoptopenjdk/openjdk11:x86_64-ubuntu-jre-11.0.11_9

✓ Tested 132 dependencies for known vulnerabilities, no vulnerable paths found.
~~~