### PR TITLE
Update log4j to 2.16.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -43,10 +43,10 @@ dependencyManagement {
 
     dependency 'javax.activation:activation:1.1.1'
 
-    dependency 'org.apache.logging.log4j:log4j-api:2.15.0'
-    dependency 'org.apache.logging.log4j:log4j:2.15.0'
-    dependency 'org.apache.logging.log4j:log4j-core:2.15.0'
-    dependency 'org.apache.logging.log4j:log4j-slf4j-impl:2.15.0'
+    dependency 'org.apache.logging.log4j:log4j-api:2.16.0'
+    dependency 'org.apache.logging.log4j:log4j:2.16.0'
+    dependency 'org.apache.logging.log4j:log4j-core:2.16.0'
+    dependency 'org.apache.logging.log4j:log4j-slf4j-impl:2.16.0'
 
     dependencySet(group: 'org.apache.tuweni', version: '0.10.0') {
       entry 'tuweni-net'


### PR DESCRIPTION
Updates to log4j2 2.16.0 which identified a second vector for JNDI attacks via ThreadContext. Web3Signer does not use ThreadContext in any way so isn't vulnerable to this issue.