### PR TITLE
Jackson deprecation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Next Version
+
+### Features Added
+- Migrate jackson `ObjectMapper` instances to `JsonMapper` and `YamlMapper` builders to resolve deprecation warnings [#507](https://github.com/ConsenSys/web3signer/pull/507)
+
 ### Bugs Fixed
 - Upgrade Vertx to 4.x, signers to 2.0.0 and various other dependencies to latest versions [#503](https://github.com/ConsenSys/web3signer/pull/503)
 

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/lotus/FilecoinJsonRpcEndpoint.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/lotus/FilecoinJsonRpcEndpoint.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.github.arteam.simplejsonrpc.client.JsonRpcClient;
 import com.google.common.net.MediaType;
 import org.apache.commons.codec.Charsets;
@@ -42,7 +43,7 @@ public abstract class FilecoinJsonRpcEndpoint {
       Optional.ofNullable(System.getenv("WEB3SIGNER_BEARER_TOKEN"));
 
   private static final ObjectMapper OBJECT_MAPPER =
-      new ObjectMapper().registerModule(new FilecoinJsonRpcModule());
+      JsonMapper.builder().addModule(new FilecoinJsonRpcModule()).build();
 
   private final JsonRpcClient jsonRpcClient;
   private final String rpcPath;

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/lotus/LotusNode.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/lotus/LotusNode.java
@@ -12,15 +12,11 @@
  */
 package tech.pegasys.web3signer.dsl.lotus;
 
-import tech.pegasys.web3signer.core.service.jsonrpc.FilecoinJsonRpcModule;
-
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Lotus is expected to be running outside of acceptance test. It can be executed using following
@@ -32,8 +28,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class LotusNode extends FilecoinJsonRpcEndpoint {
 
   private final String fcUrl;
-  public static final ObjectMapper OBJECT_MAPPER =
-      new ObjectMapper().registerModule(new FilecoinJsonRpcModule());
 
   public LotusNode(final String host, final int port) {
     super("/rpc/v0");

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/MetadataFileHelpers.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/MetadataFileHelpers.java
@@ -39,12 +39,12 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
 public class MetadataFileHelpers {
-  private static final ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+  private static final ObjectMapper YAML_OBJECT_MAPPER = YAMLMapper.builder().build();
   private static final Bytes SALT =
       Bytes.fromHexString("0x9ac471d9d421bc06d9aefe2b46cf96d11829c51e36ed0b116132be57a9f8c22b");
   private static final Bytes IV = Bytes.fromHexString("0xcca2c67ec95a1dd13edd986fea372789");

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/filecoin/FcBlsSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/filecoin/FcBlsSigningAcceptanceTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import com.github.arteam.simplejsonrpc.core.domain.Request;
@@ -71,7 +72,7 @@ public class FcBlsSigningAcceptanceTest extends SigningAcceptanceTestBase {
     setupFilecoinSigner();
 
     final ValueNode id = JsonNodeFactory.instance.numberNode(1);
-    final ObjectMapper mapper = new ObjectMapper();
+    final ObjectMapper mapper = JsonMapper.builder().build();
     final Map<String, String> metaData = Map.of("type", "message", "extra", DATA.toBase64String());
     final JsonNode params =
         mapper.convertValue(

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/filecoin/FcBlsVerifyAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/filecoin/FcBlsVerifyAcceptanceTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import com.github.arteam.simplejsonrpc.core.domain.Request;
@@ -66,7 +67,7 @@ public class FcBlsVerifyAcceptanceTest extends AcceptanceTestBase {
     startSigner(new SignerConfigurationBuilder().withMode("filecoin").build());
 
     final ValueNode id = JsonNodeFactory.instance.numberNode(1);
-    final ObjectMapper mapper = new ObjectMapper();
+    final ObjectMapper mapper = JsonMapper.builder().build();
 
     final FilecoinSignature filecoinSignature =
         new FilecoinSignature(

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/filecoin/FcSecpSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/filecoin/FcSecpSigningAcceptanceTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import com.github.arteam.simplejsonrpc.core.domain.Request;
@@ -67,7 +68,7 @@ public class FcSecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
     setupFilecoinSigner();
 
     final ValueNode id = JsonNodeFactory.instance.numberNode(1);
-    final ObjectMapper mapper = new ObjectMapper();
+    final ObjectMapper mapper = JsonMapper.builder().build();
     final Map<String, String> metaData = Map.of("type", "unknown");
     final JsonNode params =
         mapper.convertValue(

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/filecoin/FcSecpVerifyAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/filecoin/FcSecpVerifyAcceptanceTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import com.github.arteam.simplejsonrpc.core.domain.Request;
@@ -52,7 +53,7 @@ public class FcSecpVerifyAcceptanceTest extends AcceptanceTestBase {
     startSigner(new SignerConfigurationBuilder().withMode("filecoin").build());
 
     final ValueNode id = JsonNodeFactory.instance.numberNode(1);
-    final ObjectMapper mapper = new ObjectMapper();
+    final ObjectMapper mapper = JsonMapper.builder().build();
 
     final FilecoinSignature filecoinSignature =
         new FilecoinSignature(FcJsonRpc.SECP_VALUE, expectedBase64Signature);

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/Eth2DepositSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/Eth2DepositSigningAcceptanceTest.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.io.Resources;
 import io.restassured.response.Response;
 import org.apache.tuweni.bytes.Bytes;
@@ -57,7 +58,7 @@ public class Eth2DepositSigningAcceptanceTest extends SigningAcceptanceTestBase 
 
     setupEth2Signer();
 
-    final ObjectMapper objectMapper = new ObjectMapper();
+    final ObjectMapper objectMapper = JsonMapper.builder().build();
 
     final Path testFilesPath = Path.of(Resources.getResource("eth2").getPath());
     try (final Stream<Path> files = Files.list(testFilesPath)) {

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/slashing/SlashingExportAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/slashing/SlashingExportAcceptanceTest.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import dsl.InterchangeV5Format;
 import dsl.SignedArtifacts;
 import io.restassured.response.Response;
@@ -96,7 +97,7 @@ public class SlashingExportAcceptanceTest extends AcceptanceTestBase {
     exportSigner.start();
     waitFor(() -> assertThat(exportSigner.isRunning()).isFalse());
 
-    final ObjectMapper mapper = new ObjectMapper().registerModule(new InterchangeModule());
+    final ObjectMapper mapper = JsonMapper.builder().addModule(new InterchangeModule()).build();
 
     final InterchangeV5Format mappedData =
         mapper.readValue(exportFile.toFile(), InterchangeV5Format.class);

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/slashing/SlashingImportAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/slashing/SlashingImportAcceptanceTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.io.Resources;
 import dsl.InterchangeV5Format;
 import dsl.SignedArtifacts;
@@ -50,9 +51,10 @@ public class SlashingImportAcceptanceTest extends AcceptanceTestBase {
   public static final String DB_PASSWORD = "postgres";
 
   private static final com.fasterxml.jackson.databind.ObjectMapper objectMapper =
-      new com.fasterxml.jackson.databind.ObjectMapper()
-          .registerModule(new InterchangeModule())
-          .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+      JsonMapper.builder()
+          .addModule(new InterchangeModule())
+          .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+          .build();
 
   protected final BLSKeyPair keyPair = BLSTestUtil.randomKeyPair(0);
 

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/tls/ServerSideTlsCaClientAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/tls/ServerSideTlsCaClientAcceptanceTest.java
@@ -97,7 +97,7 @@ public class ServerSideTlsCaClientAcceptanceTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void clientNotInCaFailedToConnectToEthSigner(
+  void clientNotInCaFailedToConnectToWeb3Signer(
       final boolean useConfigFile, @TempDir final Path tempDir) throws Exception {
     signer = createSigner(clientCert, tempDir, useConfigFile);
     signer.start();

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/valueprovider/YamlConfigFileDefaultProvider.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/valueprovider/YamlConfigFileDefaultProvider.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.apache.commons.lang3.ArrayUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.IDefaultValueProvider;
@@ -67,10 +67,10 @@ public class YamlConfigFileDefaultProvider implements IDefaultValueProvider {
   }
 
   private Map<String, Object> loadConfigurationFromFile() {
-    final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+    final ObjectMapper yamlMapper = YAMLMapper.builder().build();
 
     try {
-      return objectMapper.readValue(configFile, new TypeReference<>() {});
+      return yamlMapper.readValue(configFile, new TypeReference<>() {});
     } catch (final FileNotFoundException | NoSuchFileException e) {
       throwParameterException(
           e, "Unable to read yaml configuration. File not found: " + configFile);

--- a/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
@@ -41,6 +41,7 @@ import tech.pegasys.web3signer.core.signing.filecoin.FilecoinNetwork;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.github.arteam.simplejsonrpc.server.JsonRpcServer;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
@@ -86,11 +87,12 @@ public class FilecoinRunner extends Runner {
     final FcJsonRpcMetrics fcJsonRpcMetrics = new FcJsonRpcMetrics(metricsSystem);
     final FcJsonRpc fileCoinJsonRpc = new FcJsonRpc(fcSigners, fcJsonRpcMetrics);
     final ObjectMapper mapper =
-        new ObjectMapper()
+        JsonMapper.builder()
             .enable(ACCEPT_CASE_INSENSITIVE_ENUMS)
             .enable(ACCEPT_CASE_INSENSITIVE_PROPERTIES)
             .disable(FAIL_ON_UNKNOWN_PROPERTIES)
-            .registerModule(new FilecoinJsonRpcModule());
+            .addModule(new FilecoinJsonRpcModule())
+            .build();
     final JsonRpcServer jsonRpcServer = JsonRpcServer.withMapper(mapper);
 
     router

--- a/core/src/main/java/tech/pegasys/web3signer/core/multikey/metadata/parser/YamlSignerParser.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/multikey/metadata/parser/YamlSignerParser.java
@@ -26,15 +26,15 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 
 public class YamlSignerParser implements SignerParser {
 
-  public static final ObjectMapper OBJECT_MAPPER =
-      new ObjectMapper(new YAMLFactory())
-          .registerModule(new SigningMetadataModule())
-          .enable(ACCEPT_CASE_INSENSITIVE_ENUMS);
+  public static final YAMLMapper YAML_MAPPER =
+      YAMLMapper.builder()
+          .addModule(new SigningMetadataModule())
+          .enable(ACCEPT_CASE_INSENSITIVE_ENUMS)
+          .build();
 
   private final Collection<AbstractArtifactSignerFactory> signerFactories;
 
@@ -46,7 +46,7 @@ public class YamlSignerParser implements SignerParser {
   public List<ArtifactSigner> parse(final String fileContent) {
     try {
       final SigningMetadata metaDataInfo =
-          OBJECT_MAPPER.readValue(fileContent, SigningMetadata.class);
+          YAML_MAPPER.readValue(fileContent, SigningMetadata.class);
 
       return signerFactories.stream()
           .filter(factory -> factory.getKeyType() == metaDataInfo.getKeyType())

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/SigningObjectMapperFactory.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/SigningObjectMapperFactory.java
@@ -46,6 +46,7 @@ import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -58,9 +59,10 @@ public class SigningObjectMapperFactory {
 
   private SigningObjectMapperFactory() {
     this.objectMapper =
-        new ObjectMapper()
+        JsonMapper.builder()
             .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
-            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
     addWeb3SignerMappers();
   }
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/SigningObjectMapperFactory.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/SigningObjectMapperFactory.java
@@ -45,6 +45,7 @@ import tech.pegasys.web3signer.core.service.http.handlers.signing.eth2.json.Bloc
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -62,11 +63,11 @@ public class SigningObjectMapperFactory {
         JsonMapper.builder()
             .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .addModule(web3SignerMappers())
             .build();
-    addWeb3SignerMappers();
   }
 
-  private void addWeb3SignerMappers() {
+  private Module web3SignerMappers() {
     final SimpleModule module =
         new SimpleModule("SigningJsonRpcModule", new Version(1, 0, 0, null, null, null));
     module.addDeserializer(Bytes.class, new HexDeserialiser());
@@ -97,9 +98,9 @@ public class SigningObjectMapperFactory {
     module.addDeserializer(SszBitvector.class, new SszBitvectorDeserializer());
     module.addSerializer(SszBitvector.class, new SszBitvectorSerializer());
 
-    module.addDeserializer(BlockRequest.class, new BlockRequestDeserializer(objectMapper));
+    module.addDeserializer(BlockRequest.class, new BlockRequestDeserializer());
 
-    objectMapper.registerModule(module);
+    return module;
   }
 
   public static ObjectMapper createObjectMapper() {

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/KeystoreFileManager.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/KeystoreFileManager.java
@@ -68,7 +68,7 @@ public class KeystoreFileManager {
                     try {
                       final String fileContent = Files.readString(path, StandardCharsets.UTF_8);
                       final SigningMetadata metaDataInfo =
-                          YamlSignerParser.OBJECT_MAPPER.readValue(
+                          YamlSignerParser.YAML_MAPPER.readValue(
                               fileContent, SigningMetadata.class);
                       if (metaDataInfo.getKeyType() == KeyType.BLS
                           && metaDataInfo instanceof FileKeyStoreMetadata) {

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/imports/ImportKeystoresHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/imports/ImportKeystoresHandler.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
@@ -60,7 +60,7 @@ public class ImportKeystoresHandler implements Handler<RoutingContext> {
   public static final int SUCCESS = 200;
   public static final int BAD_REQUEST = 400;
   public static final int SERVER_ERROR = 500;
-  private static final ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+  private static final ObjectMapper YAML_OBJECT_MAPPER = YAMLMapper.builder().build();
 
   private final ObjectMapper objectMapper;
   private final Path keystorePath;

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/json/BlockRequestDeserializer.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/json/BlockRequestDeserializer.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.web3signer.core.service.http.handlers.signing.eth2.json;
 
+import com.fasterxml.jackson.core.ObjectCodec;
 import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.altair.BeaconBlockAltair;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -26,24 +27,24 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class BlockRequestDeserializer extends JsonDeserializer<BlockRequest> {
-  private final ObjectMapper objectMapper;
 
-  public BlockRequestDeserializer(final ObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
+  public BlockRequestDeserializer() {
+
   }
 
   @Override
   public BlockRequest deserialize(final JsonParser p, final DeserializationContext ctxt)
       throws IOException {
-    final JsonNode node = p.getCodec().readTree(p);
+    final ObjectCodec codec = p.getCodec();
+    final JsonNode node = codec.readTree(p);
     final SpecMilestone specMilestone = SpecMilestone.valueOf(node.findValue("version").asText());
     final BeaconBlock beaconBlock;
     switch (specMilestone) {
       case ALTAIR:
-        beaconBlock = objectMapper.treeToValue(node.findValue("block"), BeaconBlockAltair.class);
+        beaconBlock = codec.treeToValue(node.findValue("block"), BeaconBlockAltair.class);
         break;
       case PHASE0:
-        beaconBlock = objectMapper.treeToValue(node.findValue("block"), BeaconBlock.class);
+        beaconBlock = codec.treeToValue(node.findValue("block"), BeaconBlock.class);
         break;
       default:
         throw new IOException("Unsupported Milestone during deserialization: " + specMilestone);

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/json/BlockRequestDeserializer.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/json/BlockRequestDeserializer.java
@@ -12,7 +12,6 @@
  */
 package tech.pegasys.web3signer.core.service.http.handlers.signing.eth2.json;
 
-import com.fasterxml.jackson.core.ObjectCodec;
 import tech.pegasys.teku.api.schema.BeaconBlock;
 import tech.pegasys.teku.api.schema.altair.BeaconBlockAltair;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -21,16 +20,14 @@ import tech.pegasys.web3signer.core.service.http.handlers.signing.eth2.BlockRequ
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class BlockRequestDeserializer extends JsonDeserializer<BlockRequest> {
 
-  public BlockRequestDeserializer() {
-
-  }
+  public BlockRequestDeserializer() {}
 
   @Override
   public BlockRequest deserialize(final JsonParser p, final DeserializationContext ctxt)

--- a/core/src/main/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractor.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/util/OpenApiSpecsExtractor.java
@@ -28,8 +28,8 @@ import java.util.stream.Stream;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.tuweni.io.Resources;
@@ -41,8 +41,8 @@ import org.apache.tuweni.io.Resources;
  */
 public class OpenApiSpecsExtractor {
   private static final String OPENAPI_RESOURCES_ROOT = "openapi-specs";
-  private static final ObjectMapper objectMapper =
-      new ObjectMapper(new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
+  private static final ObjectMapper yamlMapper =
+      YAMLMapper.builder().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER).build();
 
   private final Path destinationDirectory;
   private final List<Path> destinationSpecPaths;
@@ -84,11 +84,11 @@ public class OpenApiSpecsExtractor {
               try {
                 // load openapi yaml in a map
                 final Map<String, Object> yamlMap =
-                    objectMapper.readValue(
+                    yamlMapper.readValue(
                         path.toFile(), new TypeReference<HashMap<String, Object>>() {});
                 fixRelativePathInOpenApiMap(path, yamlMap);
                 // write map back as yaml
-                objectMapper.writerWithDefaultPrettyPrinter().writeValue(path.toFile(), yamlMap);
+                yamlMapper.writerWithDefaultPrettyPrinter().writeValue(path.toFile(), yamlMap);
 
               } catch (final IOException e) {
                 throw new UncheckedIOException(e);

--- a/core/src/test/java/tech/pegasys/web3signer/core/multikey/SignerLoaderTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/multikey/SignerLoaderTest.java
@@ -42,7 +42,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
@@ -56,7 +56,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class SignerLoaderTest {
-  private static final ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+  private static final ObjectMapper YAML_OBJECT_MAPPER = YAMLMapper.builder().build();
   @TempDir Path configsDirectory;
   @Mock private SignerParser signerParser;
 

--- a/core/src/test/java/tech/pegasys/web3signer/core/multikey/metadata/InterlockSigningMetadataFileParsingTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/multikey/metadata/InterlockSigningMetadataFileParsingTest.java
@@ -14,7 +14,7 @@ package tech.pegasys.web3signer.core.multikey.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static tech.pegasys.web3signer.core.multikey.metadata.parser.YamlSignerParser.OBJECT_MAPPER;
+import static tech.pegasys.web3signer.core.multikey.metadata.parser.YamlSignerParser.YAML_MAPPER;
 
 import tech.pegasys.web3signer.core.signing.KeyType;
 
@@ -33,8 +33,7 @@ class InterlockSigningMetadataFileParsingTest {
   void yamlFileIsSuccessfullyParsed() throws IOException {
     final URL testFile = Resources.getResource("interlock_test.yaml");
 
-    final SigningMetadata signingMetadata =
-        OBJECT_MAPPER.readValue(testFile, SigningMetadata.class);
+    final SigningMetadata signingMetadata = YAML_MAPPER.readValue(testFile, SigningMetadata.class);
 
     assertThat(signingMetadata).isInstanceOf(InterlockSigningMetadata.class);
 
@@ -52,7 +51,7 @@ class InterlockSigningMetadataFileParsingTest {
     final URL testFile = Resources.getResource("interlock_incomplete.yaml");
 
     assertThatExceptionOfType(JsonMappingException.class)
-        .isThrownBy(() -> OBJECT_MAPPER.readValue(testFile, SigningMetadata.class))
+        .isThrownBy(() -> YAML_MAPPER.readValue(testFile, SigningMetadata.class))
         .withMessageContaining("Missing required creator property 'volume'");
   }
 }

--- a/core/src/test/java/tech/pegasys/web3signer/core/multikey/metadata/YubiHsmSigningMetadataFileParsingTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/multikey/metadata/YubiHsmSigningMetadataFileParsingTest.java
@@ -14,7 +14,7 @@ package tech.pegasys.web3signer.core.multikey.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static tech.pegasys.web3signer.core.multikey.metadata.parser.YamlSignerParser.OBJECT_MAPPER;
+import static tech.pegasys.web3signer.core.multikey.metadata.parser.YamlSignerParser.YAML_MAPPER;
 
 import tech.pegasys.web3signer.core.signing.KeyType;
 
@@ -33,8 +33,7 @@ class YubiHsmSigningMetadataFileParsingTest {
   void yamlFileWithRequiredValuesIsSuccessfullyParsed() throws IOException {
     final URL testFile = Resources.getResource("yubihsm_required.yaml");
 
-    final SigningMetadata signingMetadata =
-        OBJECT_MAPPER.readValue(testFile, SigningMetadata.class);
+    final SigningMetadata signingMetadata = YAML_MAPPER.readValue(testFile, SigningMetadata.class);
 
     assertThat(signingMetadata).isInstanceOf(YubiHsmSigningMetadata.class);
 
@@ -51,8 +50,7 @@ class YubiHsmSigningMetadataFileParsingTest {
   void yamlFileWithCompleteValuesIsSuccessfullyParsed() throws IOException {
     final URL testFile = Resources.getResource("yubihsm_complete.yaml");
 
-    final SigningMetadata signingMetadata =
-        OBJECT_MAPPER.readValue(testFile, SigningMetadata.class);
+    final SigningMetadata signingMetadata = YAML_MAPPER.readValue(testFile, SigningMetadata.class);
 
     assertThat(signingMetadata).isInstanceOf(YubiHsmSigningMetadata.class);
 
@@ -70,7 +68,7 @@ class YubiHsmSigningMetadataFileParsingTest {
     final URL testFile = Resources.getResource("yubihsm_incomplete.yaml");
 
     assertThatExceptionOfType(JsonMappingException.class)
-        .isThrownBy(() -> OBJECT_MAPPER.readValue(testFile, SigningMetadata.class))
+        .isThrownBy(() -> YAML_MAPPER.readValue(testFile, SigningMetadata.class))
         .withMessageContaining("Missing required creator property 'connectorUrl'");
   }
 }

--- a/core/src/test/java/tech/pegasys/web3signer/core/multikey/metadata/parser/YamlSignerParserTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/multikey/metadata/parser/YamlSignerParserTest.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +56,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class YamlSignerParserTest {
 
-  private static final ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+  private static final ObjectMapper YAML_OBJECT_MAPPER = YAMLMapper.builder().build();
   private static final String PRIVATE_KEY =
       "3ee2224386c82ffea477e2adf28a2929f5c349165a4196158c7f3a2ecca40f35";
 

--- a/slashing-protection/referencetests/src/test/java/tech/pegasys/web3signer/slashingprotection/ReferenceTestRunner.java
+++ b/slashing-protection/referencetests/src/test/java/tech/pegasys/web3signer/slashingprotection/ReferenceTestRunner.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.io.Resources;
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
 import dsl.SignedArtifacts;
@@ -57,9 +58,10 @@ public class ReferenceTestRunner {
   private static final String PASSWORD = "postgres";
 
   private static final ObjectMapper objectMapper =
-      new ObjectMapper()
-          .registerModule(new InterchangeModule())
-          .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+      JsonMapper.builder()
+          .addModule(new InterchangeModule())
+          .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+          .build();
   private final ValidatorsDao validators = new ValidatorsDao();
 
   private EmbeddedPostgres slashingDatabase;

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/IntegrationTestBase.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/IntegrationTestBase.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
 import dsl.TestSlashingProtectionParameters;
 import org.apache.tuweni.bytes.Bytes;
@@ -42,7 +43,8 @@ import org.junit.jupiter.api.BeforeEach;
 
 public class IntegrationTestBase {
 
-  protected final ObjectMapper mapper = new ObjectMapper().registerModule(new InterchangeModule());
+  protected final ObjectMapper mapper =
+      JsonMapper.builder().addModule(new InterchangeModule()).build();
 
   protected final ValidatorsDao validators = new ValidatorsDao();
   protected final LowWatermarkDao lowWatermarkDao = new LowWatermarkDao();

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -37,8 +37,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import org.apache.logging.log4j.LogManager;
@@ -112,10 +112,11 @@ public class DbSlashingProtection implements SlashingProtection {
             signedAttestationsDao,
             metadataDao,
             lowWatermarkDao,
-            new ObjectMapper()
-                .registerModule(new InterchangeModule())
+            JsonMapper.builder()
+                .addModule(new InterchangeModule())
                 .configure(FLUSH_AFTER_WRITE_VALUE, true)
-                .enable(SerializationFeature.INDENT_OUTPUT));
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                .build());
     this.dbPruner =
         new DbPruner(pruningJdbi, signedBlocksDao, signedAttestationsDao, lowWatermarkDao);
     this.pruningEpochsToKeep = pruningEpochsToKeep;

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/interchange/model/MetadataTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/interchange/model/MetadataTest.java
@@ -20,19 +20,22 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 
 class MetadataTest {
 
-  private final ObjectMapper mapper = new ObjectMapper().registerModule(new InterchangeModule());
+  private final ObjectMapper mapper =
+      JsonMapper.builder().addModule(new InterchangeModule()).build();
 
   @Test
   @SuppressWarnings("unchecked")
   void metadataHasCorrectlyNamedFields() throws JsonProcessingException {
     final Metadata medataData = new Metadata("5", Bytes.fromHexString("0x123456"));
     final String jsonOutput = mapper.writeValueAsString(medataData);
-    final Map<String, String> jsonContent = new ObjectMapper().readValue(jsonOutput, Map.class);
+    final Map<String, String> jsonContent =
+        JsonMapper.builder().build().readValue(jsonOutput, Map.class);
 
     assertThat(jsonContent.get("interchange_format_version"))
         .isEqualTo(medataData.getFormatVersion());

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/interchange/model/SignedAttestationTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/interchange/model/SignedAttestationTest.java
@@ -20,13 +20,15 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.junit.jupiter.api.Test;
 
 class SignedAttestationTest {
 
-  private final ObjectMapper mapper = new ObjectMapper().registerModule(new InterchangeModule());
+  private final ObjectMapper mapper =
+      JsonMapper.builder().addModule(new InterchangeModule()).build();
 
   @Test
   @SuppressWarnings("unchecked")
@@ -35,7 +37,8 @@ class SignedAttestationTest {
         new SignedAttestation(UInt64.valueOf(1), UInt64.valueOf(2), Bytes.fromHexString("0x01"));
 
     final String jsonOutput = mapper.writeValueAsString(attestation);
-    final Map<String, String> jsonContent = new ObjectMapper().readValue(jsonOutput, Map.class);
+    final Map<String, String> jsonContent =
+        JsonMapper.builder().build().readValue(jsonOutput, Map.class);
 
     assertThat(jsonContent.get("source_epoch")).isEqualTo(attestation.getSourceEpoch().toString());
     assertThat(jsonContent.get("target_epoch")).isEqualTo(attestation.getTargetEpoch().toString());
@@ -51,7 +54,8 @@ class SignedAttestationTest {
 
     final String jsonOutput = mapper.writeValueAsString(attestation);
 
-    final Map<String, String> jsonContent = new ObjectMapper().readValue(jsonOutput, Map.class);
+    final Map<String, String> jsonContent =
+        JsonMapper.builder().build().readValue(jsonOutput, Map.class);
 
     assertThat(jsonContent.keySet()).doesNotContain("signing_root");
   }

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/interchange/model/SignedBlockTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/interchange/model/SignedBlockTest.java
@@ -20,13 +20,15 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.junit.jupiter.api.Test;
 
 class SignedBlockTest {
 
-  private final ObjectMapper mapper = new ObjectMapper().registerModule(new InterchangeModule());
+  private final ObjectMapper mapper =
+      JsonMapper.builder().addModule(new InterchangeModule()).build();
 
   @Test
   @SuppressWarnings("unchecked")
@@ -35,7 +37,8 @@ class SignedBlockTest {
 
     final String jsonOutput = mapper.writeValueAsString(block);
 
-    final Map<String, String> jsonContent = new ObjectMapper().readValue(jsonOutput, Map.class);
+    final Map<String, String> jsonContent =
+        JsonMapper.builder().build().readValue(jsonOutput, Map.class);
 
     assertThat(jsonContent.get("slot")).isEqualTo(block.getSlot().toString());
     assertThat(jsonContent.get("signing_root")).isEqualTo(block.getSigningRoot().toHexString());
@@ -48,7 +51,8 @@ class SignedBlockTest {
 
     final String jsonOutput = mapper.writeValueAsString(block);
 
-    final Map<String, String> jsonContent = new ObjectMapper().readValue(jsonOutput, Map.class);
+    final Map<String, String> jsonContent =
+        JsonMapper.builder().build().readValue(jsonOutput, Map.class);
 
     assertThat(jsonContent.keySet()).doesNotContain("signing_root");
   }


### PR DESCRIPTION
* Fix jackson deprecation warnings
* Additional Jackson mapper builder changes to align with the deprecation fixes
  * Migrate new ObjectMapper to JsonMapper.builder() or YamlMapper.builder() as appropriate
  * Use addModule instead of registerModule