### PR TITLE
update openjdk 11 -> 16

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM adoptopenjdk/openjdk11:x86_64-ubuntu-jre-11.0.11_9
+FROM adoptopenjdk/openjdk16:x86_64-ubuntu-jre-16.0.1_9
 
 COPY web3signer /opt/web3signer/
 WORKDIR /opt/web3signer


### PR DESCRIPTION
This should fix the issue when running the web3signer with tls enabled inside docker container ->

```
java.io.ioexception: integrity check failed: java.security.nosuchalgorithmexception: algorithm hmacpbesha256 not available
```