### PR TITLE
Upgrade protobuf and jackson-databind to fix CVE-2022-3171 and CVE-2022-42003

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
   }
   dependencies {
     classpath 'tech.pegasys.internal.license.reporter:license-reporter:1.0.1'
-    classpath 'org.owasp:dependency-check-gradle:7.1.0.1'
+    classpath 'org.owasp:dependency-check-gradle:7.2.1'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
   }
   dependencies {
     classpath 'tech.pegasys.internal.license.reporter:license-reporter:1.0.1'
-    classpath 'org.owasp:dependency-check-gradle:7.2.1'
+    classpath 'org.owasp:dependency-check-gradle:7.1.0.1'
   }
 }
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -13,7 +13,7 @@
 
 dependencyManagement {
   dependencies {
-    dependency 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+    dependency 'com.fasterxml.jackson.core:jackson-databind:2.14.0-rc1'
     dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4'
 
     dependencySet(group: 'com.google.errorprone', version: '2.10.0') {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -84,7 +84,7 @@ dependencyManagement {
     dependency 'org.hyperledger.besu:plugin-api:22.7.6'
     dependency 'org.hyperledger.besu.internal:metrics-core:22.7.6'
 
-    dependencySet(group: 'tech.pegasys.teku.internal', version: '22.9.0') {
+    dependencySet(group: 'tech.pegasys.teku.internal', version: '22.9.1') {
       entry 'bls'
       entry 'spec'
       entry 'serializer'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -81,8 +81,8 @@ dependencyManagement {
       entry 'mockito-junit-jupiter'
     }
 
-    dependency 'org.hyperledger.besu:plugin-api:22.4.1'
-    dependency 'org.hyperledger.besu.internal:metrics-core:22.4.4'
+    dependency 'org.hyperledger.besu:plugin-api:22.7.6'
+    dependency 'org.hyperledger.besu.internal:metrics-core:22.7.6'
 
     dependencySet(group: 'tech.pegasys.teku.internal', version: '22.9.0') {
       entry 'bls'
@@ -145,11 +145,11 @@ dependencyManagement {
     }
 
     // explicit declaring to override older versions with vulnerabilities
-    dependencySet(group: 'com.google.protobuf', version: '3.19.4') {
+    dependencySet(group: 'com.google.protobuf', version: '3.19.6') {
       /*
-        com.google.protobuf:protobuf-java*:3.11.4 -> 3.19.4
+        com.google.protobuf:protobuf-java*:3.11.4 -> 3.19.4 // CVE-2022-3171
         \--- io.jaegertracing:jaeger-proto:0.7.0
-          \--- org.hyperledger.besu.internal:metrics-core:22.1.3
+          \--- org.hyperledger.besu.internal:metrics-core:22.7.6
       */
       entry 'protobuf-java'
       entry 'protobuf-java-util'


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-h4h5-3hr4-j3g2
https://nvd.nist.gov/vuln/detail/CVE-2022-42003