### PR TITLE
docker multi architecture signing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,12 +58,18 @@ executors:
     machine:
       image: ubuntu-2004:202101-01
     resource_class: arm.medium
+    environment:
+      architecture: "arm64"
+      platform: "linux/arm64"
 
   machine_executor_amd64:
     machine:
       image: ubuntu-2004:202008-01 #Ubuntu 20.04, docker 19.03, docker-compose 1.27.4
       docker_layer_caching: true
     working_directory: ~/project
+    environment:
+      architecture: "amd64"
+      platform: "linux/amd64"
 
 commands:
   prepare:
@@ -116,17 +122,7 @@ commands:
           path: build/test-reports
           destination: test-reports
 
-  install_docker_buildx:
-    description: "Install Docker buildx plugin"
-    steps:
-      - run:
-          name: "Install Docker buildx plugin"
-          command: |
-            mkdir -vp ~/.docker/cli-plugins/
-            curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
-
-  sign_docker_images:
+  docker_trust_sign:
     description: "Sign docker images"
     steps:
       - run:
@@ -138,7 +134,15 @@ commands:
             echo $DCT_KEY | base64 --decode > $HOME/.docker/trust/private/$DCT_HASH.key
             chmod 600 $HOME/.docker/trust/private/$DCT_HASH.key
             docker trust key load $HOME/.docker/trust/private/$DCT_HASH.key --name opsquorum
-            ./gradlew --no-daemon --parallel "-Pbranch=${CIRCLE_BRANCH}" dockerContentTrust
+
+  docker_publish_images:
+    description: "Upload the docker images"
+    steps:
+      - run:
+          name: "Publish Docker Images"
+          command: |
+            docker login --username "${DOCKER_USER_RW}" --password "${DOCKER_PASSWORD_RW}"
+            ./gradlew --no-daemon --parallel "-Pbranch=${CIRCLE_BRANCH}" uploadDocker
 
   notify:
     description: "Notify Slack"
@@ -243,42 +247,35 @@ jobs:
             ./gradlew --no-daemon --parallel "-Pbranch=${CIRCLE_BRANCH}" testDocker
       - notify
 
-  publishDocker:
+  publishDockerAmd64:
     executor: machine_executor_amd64
     steps:
       - prepare
       - attach_workspace:
           at: ~/project
-      - install_docker_buildx
-      - run:
-          name: Configure Buildx for Multi-Arch
-          command: |
-            docker run --rm --privileged tonistiigi/binfmt:latest --install "linux/amd64,linux/arm64"
-            docker buildx create --use --driver docker-container
-      - run:
-          name: Publish Docker
-          command: |
-            docker login --username "${DOCKER_USER_RW}" --password "${DOCKER_PASSWORD_RW}"
-            ./gradlew --no-daemon --parallel "-Pbranch=${CIRCLE_BRANCH}" dockerUpload
-
+      - docker_trust_sign
+      - docker_publish_images
       - notify
 
-  signDockerAmd64:
-    executor: machine_executor_amd64
-    steps:
-      - prepare
-      - attach_workspace:
-          at: ~/project
-      - sign_docker_images
-      - notify
-
-  signDockerArm64:
+  publishDockerArm64:
     executor: machine_executor_arm64
     steps:
       - prepare
       - attach_workspace:
           at: ~/project
-      - sign_docker_images
+      - docker_trust_sign
+      - docker_publish_images
+      - notify
+
+  manifestDocker:
+    executor: executor_med
+    steps:
+      - prepare
+      - docker_trust_sign
+      - run:
+          name: Create and publish docker manifest
+          command: |
+            ./gradlew --no-daemon --parallel manifestDocker
       - notify
 
   publishOpenApiSpec:
@@ -364,7 +361,7 @@ workflows:
           filters:
             tags:
               <<: *filters-release-tags
-      - publishDocker:
+      - publishDockerAmd64:
           filters:
             branches:
               only:
@@ -377,7 +374,8 @@ workflows:
             - buildDocker
           context:
             - dockerhub-quorumengineering-rw
-      - signDockerAmd64:
+            - dockerhub-opsquorum-dct            
+      - publishDockerArm64:
           filters:
             branches:
               only:
@@ -386,21 +384,22 @@ workflows:
             tags:
               <<: *filters-release-tags
           requires:
-            - publishDocker
+            - acceptanceTests
+            - buildDocker
           context:
             - dockerhub-quorumengineering-rw
-            - dockerhub-opsquorum-dct
-      - signDockerArm64:
+            - dockerhub-opsquorum-dct        
+      - manifestDocker:
           filters:
             branches:
               only:
                 - master
                 - /^release-.*/
-                - dct3
             tags:
               <<: *filters-release-tags
-#          requires:
-#            - publishDocker
+          requires:
+            - publishDockerArm64
+            - publishDockerAmd64
           context:
             - dockerhub-quorumengineering-rw
