### PR TITLE
Upgrade to vertx 4 and other dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Next Version
+### Breaking Changes
+- Update Vertx to 4.x.
+- Update signers to 2.0.0
+- Update various other dependencies to latest versions.
+
+---
 ## 21.10.5
 ### Bugs Fixed
 - Updated to log4j 2.17.1. Resolves two potential vulnerabilities which are only exploitable when using custom log4j configurations that are either writable by untrusted users or log data from the `ThreadContext`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Changelog
 
 ## Next Version
-### Breaking Changes
-- Update Vertx to 4.x.
-- Update signers to 2.0.0
-- Update various other dependencies to latest versions.
+### Bugs Fixed
+- Upgrade Vertx to 4.x, signers to 2.0.0 and various other dependencies to latest versions [#503](https://github.com/ConsenSys/web3signer/pull/503)
 
 ---
 ## 21.10.5

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/Web3SignerRunner.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/Web3SignerRunner.java
@@ -97,15 +97,15 @@ public abstract class Web3SignerRunner {
 
   private void loadPortsFile() {
     final File portsFile = new File(dataPath.toFile(), PORTS_FILENAME);
-    LOG.info("Awaiting presence of ethsigner.ports file: {}", portsFile.getAbsolutePath());
+    LOG.info("Awaiting presence of {} file: {}", PORTS_FILENAME, portsFile.getAbsolutePath());
     awaitPortsFile(dataPath);
-    LOG.info("Found ethsigner.ports file: {}", portsFile.getAbsolutePath());
+    LOG.info("Found {} file: {}", PORTS_FILENAME, portsFile.getAbsolutePath());
 
     try (final FileInputStream fis = new FileInputStream(portsFile)) {
       portsProperties.load(fis);
-      LOG.info("EthSigner ports: {}", portsProperties);
+      LOG.info("Web3signer ports: {}", portsProperties);
     } catch (final IOException e) {
-      throw new RuntimeException("Error reading Web3Provider ports file", e);
+      throw new RuntimeException("Error reading Web3Signer ports file", e);
     }
   }
 

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/SecpSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/SecpSigningAcceptanceTest.java
@@ -36,7 +36,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariables;
-import org.junit.jupiter.api.io.TempDir;
 import org.web3j.crypto.Sign.SignatureData;
 
 public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
@@ -57,12 +56,12 @@ public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
   private final MetadataFileHelpers metadataFileHelpers = new MetadataFileHelpers();
 
   @Test
-  public void signDataWithFileBasedKey(@TempDir Path keyConfigDirectory) throws URISyntaxException {
+  public void signDataWithFileBasedKey() throws URISyntaxException {
     final String keyPath =
         new File(Resources.getResource("secp256k1/wallet.json").toURI()).getAbsolutePath();
 
     metadataFileHelpers.createKeyStoreYamlFileAt(
-        keyConfigDirectory.resolve(PUBLIC_KEY_HEX_STRING + ".yaml"),
+        testDirectory.resolve(PUBLIC_KEY_HEX_STRING + ".yaml"),
         Path.of(keyPath),
         "pass",
         KeyType.SECP256K1);
@@ -71,7 +70,7 @@ public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
   }
 
   @Test
-  public void signDataWithKeyFromHashicorp(@TempDir Path keyConfigDirectory) {
+  public void signDataWithKeyFromHashicorp() {
     final HashicorpNode hashicorpNode = HashicorpNode.createAndStartHashicorp(true);
     try {
       final String secretPath = "acceptanceTestSecretPath";
@@ -82,7 +81,7 @@ public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
           new HashicorpSigningParams(hashicorpNode, secretPath, secretName, KeyType.SECP256K1);
 
       metadataFileHelpers.createHashicorpYamlFileAt(
-          keyConfigDirectory.resolve(PUBLIC_KEY_HEX_STRING + ".yaml"), hashicorpSigningParams);
+          testDirectory.resolve(PUBLIC_KEY_HEX_STRING + ".yaml"), hashicorpSigningParams);
 
       signAndVerifySignature();
     } finally {
@@ -97,9 +96,9 @@ public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
     @EnabledIfEnvironmentVariable(named = "AZURE_KEY_VAULT_NAME", matches = ".*"),
     @EnabledIfEnvironmentVariable(named = "AZURE_TENANT_ID", matches = ".*")
   })
-  public void signDataWithKeyInAzure(@TempDir Path keyConfigDirectory) {
+  public void signDataWithKeyInAzure() {
     metadataFileHelpers.createAzureKeyYamlFileAt(
-        keyConfigDirectory.resolve(AZURE_PUBLIC_KEY_HEX_STRING + ".yaml"),
+        testDirectory.resolve(AZURE_PUBLIC_KEY_HEX_STRING + ".yaml"),
         clientId,
         clientSecret,
         keyVaultName,

--- a/build.gradle
+++ b/build.gradle
@@ -30,13 +30,13 @@ buildscript {
 
 plugins {
   id 'java-test-fixtures'
-  id 'com.diffplug.spotless' version '5.12.5'
+  id 'com.diffplug.spotless' version '6.2.0'
   id 'com.github.ben-manes.versions' version '0.27.0'
-  id 'com.github.jk1.dependency-license-report' version '1.16'
-  id 'io.spring.dependency-management' version '1.0.9.RELEASE'
-  id 'me.champeau.gradle.jmh' version '0.5.0' apply false
-  id 'net.ltgt.errorprone' version '2.0.1'
-  id 'org.ajoberstar.grgit' version '4.1.0'
+  id 'com.github.jk1.dependency-license-report' version '2.0'
+  id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+  id 'me.champeau.gradle.jmh' version '0.5.3' apply false
+  id 'net.ltgt.errorprone' version '2.0.2'
+  id 'org.ajoberstar.grgit' version '4.1.1'
 }
 
 if (!JavaVersion.current().java11Compatible) {
@@ -635,10 +635,7 @@ task releaseIntegrationTest(type: Test){
 task releaseAcceptanceTest(type: Test, dependsOn : ':acceptance-tests:acceptanceTest') {}
 
 task cloudsmithUpload {
-  dependsOn([
-    distTar,
-    distZip,
-  ])
+  dependsOn([distTar, distZip,])
   doLast {
     exec {
       executable project.file("scripts/cloudsmith-upload.sh")

--- a/commandline/build.gradle
+++ b/commandline/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation 'org.hyperledger.besu.internal:metrics-core'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-  implementation 'commons-lang:commons-lang'
+  implementation 'org.apache.commons:commons-lang3'
 
   implementation 'tech.pegasys.teku.internal:spec'
   implementation 'tech.pegasys.teku.internal:unsigned'

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ExportSubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ExportSubCommand.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ImportSubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ImportSubCommand.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/valueprovider/YamlConfigFileDefaultProvider.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/valueprovider/YamlConfigFileDefaultProvider.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.IDefaultValueProvider;
 import picocli.CommandLine.Model.ArgSpec;

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'org.apache.logging.log4j:log4j-core'
   implementation 'commons-io:commons-io'
-  implementation 'commons-lang:commons-lang'
+  implementation 'org.apache.commons:commons-lang3'
 
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-net'
@@ -86,7 +86,7 @@ dependencies {
 
   testFixturesImplementation 'org.apache.logging.log4j:log4j-api'
   testFixturesImplementation 'org.apache.logging.log4j:log4j-core'
-  testFixturesImplementation 'commons-lang:commons-lang'
+  testFixturesImplementation 'org.apache.commons:commons-lang3'
   testFixturesApi 'tech.pegasys.teku.internal:bls'
   testFixturesImplementation 'org.apache.tuweni:tuweni-bytes'
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -309,10 +309,10 @@ public abstract class Runner implements Runnable {
       constraints
           .getKnownClientsFile()
           .ifPresent(
-              whitelistFile ->
+              allowlistFile ->
                   result.setTrustOptions(
                       VertxTrustOptions.allowlistClients(
-                          whitelistFile.toPath(), constraints.isCaAuthorizedClientAllowed())));
+                          allowlistFile.toPath(), constraints.isCaAuthorizedClientAllowed())));
     } catch (final IllegalArgumentException e) {
       throw new InitializationException("Illegally formatted client fingerprint file.");
     }

--- a/core/src/main/java/tech/pegasys/web3signer/core/multikey/SignerLoader.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/multikey/SignerLoader.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/imports/ImportKeystoresHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/imports/ImportKeystoresHandler.java
@@ -48,7 +48,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.api.RequestParameters;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;

--- a/core/src/main/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractor.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractor.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tuweni.io.Resources;
 
 /**

--- a/core/src/testFixtures/java/tech/pegasys/web3signer/FileHiddenUtil.java
+++ b/core/src/testFixtures/java/tech/pegasys/web3signer/FileHiddenUtil.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 
 public class FileHiddenUtil {
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,5 +11,5 @@ org.gradle.jvmargs=-Xmx1g \
   --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
   --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
   --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
-hashicorpVaultVersion=1.4.3
+hashicorpVaultVersion=1.9.2
 hashicorpVaultUrl=https://releases.hashicorp.com/vault

--- a/gradle/license-report-config/allowed-licenses.json
+++ b/gradle/license-report-config/allowed-licenses.json
@@ -62,13 +62,16 @@
     },
     {
       "moduleLicense": "IAIK of Graz University of Technology License",
-      "moduleVersion": "1.4.7",
+      "moduleVersion": "1.4.8",
       "moduleName": "org.xipki.iaik:sunpkcs11-wrapper"
     },
     {
       "moduleLicense": "Unicode/ICU License",
       "moduleVersion": "58.2",
       "moduleName": "com.ibm.icu:icu4j"
+    },
+    {
+      "moduleName": "io.netty:netty-tcnative-classes"
     }
   ],
   "overrideLicenses": [
@@ -114,6 +117,10 @@
     },
     {
       "moduleName": "org.ow2.asm",
+      "moduleLicense": "Apache License, Version 2.0"
+    },
+    {
+      "moduleName": "io.netty:netty-tcnative-classes",
       "moduleLicense": "Apache License, Version 2.0"
     }
   ]

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -68,7 +68,7 @@ dependencyManagement {
       entry 'bcprov-jdk15on'
     }
 
-    dependencySet(group: 'org.junit.jupiter', version: '5.7.2') {
+    dependencySet(group: 'org.junit.jupiter', version: '5.8.2') {
       entry 'junit-jupiter-api'
       entry 'junit-jupiter-engine'
       entry 'junit-jupiter-params'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -23,11 +23,11 @@ dependencyManagement {
       entry 'error_prone_test_helpers'
     }
 
-    dependency 'com.google.guava:guava:28.2-jre'
+    dependency 'com.google.guava:guava:31.0.1-jre'
 
-    dependency 'commons-cli:commons-cli:1.4'
-    dependency 'commons-io:commons-io:2.6'
-    dependency 'commons-lang:commons-lang:2.6'
+    dependency 'commons-cli:commons-cli:1.5.0'
+    dependency 'commons-io:commons-io:2.11.0'
+    dependency 'org.apache.commons:commons-lang3:3.12.0'
 
     dependency 'info.picocli:picocli:4.5.1'
 
@@ -63,8 +63,10 @@ dependencyManagement {
 
     dependency 'org.awaitility:awaitility:4.0.2'
 
-    dependency 'org.bouncycastle:bcpkix-jdk15on:1.64'
-    dependency 'org.bouncycastle:bcprov-jdk15on:1.64'
+    dependencySet(group: 'org.bouncycastle', version: '1.70') {
+      entry 'bcpkix-jdk15on'
+      entry 'bcprov-jdk15on'
+    }
 
     dependency 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     dependency 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
@@ -107,7 +109,9 @@ dependencyManagement {
 
     dependency 'io.rest-assured:rest-assured:4.3.1'
     dependency 'org.zeroturnaround:zt-exec:1.11'
-    dependency 'org.web3j:core:4.5.14'
+    dependency 'org.web3j:core:4.8.9'
+    // explicit declaring to override Java-WebSocket:1.3.8 transitive in web3j:core:4.8.9
+    dependency 'org.java-websocket:Java-WebSocket:1.5.2'
 
     dependency 'com.github.arteam:simple-json-rpc-server:1.2'
     dependency 'com.github.arteam:simple-json-rpc-client:1.2'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -68,9 +68,11 @@ dependencyManagement {
       entry 'bcprov-jdk15on'
     }
 
-    dependency 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    dependency 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
-    dependency 'org.junit.jupiter:junit-jupiter-params:5.6.0'
+    dependencySet(group: 'org.junit.jupiter', version: '5.7.2') {
+      entry 'junit-jupiter-api'
+      entry 'junit-jupiter-engine'
+      entry 'junit-jupiter-params'
+    }
 
     dependencySet(group: 'org.mockito', version: '4.2.0') {
       entry 'mockito-core'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -29,7 +29,7 @@ dependencyManagement {
     dependency 'commons-io:commons-io:2.11.0'
     dependency 'org.apache.commons:commons-lang3:3.12.0'
 
-    dependency 'info.picocli:picocli:4.5.1'
+    dependency 'info.picocli:picocli:4.6.2'
 
     dependencySet(group: 'io.vertx', version: '4.2.3') {
       entry 'vertx-codegen'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -16,7 +16,7 @@ dependencyManagement {
     dependency 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
     dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.1'
 
-    dependencySet(group: 'com.google.errorprone', version: '2.7.1') {
+    dependencySet(group: 'com.google.errorprone', version: '2.10.0') {
       entry 'error_prone_annotation'
       entry 'error_prone_check_api'
       entry 'error_prone_core'
@@ -59,9 +59,9 @@ dependencyManagement {
       entry 'tuweni-io'
     }
 
-    dependency 'org.assertj:assertj-core:3.15.0'
+    dependency 'org.assertj:assertj-core:3.22.0'
 
-    dependency 'org.awaitility:awaitility:4.0.2'
+    dependency 'org.awaitility:awaitility:4.1.1'
 
     dependencySet(group: 'org.bouncycastle', version: '1.70') {
       entry 'bcpkix-jdk15on'
@@ -72,9 +72,11 @@ dependencyManagement {
     dependency 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
     dependency 'org.junit.jupiter:junit-jupiter-params:5.6.0'
 
-    dependency 'org.mockito:mockito-core:3.2.4'
-    dependency 'org.mockito:mockito-inline:3.2.4'
-    dependency 'org.mockito:mockito-junit-jupiter:3.2.4'
+    dependencySet(group: 'org.mockito', version: '4.2.0') {
+      entry 'mockito-core'
+      entry 'mockito-inline'
+      entry 'mockito-junit-jupiter'
+    }
 
     dependency 'org.miracl.milagro.amcl:milagro-crypto-java:0.4.0'
 
@@ -107,8 +109,8 @@ dependencyManagement {
       entry 'acceptance-tests'
     }
 
-    dependency 'io.rest-assured:rest-assured:4.3.1'
-    dependency 'org.zeroturnaround:zt-exec:1.11'
+    dependency 'io.rest-assured:rest-assured:4.4.0'
+    dependency 'org.zeroturnaround:zt-exec:1.12'
     dependency 'org.web3j:core:4.8.9'
     // explicit declaring to override Java-WebSocket:1.3.8 transitive in web3j:core:4.8.9
     dependency 'org.java-websocket:Java-WebSocket:1.5.2'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -13,8 +13,8 @@
 
 dependencyManagement {
   dependencies {
-    dependency 'com.fasterxml.jackson.core:jackson-databind:2.12.5'
-    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.2'
+    dependency 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
+    dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.1'
 
     dependencySet(group: 'com.google.errorprone', version: '2.7.1') {
       entry 'error_prone_annotation'
@@ -31,7 +31,7 @@ dependencyManagement {
 
     dependency 'info.picocli:picocli:4.5.1'
 
-    dependencySet(group: 'io.vertx', version: '3.9.10') {
+    dependencySet(group: 'io.vertx', version: '4.2.3') {
       entry 'vertx-codegen'
       entry 'vertx-core'
       entry 'vertx-unit'
@@ -76,8 +76,8 @@ dependencyManagement {
 
     dependency 'org.miracl.milagro.amcl:milagro-crypto-java:0.4.0'
 
-    dependency 'org.hyperledger.besu:plugin-api:21.1.3'
-    dependency 'org.hyperledger.besu.internal:metrics-core:21.1.3'
+    dependency 'org.hyperledger.besu:plugin-api:21.10.9'
+    dependency 'org.hyperledger.besu.internal:metrics-core:21.10.9'
 
     // TODO: Use latest release which contains new fixes
     dependencySet(group: 'tech.pegasys.teku.internal', version: '22.1.1') {
@@ -94,7 +94,7 @@ dependencyManagement {
 
     dependency 'tech.pegasys:jblst:0.3.3-1'
 
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.25') {
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '2.0.0') {
       entry 'bls-keystore'
       entry 'keystorage-hashicorp'
       entry 'keystorage-azure'
@@ -114,8 +114,8 @@ dependencyManagement {
 
     dependency 'org.miracl.milagro.amcl:milagro-crypto-java:0.4.0'
 
-    dependency 'com.azure:azure-security-keyvault-secrets:4.3.3'
-    dependency 'com.azure:azure-identity:1.3.6'
+    dependency 'com.azure:azure-security-keyvault-secrets:4.3.6'
+    dependency 'com.azure:azure-identity:1.4.3'
 
     dependency 'com.zaxxer:HikariCP:3.4.5'
     dependency 'org.postgresql:postgresql:42.2.20'

--- a/slashing-protection/build.gradle
+++ b/slashing-protection/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'org.apache.logging.log4j:log4j-core'
   implementation 'commons-io:commons-io'
-  implementation 'commons-lang:commons-lang'
+  implementation 'org.apache.commons:commons-lang3'
   implementation 'org.apache.tuweni:tuweni-units'
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   implementation 'org.hyperledger.besu.internal:metrics-core'
@@ -49,7 +49,7 @@ dependencies {
 
   testFixturesImplementation 'org.apache.logging.log4j:log4j-api'
   testFixturesImplementation 'org.apache.logging.log4j:log4j-core'
-  testFixturesImplementation 'commons-lang:commons-lang'
+  testFixturesImplementation 'org.apache.commons:commons-lang3'
   testFixturesImplementation 'com.fasterxml.jackson.core:jackson-databind'
 
   integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/slashing-protection/referencetests/build.gradle
+++ b/slashing-protection/referencetests/build.gradle
@@ -35,6 +35,6 @@ dependencies {
 
   testFixturesImplementation 'org.apache.logging.log4j:log4j-api'
   testFixturesImplementation 'org.apache.logging.log4j:log4j-core'
-  testFixturesImplementation 'commons-lang:commons-lang'
+  testFixturesImplementation 'org.apache.commons:commons-lang3'
   testFixturesImplementation 'com.fasterxml.jackson.core:jackson-databind'
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbConnection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbConnection.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.web3signer.slashingprotection;
 
-import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import tech.pegasys.web3signer.slashingprotection.ArgumentFactories.BytesArgumentFactory;
 import tech.pegasys.web3signer.slashingprotection.ArgumentFactories.UInt64ArgumentFactory;


### PR DESCRIPTION
Upgrade to vertx 4.2.3 to match besu and signers
Upgrade signers to 2.0.0
Upgrade besu metrics to 21.10.9
Upgrade various deps and plugins to match signers and ethsigner

[owasp dependency-check](https://owasp.org/www-project-dependency-check/) report is passing locally.

https://github.com/ConsenSys/web3signer/issues/484