### PR TITLE
force delete ./dist.

### DIFF
--- a/.openapidoc/publish.js
+++ b/.openapidoc/publish.js
@@ -66,7 +66,7 @@ async function main() {
  */
 function prepareDistDir(dirPath) {
   log("Cleaning up " + dirPath)
-  fs.rmSync(dirPath, { recursive: true });
+  fs.rmSync(dirPath, { recursive: true, force: true });
   fs.mkdirSync(dirPath, { recursive: true });
 }
 


### PR DESCRIPTION
 -- allows to ignore errors if directory doesnt exists

Signed-off-by: Usman Saleem <usman@usmans.info>