-            - dockerhub-opsquorum-dct
+            - dockerhub-opsquorum-dct         

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ build/
 out/
 docker/reports/*
 .vscode
+.lh/*

--- a/build.gradle
+++ b/build.gradle
@@ -431,9 +431,8 @@ tasks.register("dockerDistUntar") {
   }
 }
 
-def dockerImageName = "consensys/web3signer"
-def dockerVariants = ["jdk17", "jdk11",]
-def dockerPlatforms = "linux/amd64,linux/arm64"
+def dockerImage = "consensys/web3signer"
+def dockerJdkVariants = ["jdk17", "jdk11",]
 def dockerBuildDir = "build/docker-web3signer/"
 
 task distDocker  {
@@ -441,13 +440,13 @@ task distDocker  {
 
   def dockerBuildVersion = 'develop'
   doLast {
-    for (def variant in dockerVariants) {
+    for (def variant in dockerJdkVariants) {
       copy {
         from file("${projectDir}/docker/${variant}/Dockerfile")
         into(dockerBuildDir)
       }
       exec {
-        def image = "${dockerImageName}:${dockerBuildVersion}-${variant}"
+        def image = "${dockerImage}:${dockerBuildVersion}-${variant}"
         workingDir dockerBuildDir
         executable "sh"
         args "-c", "docker build --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
@@ -456,7 +455,7 @@ task distDocker  {
     // tag the "default" (which is the variant in the zero position)
     exec {
       executable "sh"
-      args "-c", "docker tag '${dockerImageName}:${dockerBuildVersion}-${dockerVariants[0]}' '${dockerImageName}:${dockerBuildVersion}'"
+      args "-c", "docker tag '${dockerImage}:${dockerBuildVersion}-${dockerJdkVariants[0]}' '${dockerImage}:${dockerBuildVersion}'"
     }
   }
 }
@@ -472,14 +471,16 @@ task testDocker {
     exec {
       workingDir "docker"
       executable "sh"
-      args "-c", "sh ./test.sh '${dockerImageName}:${dockerBuildVersion}'"
+      args "-c", "sh ./test.sh '${dockerImage}:${dockerBuildVersion}'"
     }
   }
 }
 
-task dockerUpload {
+task uploadDocker {
   dependsOn([distDocker])
   def dockerBuildVersion = "${rootProject.version}".replace('+', '-')
+  def architecture = System.getenv('architecture')
+  def platform = System.getenv('platform')
 
   def versionPrefixes = [dockerBuildVersion]
   if (project.hasProperty('branch') && project.property('branch') == 'master') {
@@ -492,11 +493,12 @@ task dockerUpload {
   }
 
   doLast {
-    for (def variant in dockerVariants) {
+    for (def variant in dockerJdkVariants) {
       def tags = ""
-      versionPrefixes.forEach { prefix -> tags += "-t ${dockerImageName}:${prefix.trim()}-${variant} "}
-      if (variant == dockerVariants[0]) {
-        versionPrefixes.forEach { prefix -> tags += "-t ${dockerImageName}:${prefix.trim()} "}
+      versionPrefixes.forEach { prefix -> tags += "-t ${dockerImage}:${prefix.trim()}-${variant}-${architecture} "}
+
+      if (variant == dockerJdkVariants[0]) {
+        versionPrefixes.forEach { prefix -> tags += "-t ${dockerImage}:${prefix.trim()}-${architecture} "}
       }
 
       copy {
@@ -507,16 +509,27 @@ task dockerUpload {
       exec {
         workingDir dockerBuildDir
         executable "sh"
-        args "-c", "docker buildx build --platform ${dockerPlatforms} --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} --push ${tags} ."
+        args "-c", "docker build --platform ${platform} --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} ${tags} ."
+      }
+
+      //docker trust sign runs one image at a time, so we have to remove the '-t' in the string and split into a list we can use
+      def trustTags = tags.replaceAll( '-t ', '' ).trim().split(' ')
+      for (def t in trustTags) {
+        exec {
+          workingDir dockerBuildDir
+          executable "sh"
+          args "-c", "docker trust sign ${t} && docker push ${t} "
+        }
       }
     }
   }
 }
 
-task dockerContentTrust {
+task manifestDocker {
   def dockerBuildVersion = "${rootProject.version}".replace('+', '-')
-
   def versionPrefixes = [dockerBuildVersion]
+  def platforms = ["arm64", "amd64"]
+
   if (project.hasProperty('branch') && project.property('branch') == 'master') {
     versionPrefixes.add('develop')
   }
@@ -527,21 +540,20 @@ task dockerContentTrust {
   }
 
   doLast {
-    for (def variant in dockerVariants) {
-      def dctTags = []
-      versionPrefixes.forEach { prefix ->
-        dctTags.add("${dockerImageName}:${prefix.trim()}-${variant}")
-      }
-      if (variant == dockerVariants[0]) {
-        versionPrefixes.forEach { prefix ->
-          dctTags.add("${dockerImageName}:${prefix.trim()}")
-        }
+    for (def variant in dockerJdkVariants) {
+      def tags = []
+      def cmd = ""
+      versionPrefixes.forEach { prefix -> tags.add("${dockerImage}:${prefix.trim()}-${variant}") }
+
+      if (variant == dockerJdkVariants[0]) {
+        versionPrefixes.forEach { prefix -> tags.add("${dockerImage}:${prefix.trim()}") }
       }
 
-      for (def tag in dctTags) {
+      for (def tag in tags) {
+        platforms.forEach { platform -> cmd += "${tag}-${platform} " }
         exec {
           executable "sh"
-          args "-c", "docker pull ${tag} && docker trust sign ${tag} "
+          args "-c", "docker manifest create ${tag} ${cmd} && docker manifest push ${tag}"
         }
       }
     }


### PR DESCRIPTION
Buildx doesn't allow for signing multi architecture images, so have removed it. In its stead the docker build job now runs on an ARM and AMD executor and builds, signs and pushes the image with the architecture in the tag as well. The final step is a manifest create and push which manually creates the manifest from the multiarch tags and then pushes that manifest out

Refer images here https://hub.docker.com/repository/docker/consensys/dctweb3signer