### PR TITLE
Upgrade gradle version to 7.3 support Java 17 compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ allprojects {
 
   version = rootProject.version
 
-  jacoco { toolVersion = '0.8.6' }
+  jacoco { toolVersion = '0.8.7' }
 
   task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Upgrade gradle version to 7.3 to support Java 17 compilation
- Update Jococo tool version to 0.8.7