### PR TITLE
Fix AWS ATs failing with NoClassDefFoundError

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -138,7 +138,7 @@ dependencyManagement {
     dependency 'com.github.ipld:java-cid:1.3.1'
     dependency 'net.jodah:failsafe:2.4.0'
 
-    dependencySet(group: 'software.amazon.awssdk', version: '2.17.125') {
+    dependencySet(group: 'software.amazon.awssdk', version: '2.17.158') {
       entry 'bom'
       entry 'auth'
       entry 'secretsmanager'


### PR DESCRIPTION
Fix AWS ATs failing with java.lang.NoClassDefFoundError. This was caused by conflicting versions of the AWS SDK for the ATs.