### PR TITLE
Upgrade signers to 1.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next Version
+### Breaking Changes
+- Upgrade to signers 1.0.18 removes support for deprecated SECP256K1 curve.
+
 ## 21.8.1
 
 ### Features Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
 ## Next Version
+
+### Features Added
+- Upgrade to signers 1.0.19 allows empty password files to be read when creating a Signer.
+
 ### Breaking Changes
-- Upgrade to signers 1.0.18 removes support for deprecated SECP256K1 curve.
+- Upgrade to signers 1.0.19 removes support for deprecated SECP256K1 curve in Azure remote signing.
 
 ## 21.8.1
 

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/MetadataFileHelpers.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/MetadataFileHelpers.java
@@ -170,7 +170,7 @@ public class MetadataFileHelpers {
       final Map<String, String> signingMetadata = new HashMap<>();
       signingMetadata.put("type", "azure-key");
       signingMetadata.put("vaultName", keyVaultName);
-      signingMetadata.put("keyName", "TestKey");
+      signingMetadata.put("keyName", "TestKey2");
       signingMetadata.put("clientId", clientId);
       signingMetadata.put("clientSecret", clientSecret);
       signingMetadata.put("tenantId", tenantId);

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/publickeys/KeyIdentifiersAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/publickeys/KeyIdentifiersAcceptanceTest.java
@@ -146,7 +146,7 @@ public class KeyIdentifiersAcceptanceTest extends KeyIdentifiersAcceptanceTestBa
     final String keyVaultName = System.getenv("AZURE_KEY_VAULT_NAME");
     final String tenantId = System.getenv("AZURE_TENANT_ID");
     final String PUBLIC_KEY_HEX_STRING =
-        "09b02f8a5fddd222ade4ea4528faefc399623af3f736be3c44f03e2df22fb792f3931a4d9573d333ca74343305762a753388c3422a86d98b713fc91c1ea04842";
+        "964f00253459f1f43c7a7720a0db09a328d4ee6f18838015023135d7fc921f1448de34d05de7a1f72a7b5c9f6c76931d7ab33d0f0846ccce5452063bd20f5809";
 
     metadataFileHelpers.createAzureKeyYamlFileAt(
         testDirectory.resolve(PUBLIC_KEY_HEX_STRING + ".yaml"),

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/SecpSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/SecpSigningAcceptanceTest.java
@@ -15,10 +15,10 @@ package tech.pegasys.web3signer.tests.signing;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.web3j.crypto.Sign.publicKeyFromPrivate;
 import static org.web3j.crypto.Sign.signedMessageToKey;
 
 import tech.pegasys.signers.hashicorp.dsl.HashicorpNode;
+import tech.pegasys.signers.secp256k1.EthPublicKeyUtils;
 import tech.pegasys.web3signer.core.signing.KeyType;
 import tech.pegasys.web3signer.dsl.HashicorpSigningParams;
 import tech.pegasys.web3signer.dsl.utils.MetadataFileHelpers;
@@ -28,6 +28,7 @@ import java.math.BigInteger;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.security.SignatureException;
+import java.security.interfaces.ECPublicKey;
 
 import com.google.common.io.Resources;
 import io.restassured.response.Response;
@@ -50,27 +51,10 @@ public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
       "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63";
   public static final String PUBLIC_KEY_HEX_STRING =
       "09b02f8a5fddd222ade4ea4528faefc399623af3f736be3c44f03e2df22fb792f3931a4d9573d333ca74343305762a753388c3422a86d98b713fc91c1ea04842";
+  public static final String AZURE_PUBLIC_KEY_HEX_STRING =
+      "964f00253459f1f43c7a7720a0db09a328d4ee6f18838015023135d7fc921f1448de34d05de7a1f72a7b5c9f6c76931d7ab33d0f0846ccce5452063bd20f5809";
 
   private final MetadataFileHelpers metadataFileHelpers = new MetadataFileHelpers();
-
-  @Test
-  @EnabledIfEnvironmentVariables({
-    @EnabledIfEnvironmentVariable(named = "AZURE_CLIENT_ID", matches = ".*"),
-    @EnabledIfEnvironmentVariable(named = "AZURE_CLIENT_SECRET", matches = ".*"),
-    @EnabledIfEnvironmentVariable(named = "AZURE_KEY_VAULT_NAME", matches = ".*"),
-    @EnabledIfEnvironmentVariable(named = "AZURE_KEY_TENANT_ID", matches = ".*")
-  })
-  public void signDataWithKeyInAzure(@TempDir Path keyConfigDirectory) {
-
-    metadataFileHelpers.createAzureKeyYamlFileAt(
-        keyConfigDirectory.resolve(PUBLIC_KEY_HEX_STRING + ".yaml"),
-        clientId,
-        clientSecret,
-        keyVaultName,
-        tenantId);
-
-    signAndVerifySignature();
-  }
 
   @Test
   public void signDataWithFileBasedKey(@TempDir Path keyConfigDirectory) throws URISyntaxException {
@@ -113,35 +97,39 @@ public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
     @EnabledIfEnvironmentVariable(named = "AZURE_KEY_VAULT_NAME", matches = ".*"),
     @EnabledIfEnvironmentVariable(named = "AZURE_TENANT_ID", matches = ".*")
   })
-  public void signDatWithKeyFromAzure(@TempDir Path keyConfigDirectory) {
+  public void signDataWithKeyInAzure(@TempDir Path keyConfigDirectory) {
     metadataFileHelpers.createAzureKeyYamlFileAt(
-        keyConfigDirectory.resolve(PUBLIC_KEY_HEX_STRING + ".yaml"),
+        keyConfigDirectory.resolve(AZURE_PUBLIC_KEY_HEX_STRING + ".yaml"),
         clientId,
         clientSecret,
         keyVaultName,
         tenantId);
 
-    signAndVerifySignature();
+    signAndVerifySignature(AZURE_PUBLIC_KEY_HEX_STRING);
   }
 
   private void signAndVerifySignature() {
+    signAndVerifySignature(PUBLIC_KEY_HEX_STRING);
+  }
+
+  private void signAndVerifySignature(String publicKeyHex) {
     setupEth1Signer();
 
     // openapi
-    final Response response = signer.eth1Sign(PUBLIC_KEY_HEX_STRING, DATA);
+    final Response response = signer.eth1Sign(publicKeyHex, DATA);
     final Bytes signature = verifyAndGetSignatureResponse(response);
-    verifySignature(signature);
+    verifySignature(signature, publicKeyHex);
   }
 
-  void verifySignature(final Bytes signature) {
-    final BigInteger privateKey = new BigInteger(1, Bytes.fromHexString(PRIVATE_KEY).toArray());
-    final BigInteger expectedPublicKey = publicKeyFromPrivate(privateKey);
+  void verifySignature(final Bytes signature, final String publicKeyHex) {
+    ECPublicKey expectedPublicKey =
+        EthPublicKeyUtils.createPublicKey(Bytes.fromHexString(publicKeyHex));
 
     final byte[] r = signature.slice(0, 32).toArray();
     final byte[] s = signature.slice(32, 32).toArray();
     final byte[] v = signature.slice(64).toArray();
     final BigInteger messagePublicKey = recoverPublicKey(new SignatureData(v, r, s));
-    assertThat(messagePublicKey).isEqualTo(expectedPublicKey);
+    assertThat(EthPublicKeyUtils.createPublicKey(messagePublicKey)).isEqualTo(expectedPublicKey);
   }
 
   private BigInteger recoverPublicKey(final SignatureData signature) {

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/SecpSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/SecpSigningAcceptanceTest.java
@@ -122,7 +122,7 @@ public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
   }
 
   void verifySignature(final Bytes signature, final String publicKeyHex) {
-    ECPublicKey expectedPublicKey =
+    final ECPublicKey expectedPublicKey =
         EthPublicKeyUtils.createPublicKey(Bytes.fromHexString(publicKeyHex));
 
     final byte[] r = signature.slice(0, 32).toArray();

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
     maven { url "https://artifacts.consensys.net/public/maven/maven/" }
   }
   dependencies {
-    classpath 'tech.pegasys.internal.license.reporter:license-reporter:1.0.0'
+    classpath 'tech.pegasys.internal.license.reporter:license-reporter:1.0.1'
   }
 }
 
@@ -238,6 +238,9 @@ task deploy() {}
 
 licenseReport {
   outputDir = "${buildDir}/reports/licenses"
+  excludes = [
+    'com.fasterxml.jackson:jackson-bom'
+  ]
   allowedLicensesFile = new File("${rootDir}/gradle/license-report-config/allowed-licenses.json")
   filters = [
     new LicenseBundleNormalizer(["bundlePath": new File("${rootDir}/gradle/license-report-config/license-normalizer.json"), "createDefaultTransformationRules": true])

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -88,7 +88,7 @@ dependencyManagement {
 
     dependency 'tech.pegasys:jblst:0.3.3-1'
 
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.18') {
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.19') {
       entry 'bls-keystore'
       entry 'keystorage-hashicorp'
       entry 'keystorage-azure'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -13,7 +13,7 @@
 
 dependencyManagement {
   dependencies {
-    dependency 'com.fasterxml.jackson.core:jackson-databind:2.11.2'
+    dependency 'com.fasterxml.jackson.core:jackson-databind:2.12.5'
     dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.2'
 
     dependencySet(group: 'com.google.errorprone', version: '2.7.1') {
@@ -31,7 +31,7 @@ dependencyManagement {
 
     dependency 'info.picocli:picocli:4.5.1'
 
-    dependencySet(group: 'io.vertx', version: '3.9.8') {
+    dependencySet(group: 'io.vertx', version: '3.9.9') {
       entry 'vertx-codegen'
       entry 'vertx-core'
       entry 'vertx-unit'
@@ -88,7 +88,7 @@ dependencyManagement {
 
     dependency 'tech.pegasys:jblst:0.3.3-1'
 
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.17') {
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.18') {
       entry 'bls-keystore'
       entry 'keystorage-hashicorp'
       entry 'keystorage-azure'
@@ -108,8 +108,8 @@ dependencyManagement {
 
     dependency 'org.miracl.milagro.amcl:milagro-crypto-java:0.4.0'
 
-    dependency 'com.azure:azure-security-keyvault-secrets:4.2.1'
-    dependency 'com.azure:azure-identity:1.0.9'
+    dependency 'com.azure:azure-security-keyvault-secrets:4.3.3'
+    dependency 'com.azure:azure-identity:1.3.6'
 
     dependency 'com.zaxxer:HikariCP:3.4.5'
     dependency 'org.postgresql:postgresql:42.2.20'


### PR DESCRIPTION
Includes vertx upgrade and azure key vault upgrade with breaking change to SECP256K1 curve.