### PR TITLE
Fix installation directory permission in Web3Signer docker image

### DIFF
--- a/docker/jdk11/Dockerfile
+++ b/docker/jdk11/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 
 RUN apt-get -y update && apt-get -y install curl iputils-ping net-tools && rm -rf /var/lib/api/lists/*
 RUN adduser --disabled-password --gecos "" --home /opt/web3signer web3signer && \
-    chown web3signer:web3signer /opt/web3signer
+    chown web3signer:web3signer /opt/web3signer && chmod 755 /opt/web3signer
 
 USER web3signer
 WORKDIR /opt/web3signer

--- a/docker/jdk17/Dockerfile
+++ b/docker/jdk17/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=jre-build /javaruntime $JAVA_HOME
 
 RUN apt-get -y update && apt-get -y install curl iputils-ping net-tools && rm -rf /var/lib/api/lists/*
 RUN adduser --disabled-password --gecos "" --home /opt/web3signer web3signer && \
-    chown web3signer:web3signer /opt/web3signer
+    chown web3signer:web3signer /opt/web3signer && chmod 755 /opt/web3signer
 
 USER web3signer
 WORKDIR /opt/web3signer


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Fixes installation directory permission in Docker image.

In our Docker file, we have `RUN adduser --disabled-password --gecos "" --home /opt/web3signer` that sets the top level `/opt/web3signer` with restricted permissions as this becomes the home folder of user `web3signer`, everything else under `/opt/web3signer` is already correct permission because we extract them from our build .tar.gz.

The fix is either to use a different `--home` in `adduser` command or fix the top level directory permission i.e. `/opt/web3signer` to allow access to the directory to the world (it defaults to user and group due to being home folder).

To test the fix via local build:
~~~
./gradlew --no-daemon installDist
./gradlew --no-daemon distDocker
docker run --rm -u 501 consensys/web3signer:develop eth2 --slashing-protection-enabled=false --version
~~~

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#647 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
