### PR TITLE
Add alias for old key manager flag

### DIFF
--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
@@ -72,7 +72,7 @@ public class Eth2SubCommand extends ModeSubCommand {
   private UInt64 bellatrixForkEpoch;
 
   @CommandLine.Option(
-      names = {"--key-manager-api-enabled"},
+      names = {"--key-manager-api-enabled", "--enable-key-manager-api"},
       paramLabel = "<BOOL>",
       description = "Enable the key manager API to manage key stores (default: ${DEFAULT-VALUE}).",
       arity = "1")


### PR DESCRIPTION
Add an alias for old key manager flag "--enable-key-manager-api=true" as the old flag went out in a release and there are people still using the old flag.