### PR TITLE
Enable access log handler

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
@@ -88,6 +88,8 @@ public class CmdLineParamsConfigFileImpl implements CmdLineParamsBuilder {
       yamlConfig.append(String.format(YAML_BOOLEAN_FMT, "swagger-ui-enabled", Boolean.TRUE));
     }
 
+    yamlConfig.append(String.format(YAML_BOOLEAN_FMT, "access-logs-enabled", Boolean.TRUE));
+
     if (signerConfig.isHttpDynamicPortAllocation()) {
       yamlConfig.append(
           String.format(YAML_STRING_FMT, "data-path", dataPath.toAbsolutePath().toString()));

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
@@ -70,6 +70,8 @@ public class CmdLineParamsDefaultImpl implements CmdLineParamsBuilder {
       params.add("--swagger-ui-enabled=true");
     }
 
+    params.add("--access-logs-enabled=true");
+
     if (signerConfig.isHttpDynamicPortAllocation()) {
       params.add("--data-path");
       params.add(dataPath.toAbsolutePath().toString());

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
@@ -168,6 +168,11 @@ public class Web3SignerBaseCommand implements Config, Runnable {
       description = "Enable swagger UI (default: ${DEFAULT-VALUE})")
   private final Boolean swaggerUiEnabled = false;
 
+  @Option(
+      names = {"--access-logs-enabled"},
+      description = "Enable access logs (default: ${DEFAULT-VALUE})")
+  private final Boolean accessLogsEnabled = false;
+
   @CommandLine.Mixin private PicoCliTlsServerOptions picoCliTlsServerOptions;
 
   @Override
@@ -242,6 +247,11 @@ public class Web3SignerBaseCommand implements Config, Runnable {
   @Override
   public Boolean isSwaggerUIEnabled() {
     return swaggerUiEnabled;
+  }
+
+  @Override
+  public Boolean isAccessLogsEnabled() {
+    return accessLogsEnabled;
   }
 
   @Override

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -53,6 +53,8 @@ import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.net.PfxOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
+import io.vertx.ext.web.handler.LoggerFormat;
+import io.vertx.ext.web.handler.LoggerHandler;
 import io.vertx.ext.web.handler.ResponseContentTypeHandler;
 import io.vertx.ext.web.impl.BlockingHandlerDecorator;
 import org.apache.logging.log4j.LogManager;
@@ -112,6 +114,10 @@ public abstract class Runner implements Runnable {
       incSignerLoadCount(metricsSystem, artifactSignerProvider.availableIdentifiers().size());
 
       final OpenAPI3RouterFactory routerFactory = getOpenAPI3RouterFactory(vertx);
+      // register access log handler first
+      if (config.isAccessLogsEnabled()) {
+        routerFactory.addGlobalHandler(LoggerHandler.create(LoggerFormat.DEFAULT));
+      }
       registerUpcheckRoute(routerFactory, errorHandler);
       registerHttpHostAllowListHandler(routerFactory);
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/Config.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/Config.java
@@ -51,4 +51,6 @@ public interface Config {
   void validateArgs();
 
   Boolean isSwaggerUIEnabled();
+
+  Boolean isAccessLogsEnabled();
 }


### PR DESCRIPTION
Introduce `--access-logs-enabled` cli option that enables access logs directed to logger output.

~~~
June 18, 2021 3:46:12 PM io.vertx.ext.web.handler.impl.LoggerHandlerImpl | INFO: 127.0.0.1 - - [Fri, 18 Jun 2021 05:46:12 GMT] "GET /upcheck HTTP/1.1" 200 2 "-" "Apache-HttpClient/4.5.3 (Java/11.0.5)"
~~~