### PR TITLE
Ensure that loaded keys metric is accurate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Added new metric `eth2_slashingprotection_database_duration` to track time spent performing database queries during either block or attestation signing operations
 - Private keys bulk loading from AWS Secrets Manager via cli options in eth2 mode [#499](https://github.com/ConsenSys/web3signer/issues/499)
 
+### Bugs Fixed
+- Fix issue where signing_signers_loaded_count metric didn't update after refresh endpoint was used to update loaded keys
 ---
 
 ## 22.5.1

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -68,7 +68,8 @@ public class Eth1Runner extends Runner {
         .handler(
             new BlockingHandlerDecorator(
                 new Eth1SignForIdentifierHandler(
-                    secpSigner, new HttpApiMetrics(context.getMetricsSystem(), SECP256K1)),
+                    secpSigner,
+                    new HttpApiMetrics(context.getMetricsSystem(), SECP256K1, signerProvider)),
                 false))
         .failureHandler(errorHandler);
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -174,7 +174,7 @@ public class Eth2Runner extends Runner {
             new BlockingHandlerDecorator(
                 new Eth2SignForIdentifierHandler(
                     blsSigner,
-                    new HttpApiMetrics(metricsSystem, BLS),
+                    new HttpApiMetrics(metricsSystem, BLS, blsSignerProvider),
                     new SlashingProtectionMetrics(metricsSystem),
                     slashingProtectionContext.map(SlashingProtectionContext::getSlashingProtection),
                     objectMapper,

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -13,7 +13,6 @@
 package tech.pegasys.web3signer.core;
 
 import static tech.pegasys.web3signer.core.service.http.OpenApiOperationsId.UPCHECK;
-import static tech.pegasys.web3signer.core.service.http.metrics.HttpApiMetrics.incSignerLoadCount;
 
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.web3signer.core.config.ClientAuthConstraints;
@@ -107,7 +106,6 @@ public abstract class Runner implements Runnable {
       } catch (final InterruptedException | ExecutionException e) {
         LOG.error("Error loading signers", e);
       }
-      incSignerLoadCount(metricsSystem, artifactSignerProvider.availableIdentifiers().size());
 
       final OpenApiSpecsExtractor openApiSpecsExtractor =
           new OpenApiSpecsExtractor.OpenApiSpecsExtractorBuilder()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
This fixes the issue where Web3Signer doesn't update the number of loaded keys metric correctly.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #585

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
