### PR TITLE
Vertx 4 deprecation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Next Version
+
+### Features Added
+- Migrate from the deprecated `vertx-web-api-contract` module to `vertx-web-openapi` [#506](https://github.com/ConsenSys/web3signer/pull/506)
+
 ### Bugs Fixed
 - Upgrade Vertx to 4.x, signers to 2.0.0 and various other dependencies to latest versions [#503](https://github.com/ConsenSys/web3signer/pull/503)
 

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -120,6 +120,7 @@ task acceptanceTest(dependsOn: [
   description = 'Runs Web3Signer acceptance tests.'
   group = 'verification'
 
+  //systemProperty 'debugSubProcess', 'true'
   systemProperty 'acctests.runWeb3SignerAsProcess', 'true'
   systemProperty 'vaultBinary', vaultBinary()
   // embedded pg initdb needs following

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -37,7 +37,7 @@ dependencies {
   implementation 'io.vertx:vertx-core'
   implementation 'io.vertx:vertx-web'
   implementation 'io.vertx:vertx-web-client'
-  implementation 'io.vertx:vertx-web-api-contract'
+  implementation 'io.vertx:vertx-web-openapi'
 
   implementation 'org.hyperledger.besu.internal:metrics-core'
   implementation 'org.hyperledger.besu:plugin-api'

--- a/core/src/main/java/tech/pegasys/web3signer/core/Context.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Context.java
@@ -20,27 +20,27 @@ import io.vertx.ext.web.openapi.RouterBuilder;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 public class Context {
-  private final RouterBuilder routerFactory;
+  private final RouterBuilder routerBuilder;
   private final MetricsSystem metricsSystem;
   private final LogErrorHandler errorHandler;
   private final Vertx vertx;
   private final ArtifactSignerProvider artifactSignerProvider;
 
   public Context(
-      final RouterBuilder routerFactory,
+      final RouterBuilder routerBuilder,
       final MetricsSystem metricsSystem,
       final LogErrorHandler errorHandler,
       final Vertx vertx,
       final ArtifactSignerProvider artifactSignerProvider) {
-    this.routerFactory = routerFactory;
+    this.routerBuilder = routerBuilder;
     this.metricsSystem = metricsSystem;
     this.errorHandler = errorHandler;
     this.vertx = vertx;
     this.artifactSignerProvider = artifactSignerProvider;
   }
 
-  public RouterBuilder getRouterFactory() {
-    return routerFactory;
+  public RouterBuilder getRouterBuilder() {
+    return routerBuilder;
   }
 
   public MetricsSystem getMetricsSystem() {

--- a/core/src/main/java/tech/pegasys/web3signer/core/Context.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Context.java
@@ -16,18 +16,18 @@ import tech.pegasys.web3signer.core.service.http.handlers.LogErrorHandler;
 import tech.pegasys.web3signer.core.signing.ArtifactSignerProvider;
 
 import io.vertx.core.Vertx;
-import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
+import io.vertx.ext.web.openapi.RouterBuilder;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 public class Context {
-  private final OpenAPI3RouterFactory routerFactory;
+  private final RouterBuilder routerFactory;
   private final MetricsSystem metricsSystem;
   private final LogErrorHandler errorHandler;
   private final Vertx vertx;
   private final ArtifactSignerProvider artifactSignerProvider;
 
   public Context(
-      final OpenAPI3RouterFactory routerFactory,
+      final RouterBuilder routerFactory,
       final MetricsSystem metricsSystem,
       final LogErrorHandler errorHandler,
       final Vertx vertx,
@@ -39,7 +39,7 @@ public class Context {
     this.artifactSignerProvider = artifactSignerProvider;
   }
 
-  public OpenAPI3RouterFactory getRouterFactory() {
+  public RouterBuilder getRouterFactory() {
     return routerFactory;
   }
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -54,16 +54,16 @@ public class Eth1Runner extends Runner {
 
   @Override
   protected Router populateRouter(final Context context) {
-    final RouterBuilder routerFactory = context.getRouterFactory();
+    final RouterBuilder routerBuilder = context.getRouterBuilder();
     final LogErrorHandler errorHandler = context.getErrorHandler();
     final ArtifactSignerProvider signerProvider = context.getArtifactSignerProvider();
 
     addPublicKeysListHandler(
-        routerFactory, signerProvider, ETH1_LIST.name(), context.getErrorHandler());
+        routerBuilder, signerProvider, ETH1_LIST.name(), context.getErrorHandler());
 
     final SignerForIdentifier<SecpArtifactSignature> secpSigner =
         new SignerForIdentifier<>(signerProvider, this::formatSecpSignature, SECP256K1);
-    routerFactory
+    routerBuilder
         .operation(ETH1_SIGN.name())
         .handler(
             new BlockingHandlerDecorator(
@@ -72,9 +72,9 @@ public class Eth1Runner extends Runner {
                 false))
         .failureHandler(errorHandler);
 
-    addReloadHandler(routerFactory, signerProvider, RELOAD.name(), context.getErrorHandler());
+    addReloadHandler(routerBuilder, signerProvider, RELOAD.name(), context.getErrorHandler());
 
-    return context.getRouterFactory().createRouter();
+    return context.getRouterBuilder().createRouter();
   }
 
   @Override

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -117,17 +117,17 @@ public class Eth2Runner extends Runner {
   @Override
   public Router populateRouter(final Context context) {
     registerEth2Routes(
-        context.getRouterFactory(),
+        context.getRouterBuilder(),
         context.getArtifactSignerProvider(),
         context.getErrorHandler(),
         context.getMetricsSystem(),
         slashingProtection);
 
-    return context.getRouterFactory().createRouter();
+    return context.getRouterBuilder().createRouter();
   }
 
   private void registerEth2Routes(
-      final RouterBuilder routerFactory,
+      final RouterBuilder routerBuilder,
       final ArtifactSignerProvider blsSignerProvider,
       final LogErrorHandler errorHandler,
       final MetricsSystem metricsSystem,
@@ -135,7 +135,7 @@ public class Eth2Runner extends Runner {
     final ObjectMapper objectMapper = SigningObjectMapperFactory.createObjectMapper();
 
     // security handler for keymanager endpoints
-    routerFactory.securityHandler(
+    routerBuilder.securityHandler(
         "bearerAuth",
         context -> {
           // TODO Auth token security logic
@@ -147,11 +147,11 @@ public class Eth2Runner extends Runner {
           }
         });
 
-    addPublicKeysListHandler(routerFactory, blsSignerProvider, ETH2_LIST.name(), errorHandler);
+    addPublicKeysListHandler(routerBuilder, blsSignerProvider, ETH2_LIST.name(), errorHandler);
 
     final SignerForIdentifier<BlsArtifactSignature> blsSigner =
         new SignerForIdentifier<>(blsSignerProvider, this::formatBlsSignature, BLS);
-    routerFactory
+    routerBuilder
         .operation(ETH2_SIGN.name())
         .handler(
             new BlockingHandlerDecorator(
@@ -165,16 +165,16 @@ public class Eth2Runner extends Runner {
                 false))
         .failureHandler(errorHandler);
 
-    addReloadHandler(routerFactory, blsSignerProvider, RELOAD.name(), errorHandler);
+    addReloadHandler(routerBuilder, blsSignerProvider, RELOAD.name(), errorHandler);
 
     if (isKeyManagerApiEnabled) {
-      routerFactory
+      routerBuilder
           .operation(KEYMANAGER_LIST.name())
           .handler(
               new BlockingHandlerDecorator(
                   new ListKeystoresHandler(blsSignerProvider, objectMapper), false));
 
-      routerFactory
+      routerBuilder
           .operation(KEYMANAGER_IMPORT.name())
           .handler(
               new BlockingHandlerDecorator(

--- a/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
@@ -65,23 +65,23 @@ public class FilecoinRunner extends Runner {
   @Override
   protected Router populateRouter(final Context context) {
     addReloadHandler(
-        context.getRouterFactory(),
+        context.getRouterBuilder(),
         context.getArtifactSignerProvider(),
         RELOAD.name(),
         context.getErrorHandler());
 
     return registerFilecoinJsonRpcRoute(
-        context.getRouterFactory(),
+        context.getRouterBuilder(),
         context.getMetricsSystem(),
         context.getArtifactSignerProvider());
   }
 
   private Router registerFilecoinJsonRpcRoute(
-      final RouterBuilder routerFactory,
+      final RouterBuilder routerBuilder,
       final MetricsSystem metricsSystem,
       final ArtifactSignerProvider fcSigners) {
 
-    final Router router = routerFactory.createRouter();
+    final Router router = routerBuilder.createRouter();
 
     final FcJsonRpcMetrics fcJsonRpcMetrics = new FcJsonRpcMetrics(metricsSystem);
     final FcJsonRpc fileCoinJsonRpc = new FcJsonRpc(fcSigners, fcJsonRpcMetrics);

--- a/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
@@ -44,8 +44,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.arteam.simplejsonrpc.server.JsonRpcServer;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
-import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
 import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.ext.web.openapi.RouterBuilder;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 public class FilecoinRunner extends Runner {
@@ -77,11 +77,11 @@ public class FilecoinRunner extends Runner {
   }
 
   private Router registerFilecoinJsonRpcRoute(
-      final OpenAPI3RouterFactory routerFactory,
+      final RouterBuilder routerFactory,
       final MetricsSystem metricsSystem,
       final ArtifactSignerProvider fcSigners) {
 
-    final Router router = routerFactory.getRouter();
+    final Router router = routerFactory.createRouter();
 
     final FcJsonRpcMetrics fcJsonRpcMetrics = new FcJsonRpcMetrics(metricsSystem);
     final FcJsonRpc fileCoinJsonRpc = new FcJsonRpc(fcSigners, fcJsonRpcMetrics);

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -116,7 +116,7 @@ public abstract class Runner implements Runnable {
                   () ->
                       new RuntimeException(
                           "Unable to load OpenApi spec " + getOpenApiSpecResource()));
-      final RouterBuilder routerBuilder = getRouterBuilder(vertx, openApiSpec.toString());
+      final RouterBuilder routerBuilder = getRouterBuilder(vertx, openApiSpec.toUri().toString());
       // register access log handler first
       if (config.isAccessLogsEnabled()) {
         routerBuilder.rootHandler(LoggerHandler.create(LoggerFormat.DEFAULT));

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -106,7 +106,7 @@ public abstract class Runner implements Runnable {
 
       final OpenApiSpecsExtractor openApiSpecsExtractor =
           new OpenApiSpecsExtractor.OpenApiSpecsExtractorBuilder()
-              .withConvertRelativeRefToAbsoluteRef(true)
+              .withConvertRelativeRefToAbsoluteRef(false)
               .withForceDeleteOnJvmExit(true)
               .build();
       final Path openApiSpec =

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -106,7 +106,7 @@ public abstract class Runner implements Runnable {
 
       final OpenApiSpecsExtractor openApiSpecsExtractor =
           new OpenApiSpecsExtractor.OpenApiSpecsExtractorBuilder()
-              .withConvertRelativeRefToAbsoluteRef(false)
+              .withConvertRelativeRefToAbsoluteRef(true)
               .withForceDeleteOnJvmExit(true)
               .build();
       final Path openApiSpec =

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -33,6 +33,7 @@ import tech.pegasys.web3signer.core.util.OpenApiSpecsExtractor;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -116,7 +117,9 @@ public abstract class Runner implements Runnable {
                   () ->
                       new RuntimeException(
                           "Unable to load OpenApi spec " + getOpenApiSpecResource()));
-      final RouterBuilder routerBuilder = getRouterBuilder(vertx, openApiSpec.toUri().toString());
+      // vertx needs a scheme present (file://) to determine this is an absolute path
+      final URI openApiSpecUri = openApiSpec.toUri();
+      final RouterBuilder routerBuilder = getRouterBuilder(vertx, openApiSpecUri.toString());
       // register access log handler first
       if (config.isAccessLogsEnabled()) {
         routerBuilder.rootHandler(LoggerHandler.create(LoggerFormat.DEFAULT));
@@ -188,6 +191,7 @@ public abstract class Runner implements Runnable {
     // disable automatic response content handler as it doesn't handle some corner cases.
     // Our handlers must set content type header manually.
     routerBuilder.getOptions().setMountResponseContentTypeHandler(false);
+    // vertx-json-schema fails to createRouter for unknown string type formats
     routerBuilder.getSchemaParser().withStringFormatValidator("uint64", Runner::validateUInt64);
     return routerBuilder;
   }

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresHandler.java
@@ -24,7 +24,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.api.RequestParameters;
+import io.vertx.ext.web.validation.RequestParameters;
+import io.vertx.ext.web.validation.ValidationHandler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -51,7 +52,7 @@ public class DeleteKeystoresHandler implements Handler<RoutingContext> {
   @Override
   public void handle(RoutingContext context) {
     // API spec - https://github.com/ethereum/keymanager-APIs/tree/master/flows#delete
-    final RequestParameters params = context.get("parsedParameters");
+    final RequestParameters params = context.get(ValidationHandler.REQUEST_CONTEXT_KEY);
     final DeleteKeystoresRequestBody parsedBody;
     try {
       parsedBody = parseRequestBody(params);

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/imports/ImportKeystoresHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/imports/ImportKeystoresHandler.java
@@ -47,7 +47,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.api.RequestParameters;
+import io.vertx.ext.web.validation.RequestParameters;
+import io.vertx.ext.web.validation.ValidationHandler;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -81,7 +82,7 @@ public class ImportKeystoresHandler implements Handler<RoutingContext> {
   @Override
   public void handle(RoutingContext context) {
     // API spec - https://github.com/ethereum/keymanager-APIs/tree/master/flows#import
-    final RequestParameters params = context.get("parsedParameters");
+    final RequestParameters params = context.get(ValidationHandler.REQUEST_CONTEXT_KEY);
     final ImportKeystoresRequestBody parsedBody;
     try {
       parsedBody = parseRequestBody(params);

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/Eth1SignForIdentifierHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/Eth1SignForIdentifierHandler.java
@@ -22,8 +22,9 @@ import tech.pegasys.web3signer.core.service.http.metrics.HttpApiMetrics;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.api.RequestParameter;
-import io.vertx.ext.web.api.RequestParameters;
+import io.vertx.ext.web.validation.RequestParameter;
+import io.vertx.ext.web.validation.RequestParameters;
+import io.vertx.ext.web.validation.ValidationHandler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -44,7 +45,7 @@ public class Eth1SignForIdentifierHandler implements Handler<RoutingContext> {
   @Override
   public void handle(final RoutingContext routingContext) {
     try (final TimingContext ignored = metrics.getSigningTimer().startTimer()) {
-      final RequestParameters params = routingContext.get("parsedParameters");
+      final RequestParameters params = routingContext.get(ValidationHandler.REQUEST_CONTEXT_KEY);
       final String identifier = params.pathParameter("identifier").toString();
       final Bytes data;
       try {

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/Eth2SignForIdentifierHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/Eth2SignForIdentifierHandler.java
@@ -46,7 +46,8 @@ import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.MIMEHeader;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.api.RequestParameters;
+import io.vertx.ext.web.validation.RequestParameters;
+import io.vertx.ext.web.validation.ValidationHandler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -88,8 +89,8 @@ public class Eth2SignForIdentifierHandler implements Handler<RoutingContext> {
   @Override
   public void handle(final RoutingContext routingContext) {
     try (final TimingContext ignored = httpMetrics.getSigningTimer().startTimer()) {
-      LOG.debug("{} || {}", routingContext.normalisedPath(), routingContext.getBody());
-      final RequestParameters params = routingContext.get("parsedParameters");
+      LOG.debug("{} || {}", routingContext.normalizedPath(), routingContext.getBody());
+      final RequestParameters params = routingContext.get(ValidationHandler.REQUEST_CONTEXT_KEY);
       final String identifier = params.pathParameter("identifier").toString();
       final Eth2SigningRequestBody eth2SigningRequestBody;
       try {

--- a/core/src/main/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractor.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractor.java
@@ -135,7 +135,7 @@ public class OpenApiSpecsExtractor {
       final Path nonNormalizedRefPath = parent.resolve(Path.of(fileName));
       // remove any . or .. from path
       final Path normalizedPath = nonNormalizedRefPath.toAbsolutePath().normalize();
-      // ensure file:// is prepended
+      // vertx needs a scheme present (file://) to determine this is an absolute path
       final URI normalizedUri = normalizedPath.toUri();
 
       final String updatedValue =

--- a/core/src/main/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractor.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractor.java
@@ -36,7 +36,7 @@ import org.apache.tuweni.io.Resources;
 
 /**
  * Extract OpenAPI specs from resources /openapi to a temporary folder on disk with capability to
- * fix relative $ref paths so that they can be used by OpenApi3RouterFactory which doesn't deal with
+ * fix relative $ref paths so that they can be used by RouterBuilder which doesn't deal with
  * relative $ref paths.
  */
 public class OpenApiSpecsExtractor {

--- a/core/src/main/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractor.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractor.java
@@ -14,6 +14,7 @@ package tech.pegasys.web3signer.core.util;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -134,11 +135,13 @@ public class OpenApiSpecsExtractor {
       final Path nonNormalizedRefPath = parent.resolve(Path.of(fileName));
       // remove any . or .. from path
       final Path normalizedPath = nonNormalizedRefPath.toAbsolutePath().normalize();
+      // ensure file:// is prepended
+      final URI normalizedUri = normalizedPath.toUri();
 
       final String updatedValue =
           StringUtils.isBlank(jsonPointer)
-              ? normalizedPath.toString()
-              : normalizedPath + "#" + jsonPointer;
+              ? normalizedUri.toString()
+              : normalizedUri + "#" + jsonPointer;
       entry.setValue(updatedValue);
     }
   }

--- a/core/src/test/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractorTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractorTest.java
@@ -45,10 +45,7 @@ class OpenApiSpecsExtractorTest {
 
     // assert that routerBuilder is able to load the extracted specs
     assertThatCode(
-            () ->
-                Runner.getRouterBuilder(vertx, specPath.get().toString())
-                    .securityHandler("bearerAuth", x -> {})
-                    .createRouter())
+            () -> Runner.getRouterBuilder(vertx, specPath.get().toString()))
         .doesNotThrowAnyException();
 
     // assert that relative ref has been converted to absolute ref

--- a/core/src/test/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractorTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractorTest.java
@@ -43,8 +43,12 @@ class OpenApiSpecsExtractorTest {
             .build();
     final Optional<Path> specPath = openApiSpecsExtractor.getSpecFilePathAtDestination(spec);
 
-    // assert that OpenAPI3RouterFactory is able to load the extracted specs
-    assertThatCode(() -> Runner.getOpenAPI3RouterFactory(vertx, specPath.get().toString()))
+    // assert that routerBuilder is able to load the extracted specs
+    assertThatCode(
+            () ->
+                Runner.getRouterBuilder(vertx, specPath.get().toString())
+                    .securityHandler("bearerAuth", x -> {})
+                    .createRouter())
         .doesNotThrowAnyException();
 
     // assert that relative ref has been converted to absolute ref

--- a/core/src/test/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractorTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractorTest.java
@@ -44,7 +44,7 @@ class OpenApiSpecsExtractorTest {
     final Optional<Path> specPath = openApiSpecsExtractor.getSpecFilePathAtDestination(spec);
 
     // assert that routerBuilder is able to load the extracted specs
-    assertThatCode(() -> Runner.getRouterBuilder(vertx, specPath.get().toString()))
+    assertThatCode(() -> Runner.getRouterBuilder(vertx, specPath.get().toUri().toString()))
         .doesNotThrowAnyException();
 
     // assert that relative ref has been converted to absolute ref

--- a/core/src/test/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractorTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractorTest.java
@@ -44,7 +44,11 @@ class OpenApiSpecsExtractorTest {
     final Optional<Path> specPath = openApiSpecsExtractor.getSpecFilePathAtDestination(spec);
 
     // assert that routerBuilder is able to load the extracted specs
-    assertThatCode(() -> Runner.getRouterBuilder(vertx, specPath.get().toUri().toString()))
+    assertThatCode(
+            () ->
+                Runner.getRouterBuilder(vertx, specPath.get().toUri().toString())
+                    .securityHandler("bearerAuth", x -> {})
+                    .createRouter())
         .doesNotThrowAnyException();
 
     // assert that relative ref has been converted to absolute ref

--- a/core/src/test/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractorTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractorTest.java
@@ -44,8 +44,7 @@ class OpenApiSpecsExtractorTest {
     final Optional<Path> specPath = openApiSpecsExtractor.getSpecFilePathAtDestination(spec);
 
     // assert that routerBuilder is able to load the extracted specs
-    assertThatCode(
-            () -> Runner.getRouterBuilder(vertx, specPath.get().toString()))
+    assertThatCode(() -> Runner.getRouterBuilder(vertx, specPath.get().toString()))
         .doesNotThrowAnyException();
 
     // assert that relative ref has been converted to absolute ref

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -37,7 +37,7 @@ dependencyManagement {
       entry 'vertx-unit'
       entry 'vertx-web-client'
       entry 'vertx-web'
-      entry 'vertx-web-api-contract'
+      entry 'vertx-web-openapi'
       entry 'vertx-junit5'
     }
 


### PR DESCRIPTION
Migration from deprecated `vertx-web-api-contract` module to `vertx-web-openapi`, see https://vert-x3.github.io/vertx-4-migration-guide/index.html#changes-in-vertx-openapi_changes-in-common-components

Main change was replacing OpenAPI3RouterFactory with RouterBuilder with near one-for-one method replacements.

Fix "format not supported" bug by adding custom string format validator for uint64. This follows same validation rules as the teku UInt64Deserializer.

Make OpenApiSpecsExtractorTest fail upon lack of uint64 validator by calling createRouter() (and registering a noop securityHandler to satisfy the eth2 keymanager openapi spec's security scheme).