### PR TITLE
Rename the eth cmd line option --enable-key-manager-api to --key-manager-api-enabled

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
@@ -185,7 +185,7 @@ public class CmdLineParamsDefaultImpl implements CmdLineParamsBuilder {
     }
 
     if (signerConfig.isKeyManagerApiEnabled()) {
-      params.add("--enable-key-manager-api");
+      params.add("--key-manager-api-enabled");
       params.add(Boolean.toString(signerConfig.isKeyManagerApiEnabled()));
     }
 

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
@@ -66,7 +66,7 @@ public class Eth2SubCommand extends ModeSubCommand {
   private UInt64 altairForkEpoch;
 
   @CommandLine.Option(
-      names = {"--enable-key-manager-api"},
+      names = {"--key-manager-api-enabled"},
       paramLabel = "<BOOL>",
       description = "Enable the key manager API to manage key stores (default: ${DEFAULT-VALUE}).",
       arity = "1")


### PR DESCRIPTION
Rename the eth cmd line option --enable-key-manager-api to --key-manager-api-enabled to make it consistent with the other Web3Signer command options that have -enabled suffix.