### PR TITLE
backport updating postgresql driver to 42.3.3 to resolve security vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 - Upgrade Vertx to 4.x, signers to 2.0.0 and various other dependencies to latest versions [#503](https://github.com/ConsenSys/web3signer/pull/503)
 
 ---
+## 21.10.6
+### Bugs Fixed
+- Updated to PostgreSQL JDBC driver to 42.3.3. Resolves a potential vulnerability CVE-2022-21724.
+
+---
 ## 21.10.5
 ### Bugs Fixed
 - Updated to log4j 2.17.1. Resolves two potential vulnerabilities which are only exploitable when using custom log4j configurations that are either writable by untrusted users or log data from the `ThreadContext`.

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -126,7 +126,7 @@ dependencyManagement {
     dependency 'com.azure:azure-identity:1.4.3'
 
     dependency 'com.zaxxer:HikariCP:3.4.5'
-    dependency 'org.postgresql:postgresql:42.2.20'
+    dependency 'org.postgresql:postgresql:42.3.3'
 
     dependencySet(group: 'org.jdbi', version: '3.14.4') {
       entry 'jdbi3-core'


### PR DESCRIPTION
Backport the changes from 21.10.6 to update the postgresql driver to fix VE-2022-21724