### PR TITLE
Incremental slashing db export

### DIFF
--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ExportSubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ExportSubCommand.java
@@ -65,7 +65,7 @@ public class Eth2ExportSubCommand implements Runnable {
       final SlashingProtection slashingProtection =
           createSlashingProtection(eth2Config.getSlashingProtectionParameters());
 
-      slashingProtection.export(outStream);
+      slashingProtection.exportData(outStream);
     } catch (final IOException e) {
       throw new UncheckedIOException("Unable to find output target file", e);
     } catch (final IllegalStateException e) {

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessor.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessor.java
@@ -122,9 +122,9 @@ public class DeleteKeystoresProcessor {
       try {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final SlashingProtection slashingProtection = this.slashingProtection.get();
-        slashingProtection.initialiseIncrementalExport(outputStream);
-        keysToExport.forEach(slashingProtection::addPublicKeyToIncrementalExport);
-        slashingProtection.finaliseIncrementalExport();
+        slashingProtection.exportIncrementallyBegin(outputStream);
+        keysToExport.forEach(slashingProtection::exportIncrementally);
+        slashingProtection.exportIncrementallyFinish();
         slashingProtectionExport = outputStream.toString(StandardCharsets.UTF_8);
       } catch (Exception e) {
         LOG.error("Failed to export slashing data", e);

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessor.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessor.java
@@ -125,7 +125,7 @@ public class DeleteKeystoresProcessor {
         final SlashingProtection slashingProtection = this.slashingProtection.get();
         try (IncrementalExporter incrementalExporter =
             slashingProtection.createIncrementalExporter(outputStream)) {
-          keysToExport.forEach(incrementalExporter::addPublicKey);
+          keysToExport.forEach(incrementalExporter::export);
           incrementalExporter.finalise();
         }
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessor.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessor.java
@@ -17,6 +17,7 @@ import tech.pegasys.web3signer.core.signing.ArtifactSignerProvider;
 import tech.pegasys.web3signer.core.signing.BlsArtifactSigner;
 import tech.pegasys.web3signer.core.util.IdentifierUtils;
 import tech.pegasys.web3signer.slashingprotection.SlashingProtection;
+import tech.pegasys.web3signer.slashingprotection.interchange.IncrementalExporter;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -122,9 +123,12 @@ public class DeleteKeystoresProcessor {
       try {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         final SlashingProtection slashingProtection = this.slashingProtection.get();
-        slashingProtection.exportIncrementallyBegin(outputStream);
-        keysToExport.forEach(slashingProtection::exportIncrementally);
-        slashingProtection.exportIncrementallyFinish();
+        try (IncrementalExporter incrementalExporter =
+            slashingProtection.createIncrementalExporter(outputStream)) {
+          keysToExport.forEach(incrementalExporter::addPublicKey);
+          incrementalExporter.finalise();
+        }
+
         slashingProtectionExport = outputStream.toString(StandardCharsets.UTF_8);
       } catch (Exception e) {
         LOG.error("Failed to export slashing data", e);

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessor.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessor.java
@@ -121,7 +121,10 @@ public class DeleteKeystoresProcessor {
     if (slashingProtection.isPresent()) {
       try {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        slashingProtection.get().exportWithFilter(outputStream, keysToExport);
+        final SlashingProtection slashingProtection = this.slashingProtection.get();
+        slashingProtection.initialiseIncrementalExport(outputStream);
+        keysToExport.forEach(slashingProtection::addPublicKeyToIncrementalExport);
+        slashingProtection.finaliseIncrementalExport();
         slashingProtectionExport = outputStream.toString(StandardCharsets.UTF_8);
       } catch (Exception e) {
         LOG.error("Failed to export slashing data", e);

--- a/core/src/test/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessorTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessorTest.java
@@ -131,9 +131,7 @@ class DeleteKeystoresProcessorTest {
     when(artifactSignerProvider.removeSigner(any()))
         .thenReturn(CompletableFuture.completedFuture(null));
     doNothing().when(keystoreFileManager).deleteKeystoreFiles(any());
-    doThrow(new RuntimeException("db error"))
-        .when(slashingProtection)
-        .addPublicKeyToIncrementalExport(any());
+    doThrow(new RuntimeException("db error")).when(slashingProtection).exportIncrementally(any());
 
     final DeleteKeystoresRequestBody requestBody =
         new DeleteKeystoresRequestBody(List.of(PUBLIC_KEY));

--- a/core/src/test/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessorTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessorTest.java
@@ -133,7 +133,7 @@ class DeleteKeystoresProcessorTest {
     doNothing().when(keystoreFileManager).deleteKeystoreFiles(any());
     doThrow(new RuntimeException("db error"))
         .when(slashingProtection)
-        .exportWithFilter(any(), any());
+        .addPublicKeyToIncrementalExport(any());
 
     final DeleteKeystoresRequestBody requestBody =
         new DeleteKeystoresRequestBody(List.of(PUBLIC_KEY));

--- a/core/src/test/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessorTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessorTest.java
@@ -134,7 +134,7 @@ class DeleteKeystoresProcessorTest {
     when(artifactSignerProvider.removeSigner(any()))
         .thenReturn(CompletableFuture.completedFuture(null));
     doNothing().when(keystoreFileManager).deleteKeystoreFiles(any());
-    doThrow(new RuntimeException("db error")).when(incrementalExporter).addPublicKey(any());
+    doThrow(new RuntimeException("db error")).when(incrementalExporter).export(any());
 
     final DeleteKeystoresRequestBody requestBody =
         new DeleteKeystoresRequestBody(List.of(PUBLIC_KEY));

--- a/core/src/test/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessorTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessorTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import tech.pegasys.web3signer.core.signing.ArtifactSigner;
 import tech.pegasys.web3signer.core.signing.ArtifactSignerProvider;
 import tech.pegasys.web3signer.slashingprotection.SlashingProtection;
+import tech.pegasys.web3signer.slashingprotection.interchange.IncrementalExporter;
 
 import java.io.IOException;
 import java.util.List;
@@ -43,6 +44,7 @@ class DeleteKeystoresProcessorTest {
   @Mock SlashingProtection slashingProtection;
   @Mock ArtifactSignerProvider artifactSignerProvider;
   @Mock ArtifactSigner signer;
+  @Mock IncrementalExporter incrementalExporter;
 
   DeleteKeystoresProcessor processor;
 
@@ -51,6 +53,7 @@ class DeleteKeystoresProcessorTest {
     processor =
         new DeleteKeystoresProcessor(
             keystoreFileManager, Optional.of(slashingProtection), artifactSignerProvider);
+    when(slashingProtection.createIncrementalExporter(any())).thenReturn(incrementalExporter);
   }
 
   @Test
@@ -131,7 +134,7 @@ class DeleteKeystoresProcessorTest {
     when(artifactSignerProvider.removeSigner(any()))
         .thenReturn(CompletableFuture.completedFuture(null));
     doNothing().when(keystoreFileManager).deleteKeystoreFiles(any());
-    doThrow(new RuntimeException("db error")).when(slashingProtection).exportIncrementally(any());
+    doThrow(new RuntimeException("db error")).when(incrementalExporter).addPublicKey(any());
 
     final DeleteKeystoresRequestBody requestBody =
         new DeleteKeystoresRequestBody(List.of(PUBLIC_KEY));

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeExportIntegrationTestBase.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeExportIntegrationTestBase.java
@@ -125,7 +125,7 @@ public class InterchangeExportIntegrationTestBase extends IntegrationTestBase {
     final IncrementalExporter incrementalExporter =
         slashingProtection.createIncrementalExporter(exportOutput);
     for (int i = 0; i < VALIDATOR_COUNT; i += 2) {
-      incrementalExporter.addPublicKey(String.format("0x0%x", i + 1));
+      incrementalExporter.export(String.format("0x0%x", i + 1));
     }
     incrementalExporter.finalise();
     incrementalExporter.close();

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeExportIntegrationTestBase.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeExportIntegrationTestBase.java
@@ -100,7 +100,7 @@ public class InterchangeExportIntegrationTestBase extends IntegrationTestBase {
     final SlashingProtection slashingProtection =
         SlashingProtectionFactory.createSlashingProtection(
             new TestSlashingProtectionParameters(databaseUrl, "postgres", "postgres"));
-    assertThatThrownBy(() -> slashingProtection.export(exportOutput))
+    assertThatThrownBy(() -> slashingProtection.exportData(exportOutput))
         .hasMessage("No genesis validators root for slashing protection data")
         .isInstanceOf(RuntimeException.class);
     exportOutput.close();
@@ -179,7 +179,7 @@ public class InterchangeExportIntegrationTestBase extends IntegrationTestBase {
 
   private InterchangeV5Format getExportObjectFromDatabase() throws IOException {
     final OutputStream exportOutput = new ByteArrayOutputStream();
-    slashingProtection.export(exportOutput);
+    slashingProtection.exportData(exportOutput);
     exportOutput.close();
 
     return mapper.readValue(exportOutput.toString(), InterchangeV5Format.class);

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningRunnerIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningRunnerIntegrationTest.java
@@ -234,23 +234,23 @@ public class PruningRunnerIntegrationTest extends IntegrationTestBase {
     }
 
     @Override
-    public void exportWithFilter(OutputStream output, List<String> pubkeys) {
-      delegate.exportWithFilter(output, pubkeys);
+    public void exportDataWithFilter(OutputStream output, List<String> pubkeys) {
+      delegate.exportDataWithFilter(output, pubkeys);
     }
 
     @Override
-    public void initialiseIncrementalExport(final OutputStream out) throws IOException {
-      delegate.initialiseIncrementalExport(out);
+    public void exportIncrementallyBegin(final OutputStream out) throws IOException {
+      delegate.exportIncrementallyBegin(out);
     }
 
     @Override
-    public void addPublicKeyToIncrementalExport(final String pubkey) {
-      delegate.addPublicKeyToIncrementalExport(pubkey);
+    public void exportIncrementally(final String pubkey) {
+      delegate.exportIncrementally(pubkey);
     }
 
     @Override
-    public void finaliseIncrementalExport() throws IOException {
-      delegate.finaliseIncrementalExport();
+    public void exportIncrementallyFinish() throws IOException {
+      delegate.exportIncrementallyFinish();
     }
 
     @Override

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningRunnerIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningRunnerIntegrationTest.java
@@ -16,6 +16,7 @@ import static db.DatabaseUtil.PASSWORD;
 import static db.DatabaseUtil.USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.time.LocalDateTime;
@@ -228,13 +229,28 @@ public class PruningRunnerIntegrationTest extends IntegrationTestBase {
     }
 
     @Override
-    public void export(final OutputStream output) {
-      delegate.export(output);
+    public void exportData(final OutputStream output) {
+      delegate.exportData(output);
     }
 
     @Override
     public void exportWithFilter(OutputStream output, List<String> pubkeys) {
       delegate.exportWithFilter(output, pubkeys);
+    }
+
+    @Override
+    public void initialiseIncrementalExport(final OutputStream out) throws IOException {
+      delegate.initialiseIncrementalExport(out);
+    }
+
+    @Override
+    public void addPublicKeyToIncrementalExport(final String pubkey) {
+      delegate.addPublicKeyToIncrementalExport(pubkey);
+    }
+
+    @Override
+    public void finaliseIncrementalExport() throws IOException {
+      delegate.finaliseIncrementalExport();
     }
 
     @Override

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningRunnerIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningRunnerIntegrationTest.java
@@ -16,7 +16,8 @@ import static db.DatabaseUtil.PASSWORD;
 import static db.DatabaseUtil.USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
+import tech.pegasys.web3signer.slashingprotection.interchange.IncrementalExporter;
+
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.time.LocalDateTime;
@@ -239,18 +240,8 @@ public class PruningRunnerIntegrationTest extends IntegrationTestBase {
     }
 
     @Override
-    public void exportIncrementallyBegin(final OutputStream out) throws IOException {
-      delegate.exportIncrementallyBegin(out);
-    }
-
-    @Override
-    public void exportIncrementally(final String pubkey) {
-      delegate.exportIncrementally(pubkey);
-    }
-
-    @Override
-    public void exportIncrementallyFinish() throws IOException {
-      delegate.exportIncrementallyFinish();
+    public IncrementalExporter createIncrementalExporter(final OutputStream out) {
+      return delegate.createIncrementalExporter(out);
     }
 
     @Override

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -173,7 +173,7 @@ public class DbSlashingProtection implements SlashingProtection {
       LOG.info("Exporting slashing protection database");
       interchangeManager.exportIncrementallyBegin(out);
     } catch (IOException e) {
-      throw new RuntimeException("Failed to initialise increment export of database content", e);
+      throw new RuntimeException("Failed to initialise incremental export of database content", e);
     }
   }
 
@@ -188,7 +188,7 @@ public class DbSlashingProtection implements SlashingProtection {
       interchangeManager.exportIncrementallyFinish();
       LOG.info("Export complete");
     } catch (IOException e) {
-      throw new RuntimeException("Failed to initialise increment export of database content", e);
+      throw new RuntimeException("Failed to finalise incremental export of database content", e);
     }
   }
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -146,10 +146,10 @@ public class DbSlashingProtection implements SlashingProtection {
   }
 
   @Override
-  public void export(final OutputStream output) {
+  public void exportData(final OutputStream output) {
     try {
       LOG.info("Exporting slashing protection database");
-      interchangeManager.export(output);
+      interchangeManager.exportData(output);
       LOG.info("Export complete");
     } catch (IOException e) {
       throw new RuntimeException("Failed to export database content", e);
@@ -164,6 +164,31 @@ public class DbSlashingProtection implements SlashingProtection {
       LOG.info("Export complete");
     } catch (IOException e) {
       throw new RuntimeException("Failed to export database content", e);
+    }
+  }
+
+  @Override
+  public void initialiseIncrementalExport(final OutputStream out) {
+    try {
+      LOG.info("Exporting slashing protection database");
+      interchangeManager.initialiseIncrementalExport(out);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to initialise increment export of database content", e);
+    }
+  }
+
+  @Override
+  public void addPublicKeyToIncrementalExport(final String pubkey) {
+    interchangeManager.addPublicKeyToIncrementalExport(pubkey);
+  }
+
+  @Override
+  public void finaliseIncrementalExport() {
+    try {
+      interchangeManager.finaliseIncrementalExport();
+      LOG.info("Export complete");
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to initialise increment export of database content", e);
     }
   }
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -157,10 +157,10 @@ public class DbSlashingProtection implements SlashingProtection {
   }
 
   @Override
-  public void exportWithFilter(final OutputStream output, final List<String> pubkeys) {
+  public void exportDataWithFilter(final OutputStream output, final List<String> pubkeys) {
     try {
       LOG.info("Exporting slashing protection database for keys: " + String.join(",", pubkeys));
-      interchangeManager.exportWithFilter(output, pubkeys);
+      interchangeManager.exportDataWithFilter(output, pubkeys);
       LOG.info("Export complete");
     } catch (IOException e) {
       throw new RuntimeException("Failed to export database content", e);
@@ -168,24 +168,24 @@ public class DbSlashingProtection implements SlashingProtection {
   }
 
   @Override
-  public void initialiseIncrementalExport(final OutputStream out) {
+  public void exportIncrementallyBegin(final OutputStream out) {
     try {
       LOG.info("Exporting slashing protection database");
-      interchangeManager.initialiseIncrementalExport(out);
+      interchangeManager.exportIncrementallyBegin(out);
     } catch (IOException e) {
       throw new RuntimeException("Failed to initialise increment export of database content", e);
     }
   }
 
   @Override
-  public void addPublicKeyToIncrementalExport(final String pubkey) {
-    interchangeManager.addPublicKeyToIncrementalExport(pubkey);
+  public void exportIncrementally(final String pubkey) {
+    interchangeManager.exportIncrementally(pubkey);
   }
 
   @Override
-  public void finaliseIncrementalExport() {
+  public void exportIncrementallyFinish() {
     try {
-      interchangeManager.finaliseIncrementalExport();
+      interchangeManager.exportIncrementallyFinish();
       LOG.info("Export complete");
     } catch (IOException e) {
       throw new RuntimeException("Failed to initialise increment export of database content", e);

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -23,6 +23,7 @@ import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlocksDao;
 import tech.pegasys.web3signer.slashingprotection.dao.Validator;
 import tech.pegasys.web3signer.slashingprotection.dao.ValidatorsDao;
+import tech.pegasys.web3signer.slashingprotection.interchange.IncrementalExporter;
 import tech.pegasys.web3signer.slashingprotection.interchange.InterchangeManager;
 import tech.pegasys.web3signer.slashingprotection.interchange.InterchangeModule;
 import tech.pegasys.web3signer.slashingprotection.interchange.InterchangeV5Manager;
@@ -168,27 +169,12 @@ public class DbSlashingProtection implements SlashingProtection {
   }
 
   @Override
-  public void exportIncrementallyBegin(final OutputStream out) {
+  public IncrementalExporter createIncrementalExporter(final OutputStream out) {
     try {
-      LOG.info("Exporting slashing protection database");
-      interchangeManager.exportIncrementallyBegin(out);
+      return interchangeManager.createIncrementalExporter(out);
     } catch (IOException e) {
-      throw new RuntimeException("Failed to initialise incremental export of database content", e);
-    }
-  }
-
-  @Override
-  public void exportIncrementally(final String pubkey) {
-    interchangeManager.exportIncrementally(pubkey);
-  }
-
-  @Override
-  public void exportIncrementallyFinish() {
-    try {
-      interchangeManager.exportIncrementallyFinish();
-      LOG.info("Export complete");
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to finalise incremental export of database content", e);
+      throw new RuntimeException(
+          "Failed to initialise incremental exporter for slashing protection data", e);
     }
   }
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtection.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.web3signer.slashingprotection;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
@@ -36,9 +37,15 @@ public interface SlashingProtection {
 
   boolean isRegisteredValidator(Bytes publicKey);
 
-  void export(OutputStream output);
+  void exportData(OutputStream output);
 
   void exportWithFilter(OutputStream output, List<String> pubkeys);
+
+  void initialiseIncrementalExport(final OutputStream out) throws IOException;
+
+  void addPublicKeyToIncrementalExport(final String pubkey);
+
+  void finaliseIncrementalExport() throws IOException;
 
   void importData(InputStream output);
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtection.java
@@ -12,7 +12,8 @@
  */
 package tech.pegasys.web3signer.slashingprotection;
 
-import java.io.IOException;
+import tech.pegasys.web3signer.slashingprotection.interchange.IncrementalExporter;
+
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
@@ -41,11 +42,7 @@ public interface SlashingProtection {
 
   void exportDataWithFilter(OutputStream output, List<String> pubkeys);
 
-  void exportIncrementallyBegin(final OutputStream out) throws IOException;
-
-  void exportIncrementally(final String pubkey);
-
-  void exportIncrementallyFinish() throws IOException;
+  IncrementalExporter createIncrementalExporter(OutputStream out);
 
   void importData(InputStream output);
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtection.java
@@ -39,13 +39,13 @@ public interface SlashingProtection {
 
   void exportData(OutputStream output);
 
-  void exportWithFilter(OutputStream output, List<String> pubkeys);
+  void exportDataWithFilter(OutputStream output, List<String> pubkeys);
 
-  void initialiseIncrementalExport(final OutputStream out) throws IOException;
+  void exportIncrementallyBegin(final OutputStream out) throws IOException;
 
-  void addPublicKeyToIncrementalExport(final String pubkey);
+  void exportIncrementally(final String pubkey);
 
-  void finaliseIncrementalExport() throws IOException;
+  void exportIncrementallyFinish() throws IOException;
 
   void importData(InputStream output);
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/IncrementalExporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/IncrementalExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ConsenSys AG.
+ * Copyright 2022 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,19 +13,13 @@
 package tech.pegasys.web3signer.slashingprotection.interchange;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.List;
 
-public interface InterchangeManager {
+public interface IncrementalExporter extends AutoCloseable {
 
-  void importData(InputStream in) throws IOException;
+  void addPublicKey(String publicKey);
 
-  void importDataWithFilter(InputStream in, List<String> pubkeys) throws IOException;
+  void finalise() throws IOException;
 
-  void exportData(OutputStream out) throws IOException;
-
-  void exportDataWithFilter(OutputStream output, List<String> pubkeys) throws IOException;
-
-  IncrementalExporter createIncrementalExporter(OutputStream out) throws IOException;
+  @Override
+  void close() throws Exception;
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/IncrementalExporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/IncrementalExporter.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 
 public interface IncrementalExporter extends AutoCloseable {
 
-  void addPublicKey(String publicKey);
+  void export(String publicKey);
 
   void finalise() throws IOException;
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeManager.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeManager.java
@@ -23,7 +23,13 @@ public interface InterchangeManager {
 
   void importDataWithFilter(InputStream in, List<String> pubkeys) throws IOException;
 
-  void export(OutputStream out) throws IOException;
+  void exportData(OutputStream out) throws IOException;
 
   void exportWithFilter(OutputStream output, List<String> pubkeys) throws IOException;
+
+  void initialiseIncrementalExport(final OutputStream out) throws IOException;
+
+  void addPublicKeyToIncrementalExport(final String pubkey);
+
+  void finaliseIncrementalExport() throws IOException;
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeManager.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeManager.java
@@ -25,11 +25,11 @@ public interface InterchangeManager {
 
   void exportData(OutputStream out) throws IOException;
 
-  void exportWithFilter(OutputStream output, List<String> pubkeys) throws IOException;
+  void exportDataWithFilter(OutputStream output, List<String> pubkeys) throws IOException;
 
-  void initialiseIncrementalExport(final OutputStream out) throws IOException;
+  void exportIncrementallyBegin(final OutputStream out) throws IOException;
 
-  void addPublicKeyToIncrementalExport(final String pubkey);
+  void exportIncrementally(final String pubkey);
 
-  void finaliseIncrementalExport() throws IOException;
+  void exportIncrementallyFinish() throws IOException;
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Exporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Exporter.java
@@ -49,7 +49,6 @@ public class InterchangeV5Exporter {
   private final MetadataDao metadataDao;
   private final LowWatermarkDao lowWatermarkDao;
   private final ObjectMapper mapper;
-  private JsonGenerator jsonGenerator;
 
   public InterchangeV5Exporter(
       final Jdbi jdbi,
@@ -250,6 +249,7 @@ public class InterchangeV5Exporter {
   }
 
   public class IncrementalInterchangeV5Exporter implements IncrementalExporter {
+    final JsonGenerator jsonGenerator;
 
     public IncrementalInterchangeV5Exporter(final OutputStream outputStream) throws IOException {
       jsonGenerator = mapper.getFactory().createGenerator(outputStream);

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Exporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Exporter.java
@@ -80,7 +80,7 @@ public class InterchangeV5Exporter {
   public void exportIncrementallyBegin(final OutputStream out) throws IOException {
     checkState(
         jsonGenerator == null,
-        "Already in exporting incrementally. Call exportIncrementallyFinish before calling exportIncrementallyBegin");
+        "Already exporting incrementally. Call exportIncrementallyFinish before calling exportIncrementallyBegin");
     jsonGenerator = mapper.getFactory().createGenerator(out);
     final Optional<Bytes32> gvr = jdbi.inTransaction(metadataDao::findGenesisValidatorsRoot);
     if (gvr.isEmpty()) {

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Exporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Exporter.java
@@ -67,15 +67,15 @@ public class InterchangeV5Exporter {
     this.mapper = mapper;
   }
 
-  public void export(final OutputStream out) throws IOException {
+  public void exportData(final OutputStream out) throws IOException {
     exportInternal(out, Optional.empty());
   }
 
-  public void exportWithFilter(OutputStream out, List<String> pubkeys) throws IOException {
+  public void exportDataWithFilter(OutputStream out, List<String> pubkeys) throws IOException {
     exportInternal(out, Optional.of(pubkeys));
   }
 
-  public void initialiseIncrementalExport(final OutputStream out) throws IOException {
+  public void exportIncrementallyBegin(final OutputStream out) throws IOException {
     jsonGenerator = mapper.getFactory().createGenerator(out);
     final Optional<Bytes32> gvr = jdbi.inTransaction(metadataDao::findGenesisValidatorsRoot);
     if (gvr.isEmpty()) {
@@ -92,11 +92,11 @@ public class InterchangeV5Exporter {
     jsonGenerator.writeArrayFieldStart("data");
   }
 
-  public void addPublicKeyToIncrementalExport(final String publicKey) {
+  public void exportIncrementally(final String publicKey) {
     populateInterchangeData(jsonGenerator, Optional.of(List.of(publicKey)));
   }
 
-  public void finaliseIncrementalExport() throws IOException {
+  public void exportIncrementallyFinish() throws IOException {
     // end the data array
     jsonGenerator.writeEndArray();
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Exporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Exporter.java
@@ -267,7 +267,7 @@ public class InterchangeV5Exporter {
     }
 
     @Override
-    public void addPublicKey(final String publicKey) {
+    public void export(final String publicKey) {
       populateInterchangeData(jsonGenerator, publicKey);
     }
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Exporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Exporter.java
@@ -39,15 +39,15 @@ public class InterchangeV5Exporter {
 
   private static final Logger LOG = LogManager.getLogger();
 
-  protected static final String FORMAT_VERSION = "5";
+  private static final String FORMAT_VERSION = "5";
 
-  protected final Jdbi jdbi;
+  private final Jdbi jdbi;
   private final ValidatorsDao validatorsDao;
   private final SignedBlocksDao signedBlocksDao;
   private final SignedAttestationsDao signedAttestationsDao;
-  protected final MetadataDao metadataDao;
+  private final MetadataDao metadataDao;
   private final LowWatermarkDao lowWatermarkDao;
-  protected final ObjectMapper mapper;
+  private final ObjectMapper mapper;
   private JsonGenerator jsonGenerator;
 
   public InterchangeV5Exporter(

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Exporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Exporter.java
@@ -262,6 +262,7 @@ public class InterchangeV5Exporter {
     final JsonGenerator jsonGenerator;
 
     public IncrementalInterchangeV5Exporter(final OutputStream outputStream) throws IOException {
+      LOG.info("Exporting slashing protection database");
       jsonGenerator = mapper.getFactory().createGenerator(outputStream);
       startInterchangeExport(jsonGenerator);
     }
@@ -274,6 +275,7 @@ public class InterchangeV5Exporter {
     @Override
     public void finalise() throws IOException {
       finaliseInterchangeExport(jsonGenerator);
+      LOG.info("Exporting complete");
     }
 
     @Override

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Exporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Exporter.java
@@ -12,6 +12,8 @@
  */
 package tech.pegasys.web3signer.slashingprotection.interchange;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
 import tech.pegasys.web3signer.slashingprotection.dao.MetadataDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
@@ -76,6 +78,9 @@ public class InterchangeV5Exporter {
   }
 
   public void exportIncrementallyBegin(final OutputStream out) throws IOException {
+    checkState(
+        jsonGenerator == null,
+        "Already in exporting incrementally. Call exportIncrementallyFinish before calling exportIncrementallyBegin");
     jsonGenerator = mapper.getFactory().createGenerator(out);
     final Optional<Bytes32> gvr = jdbi.inTransaction(metadataDao::findGenesisValidatorsRoot);
     if (gvr.isEmpty()) {
@@ -104,6 +109,7 @@ public class InterchangeV5Exporter {
     jsonGenerator.writeEndObject();
 
     jsonGenerator.close();
+    jsonGenerator = null;
   }
 
   private void exportInternal(final OutputStream out, final Optional<List<String>> pubkeys)

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Manager.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Manager.java
@@ -71,7 +71,7 @@ public class InterchangeV5Manager implements InterchangeManager {
   }
 
   @Override
-  public void export(final OutputStream out) throws IOException {
+  public void exportData(final OutputStream out) throws IOException {
     exporter.export(out);
   }
 
@@ -79,5 +79,20 @@ public class InterchangeV5Manager implements InterchangeManager {
   public void exportWithFilter(final OutputStream out, final List<String> pubkeys)
       throws IOException {
     exporter.exportWithFilter(out, pubkeys);
+  }
+
+  @Override
+  public void initialiseIncrementalExport(final OutputStream out) throws IOException {
+    exporter.initialiseIncrementalExport(out);
+  }
+
+  @Override
+  public void addPublicKeyToIncrementalExport(final String pubkey) {
+    exporter.addPublicKeyToIncrementalExport(pubkey);
+  }
+
+  @Override
+  public void finaliseIncrementalExport() throws IOException {
+    exporter.finaliseIncrementalExport();
   }
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Manager.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Manager.java
@@ -72,27 +72,27 @@ public class InterchangeV5Manager implements InterchangeManager {
 
   @Override
   public void exportData(final OutputStream out) throws IOException {
-    exporter.export(out);
+    exporter.exportData(out);
   }
 
   @Override
-  public void exportWithFilter(final OutputStream out, final List<String> pubkeys)
+  public void exportDataWithFilter(final OutputStream out, final List<String> pubkeys)
       throws IOException {
-    exporter.exportWithFilter(out, pubkeys);
+    exporter.exportDataWithFilter(out, pubkeys);
   }
 
   @Override
-  public void initialiseIncrementalExport(final OutputStream out) throws IOException {
-    exporter.initialiseIncrementalExport(out);
+  public void exportIncrementallyBegin(final OutputStream out) throws IOException {
+    exporter.exportIncrementallyBegin(out);
   }
 
   @Override
-  public void addPublicKeyToIncrementalExport(final String pubkey) {
-    exporter.addPublicKeyToIncrementalExport(pubkey);
+  public void exportIncrementally(final String pubkey) {
+    exporter.exportIncrementally(pubkey);
   }
 
   @Override
-  public void finaliseIncrementalExport() throws IOException {
-    exporter.finaliseIncrementalExport();
+  public void exportIncrementallyFinish() throws IOException {
+    exporter.exportIncrementallyFinish();
   }
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Manager.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Manager.java
@@ -82,17 +82,7 @@ public class InterchangeV5Manager implements InterchangeManager {
   }
 
   @Override
-  public void exportIncrementallyBegin(final OutputStream out) throws IOException {
-    exporter.exportIncrementallyBegin(out);
-  }
-
-  @Override
-  public void exportIncrementally(final String pubkey) {
-    exporter.exportIncrementally(pubkey);
-  }
-
-  @Override
-  public void exportIncrementallyFinish() throws IOException {
-    exporter.exportIncrementallyFinish();
+  public IncrementalExporter createIncrementalExporter(final OutputStream out) throws IOException {
+    return exporter.createIncrementalExporter(out);
   }
 }


### PR DESCRIPTION
Add incremental export of the slashing protection database. This will allow for changing the keymanger delete functionality to use a incremental slashing protection export necessary to handle database rollbacks with the validator disable correctly.

This also changes the key manager delete to use the incremental export but does not change it to use a streaming approach. Changing delete to process the deletion of keys and slashing protection data one by one will be done in another PR.