### PR TITLE
Add command line flag to enable Key Manager API

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfiguration.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfiguration.java
@@ -56,6 +56,7 @@ public class SignerConfiguration {
   private final long slashingPruningInterval;
   private final Optional<Long> altairForkEpoch;
   private final Optional<String> network;
+  private final boolean keyManagerApiEnabled;
 
   public SignerConfiguration(
       final String hostname,
@@ -86,7 +87,8 @@ public class SignerConfiguration {
       final boolean useConfigFile,
       final Optional<Path> slashingDbPoolConfigurationFile,
       final Optional<Long> altairForkEpoch,
-      final Optional<String> network) {
+      final Optional<String> network,
+      final boolean keyManagerApiEnabled) {
     this.hostname = hostname;
     this.logLevel = logLevel;
     this.httpRpcPort = httpRpcPort;
@@ -116,6 +118,7 @@ public class SignerConfiguration {
     this.slashingProtectionDbPoolConfigurationFile = slashingDbPoolConfigurationFile;
     this.altairForkEpoch = altairForkEpoch;
     this.network = network;
+    this.keyManagerApiEnabled = keyManagerApiEnabled;
   }
 
   public String hostname() {
@@ -240,5 +243,9 @@ public class SignerConfiguration {
 
   public Optional<String> getNetwork() {
     return network;
+  }
+
+  public boolean isKeyManagerApiEnabled() {
+    return keyManagerApiEnabled;
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfigurationBuilder.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfigurationBuilder.java
@@ -58,6 +58,7 @@ public class SignerConfigurationBuilder {
   private long slashingPruningInterval = 1;
   private Long altairForkEpoch = null;
   private String network = null;
+  private boolean keyManagerApiEnabled = false;
 
   public SignerConfigurationBuilder withLogLevel(final Level logLevel) {
     this.logLevel = logLevel;
@@ -207,6 +208,11 @@ public class SignerConfigurationBuilder {
     return this;
   }
 
+  public SignerConfigurationBuilder withKeyManagerApiEnabled(final boolean keyManagerApiEnabled) {
+    this.keyManagerApiEnabled = keyManagerApiEnabled;
+    return this;
+  }
+
   public SignerConfiguration build() {
     if (mode == null) {
       throw new IllegalArgumentException("Mode cannot be null");
@@ -240,6 +246,7 @@ public class SignerConfigurationBuilder {
         useConfigFile,
         Optional.ofNullable(slashingProtectionDbPoolConfigurationFile),
         Optional.ofNullable(altairForkEpoch),
-        Optional.ofNullable(network));
+        Optional.ofNullable(network),
+        keyManagerApiEnabled);
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
@@ -184,6 +184,11 @@ public class CmdLineParamsDefaultImpl implements CmdLineParamsBuilder {
       params.add(signerConfig.getNetwork().get());
     }
 
+    if (signerConfig.isKeyManagerApiEnabled()) {
+      params.add("--enable-key-manager-api");
+      params.add(Boolean.toString(signerConfig.isKeyManagerApiEnabled()));
+    }
+
     return params;
   }
 

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
@@ -65,13 +65,25 @@ public class Eth2SubCommand extends ModeSubCommand {
       converter = UInt64Converter.class)
   private UInt64 altairForkEpoch;
 
+  @CommandLine.Option(
+      names = {"--enable-key-manager-api"},
+      paramLabel = "<BOOL>",
+      description = "Enable the key manager API to manage key stores (default: ${DEFAULT-VALUE}).",
+      arity = "1")
+  private boolean isKeyManagerApiEnabled = false;
+
   @Mixin private PicoCliSlashingProtectionParameters slashingProtectionParameters;
   @Mixin private PicoCliAzureKeyVaultParameters azureKeyVaultParameters;
   private tech.pegasys.teku.spec.Spec eth2Spec;
 
   @Override
   public Runner createRunner() {
-    return new Eth2Runner(config, slashingProtectionParameters, azureKeyVaultParameters, eth2Spec);
+    return new Eth2Runner(
+        config,
+        slashingProtectionParameters,
+        azureKeyVaultParameters,
+        eth2Spec,
+        isKeyManagerApiEnabled);
   }
 
   @Override

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -73,18 +73,21 @@ public class Eth2Runner extends Runner {
   private final SlashingProtectionParameters slashingProtectionParameters;
   private final boolean pruningEnabled;
   private final Spec eth2Spec;
+  private final boolean isKeyManagerApiEnabled;
 
   public Eth2Runner(
       final Config config,
       final SlashingProtectionParameters slashingProtectionParameters,
       final AzureKeyVaultParameters azureKeyVaultParameters,
-      final Spec eth2Spec) {
+      final Spec eth2Spec,
+      final boolean isKeyManagerApiEnabled) {
     super(config);
     this.slashingProtection = createSlashingProtection(slashingProtectionParameters);
     this.azureKeyVaultParameters = azureKeyVaultParameters;
     this.slashingProtectionParameters = slashingProtectionParameters;
     this.pruningEnabled = slashingProtectionParameters.isPruningEnabled();
     this.eth2Spec = eth2Spec;
+    this.isKeyManagerApiEnabled = isKeyManagerApiEnabled;
   }
 
   private Optional<SlashingProtection> createSlashingProtection(
@@ -144,6 +147,10 @@ public class Eth2Runner extends Runner {
     routerFactory.addFailureHandlerByOperationId(ETH2_SIGN.name(), errorHandler);
 
     addReloadHandler(routerFactory, blsSignerProvider, RELOAD.name(), errorHandler);
+
+    if (isKeyManagerApiEnabled) {
+      // TODO Implement KeyManager API handlers
+    }
   }
 
   @Override


### PR DESCRIPTION
First PR that starts introducing the Key Manager API as discussed in #439 

This introduces the boolean command line flag that controls whether or not to enable the new API.