### PR TITLE
Upgrade Teku libraries to 21.8.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Next Release
+
+### Features Added
+- Upgraded Teku libraries to 21.8.1. Added support for Altair upgrade on the Pyrmont testnet at epoch 61650.
+
 ## 21.7.0
 
 ### Breaking changes

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -75,7 +75,7 @@ dependencyManagement {
     dependency 'org.hyperledger.besu:plugin-api:21.1.3'
     dependency 'org.hyperledger.besu.internal:metrics-core:21.1.3'
 
-    dependencySet(group: 'tech.pegasys.teku.internal', version: '21.7.0') {
+    dependencySet(group: 'tech.pegasys.teku.internal', version: '21.8.1') {
       entry 'bls'
       entry ('core') {
         exclude 'teku:data' // empty module which is incorrectly referenced in Teku's "core" pom


### PR DESCRIPTION
-- Upgrade Teku libraries to 21.8.1. Added support for Altair upgrade on the Pyrmont testnet at epoch 61650.
