### PR TITLE
Fix AWS environment mode not supporting web identity token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 22.5.0
+
+### Bugs Fixed
+- Keys loaded using the AWS secrets manager with environment config didn't work when using web identity tokens due to missing sts library.
+
+---
 ## 22.4.1
 
 ### Features Added

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -97,7 +97,7 @@ dependencyManagement {
 
     dependency 'tech.pegasys:jblst:0.3.6-4'
 
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '2.2.1') {
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '2.2.2') {
       entry 'bls-keystore'
       entry 'keystorage-hashicorp'
       entry 'keystorage-azure'


### PR DESCRIPTION
AWS environment mode is not working with web identity token due to the sts library missing. This PR updates to the latest version of the signers library which includes the sts library.