### PR TITLE
Key Manager Delete API - return not_active status when keys have slashing protection data

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/keymanager/DeleteKeystoresAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/keymanager/DeleteKeystoresAcceptanceTest.java
@@ -67,10 +67,23 @@ public class DeleteKeystoresAcceptanceTest extends KeyManagerTestBase {
   }
 
   @Test
-  public void deletingNonExistingKeyReturnNotFound() throws URISyntaxException {
+  public void deletingExistingKeyWithNoSlashingProtectionDataTwiceReturnsNotFound()
+      throws URISyntaxException {
+    final String pubKey =
+        "0xa46bf94016af71e55ca0518fe6a8bd3852e01b3f959780a4faf3bbe461ac553c0a83f232cc5f2a4b827d8d3455b706e4";
     createBlsKey("eth2/bls_keystore_2.json", "otherpassword");
     setupSignerWithKeyManagerApi(true);
-    callDeleteKeystores(composeRequestBody())
+    callDeleteKeystores(composeRequestBody(pubKey))
+        .then()
+        .contentType(ContentType.JSON)
+        .assertThat()
+        .statusCode(200)
+        .body("data[0].status", is("deleted"))
+        .and()
+        .body("slashing_protection", is(emptySlashingData));
+
+    // call API again with same key should return not_found
+    callDeleteKeystores(composeRequestBody(pubKey))
         .then()
         .contentType(ContentType.JSON)
         .assertThat()

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ImportSubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2ImportSubCommand.java
@@ -34,7 +34,7 @@ import picocli.CommandLine.Spec;
 
 @Command(
     name = "import",
-    description = "Exports the slashing protection database",
+    description = "Imports the slashing protection database",
     subcommands = {HelpCommand.class},
     mixinStandardHelpOptions = true)
 public class Eth2ImportSubCommand implements Runnable {

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessor.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessor.java
@@ -71,15 +71,12 @@ public class DeleteKeystoresProcessor {
 
         // check that key is active
         if (signer.isEmpty()) {
-          // if not active, check if we ever had this key registered in the slashing DB
-          final boolean wasRegistered =
+          final boolean slashingProtectionDataExistsForPubKey =
               slashingProtection
-                  .map(protection -> protection.isRegisteredValidator(Bytes.fromHexString(pubkey)))
+                  .map(sp -> sp.slashingProtectionDataExistsFor(Bytes.fromHexString(pubkey)))
                   .orElse(false);
 
-          // if it was registered previously, return not_active and add to list of keys to export,
-          // otherwise not_found
-          if (wasRegistered) {
+          if (slashingProtectionDataExistsForPubKey) {
             keysToExport.add(pubkey);
             results.add(new DeleteKeystoreResult(DeleteKeystoreStatus.NOT_ACTIVE, ""));
           } else {

--- a/core/src/test/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessorTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/service/http/handlers/keymanager/delete/DeleteKeystoresProcessorTest.java
@@ -71,7 +71,7 @@ class DeleteKeystoresProcessorTest {
   @Test
   void testSignerNotFound() {
     when(artifactSignerProvider.getSigner(any())).thenReturn(Optional.empty());
-    when(slashingProtection.isRegisteredValidator(any())).thenReturn(false);
+    when(slashingProtection.slashingProtectionDataExistsFor(any())).thenReturn(false);
 
     final DeleteKeystoresRequestBody requestBody =
         new DeleteKeystoresRequestBody(List.of(PUBLIC_KEY));
@@ -84,7 +84,7 @@ class DeleteKeystoresProcessorTest {
   @Test
   void testSignerNotActive() {
     when(artifactSignerProvider.getSigner(any())).thenReturn(Optional.empty());
-    when(slashingProtection.isRegisteredValidator(any())).thenReturn(true);
+    when(slashingProtection.slashingProtectionDataExistsFor(any())).thenReturn(true);
 
     final DeleteKeystoresRequestBody requestBody =
         new DeleteKeystoresRequestBody(List.of(PUBLIC_KEY));

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningRunnerIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningRunnerIntegrationTest.java
@@ -223,8 +223,8 @@ public class PruningRunnerIntegrationTest extends IntegrationTestBase {
     }
 
     @Override
-    public boolean isRegisteredValidator(final Bytes publicKey) {
-      return delegate.isRegisteredValidator(publicKey);
+    public boolean slashingProtectionDataExistsFor(final Bytes publicKey) {
+      return delegate.slashingProtectionDataExistsFor(publicKey);
     }
 
     @Override

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -285,8 +285,8 @@ public class DbSlashingProtection implements SlashingProtection {
   }
 
   @Override
-  public boolean isRegisteredValidator(final Bytes publicKey) {
-    return registeredValidators.get(publicKey) != null;
+  public boolean slashingProtectionDataExistsFor(final Bytes publicKey) {
+    return jdbi.inTransaction(READ_COMMITTED, handle -> validatorsDao.hasSigned(handle, publicKey));
   }
 
   private int validatorId(final Bytes publicKey) {

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtection.java
@@ -34,7 +34,7 @@ public interface SlashingProtection {
 
   void registerValidators(List<Bytes> validators);
 
-  boolean isRegisteredValidator(Bytes publicKey);
+  boolean slashingProtectionDataExistsFor(Bytes publicKey);
 
   void export(OutputStream output);
 

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/ValidatorsDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/ValidatorsDaoTest.java
@@ -23,6 +23,7 @@ import db.DatabaseSetupExtension;
 import db.DatabaseUtil;
 import db.DatabaseUtil.TestDatabaseInfo;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt64;
 import org.flywaydb.core.Flyway;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
@@ -126,11 +127,59 @@ public class ValidatorsDaoTest {
     assertThat(new ValidatorsDao().isEnabled(handle, 1)).isFalse();
   }
 
+  @Test
+  public void hasSignedReturnsFalseWhenValidatorNotRegistered(final Handle handle) {
+    assertThat(new ValidatorsDao().hasSigned(handle, Bytes.of(9))).isFalse();
+  }
+
+  @Test
+  public void hasSignedReturnsFalseWhenNoSignedBlocksOrAttestations(final Handle handle) {
+    insertValidator(handle, 1, Bytes.of(9));
+    assertThat(new ValidatorsDao().hasSigned(handle, Bytes.of(9))).isFalse();
+  }
+
+  @Test
+  public void hasSignedReturnsTrueWhenSignedBlock(final Handle handle) {
+    insertValidator(handle, 1, Bytes.of(9));
+    insertBlock(handle, 1);
+    assertThat(new ValidatorsDao().hasSigned(handle, Bytes.of(9))).isTrue();
+  }
+
+  @Test
+  public void hasSignedReturnsTrueWhenSignedAttestation(final Handle handle) {
+    insertValidator(handle, 1, Bytes.of(9));
+    insertAttestation(handle, 1);
+    assertThat(new ValidatorsDao().hasSigned(handle, Bytes.of(9))).isTrue();
+  }
+
   private void insertValidator(final Handle h, final Bytes publicKey) {
     insertValidator(h, publicKey, true);
   }
 
   private void insertValidator(final Handle h, final Bytes publicKey, final boolean enabled) {
     h.execute("INSERT INTO validators (public_key, enabled) VALUES (?, ?)", publicKey, enabled);
+  }
+
+  private void insertValidator(final Handle h, final int validatorId, final Bytes publicKey) {
+    h.execute("INSERT INTO validators (id, public_key) VALUES (?, ?)", validatorId, publicKey);
+  }
+
+  private void insertBlock(final Handle handle, final int validatorId) {
+    handle.execute(
+        "INSERT INTO signed_blocks (validator_id, slot, signing_root) VALUES (?, ?, ?)",
+        validatorId,
+        2,
+        Bytes.of(3));
+  }
+
+  private void insertAttestation(final Handle handle, final int validatorId) {
+    handle.execute(
+        "INSERT INTO signed_attestations "
+            + "(validator_id, signing_root, source_epoch, target_epoch) "
+            + "VALUES (?, ?, ?, ?)",
+        validatorId,
+        Bytes.of(2),
+        UInt64.valueOf(3),
+        UInt64.valueOf(4));
   }
 }


### PR DESCRIPTION
Following a delete, validators can be registered in the database but still not have signed anything and therefore have no slashing protection data.
When re-deleting such a key, return a status not_found.
In the more typical case where there is slashing protection data, i.e. the key has signed something, return not_active.

Fixes https://github.com/ConsenSys/web3signer/issues/524