### PR TITLE
Better database pruning default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 - Introduced cli option to specify Hikari configuration for pruning database connection [#661](https://github.com/ConsenSys/web3signer/issues/661)
-- Better database pruning default values: Pruning enabled by default with `slashing-protection-pruning-epochs-to-keep = 250` and `slashing-protection-pruning-at-boot-enabled = false` 
+- Better database pruning default values: Pruning enabled by default with `slashing-protection-pruning-epochs-to-keep = 250`, `slashing-protection-pruning-at-boot-enabled = false` and `slashing-protection-pruning-interval = 12`
 
 ## 22.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 - Introduced cli option to specify Hikari configuration for pruning database connection [#661](https://github.com/ConsenSys/web3signer/issues/661)
-- Better database pruning default values: `slashing-protection-pruning-epochs-to-keep = 250` and `slashing-protection-pruning-at-boot-enabled = false` 
+- Better database pruning default values: Pruning enabled by default with `slashing-protection-pruning-epochs-to-keep = 250` and `slashing-protection-pruning-at-boot-enabled = false` 
 
 ## 22.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 - Introduced cli option to specify Hikari configuration for pruning database connection [#661](https://github.com/ConsenSys/web3signer/issues/661)
+- Better database pruning default values: `slashing-protection-pruning-epochs-to-keep = 250` and `slashing-protection-pruning-at-boot-enabled = false` 
 
 ## 22.10.0
 

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfiguration.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfiguration.java
@@ -54,6 +54,7 @@ public class SignerConfiguration {
   private final Optional<Path> slashingExportPath;
   private final Optional<Path> slashingImportPath;
   private final boolean enableSlashingPruning;
+  private final boolean enableSlashingPruningAtBoot;
   private final boolean swaggerUIEnabled;
   private final boolean useConfigFile;
   private final long slashingPruningEpochsToKeep;
@@ -91,6 +92,7 @@ public class SignerConfiguration {
       final Optional<Path> slashingExportPath,
       final Optional<Path> slashingImportPath,
       final boolean enableSlashingPruning,
+      final boolean enableSlashingPruningAtBoot,
       final long slashingPruningEpochsToKeep,
       final long slashingPruningSlotsPerEpoch,
       final long slashingPruningSchedule,
@@ -125,6 +127,7 @@ public class SignerConfiguration {
     this.slashingExportPath = slashingExportPath;
     this.slashingImportPath = slashingImportPath;
     this.enableSlashingPruning = enableSlashingPruning;
+    this.enableSlashingPruningAtBoot = enableSlashingPruningAtBoot;
     this.slashingPruningEpochsToKeep = slashingPruningEpochsToKeep;
     this.slashingPruningSlotsPerEpoch = slashingPruningSlotsPerEpoch;
     this.slashingPruningInterval = slashingPruningSchedule;
@@ -235,6 +238,10 @@ public class SignerConfiguration {
 
   public boolean isSlashingProtectionPruningEnabled() {
     return enableSlashingPruning;
+  }
+
+  public boolean isSlashingProtectionPruningAtBootEnabled() {
+    return enableSlashingPruningAtBoot;
   }
 
   public long getSlashingProtectionPruningEpochsToKeep() {

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfigurationBuilder.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfigurationBuilder.java
@@ -57,6 +57,7 @@ public class SignerConfigurationBuilder {
   private Path slashingExportPath;
   private Path slashingImportPath;
   private boolean enableSlashingPruning = false;
+  private boolean enableSlashingPruningAtBoot = true;
   private boolean swaggerUIEnabled = false;
   private boolean useConfigFile = false;
   private long pruningEpochsToKeep = 1;
@@ -185,6 +186,12 @@ public class SignerConfigurationBuilder {
     return this;
   }
 
+  public SignerConfigurationBuilder withSlashingPruningEnabledAtBoot(
+      final boolean enablePruningAtBoot) {
+    this.enableSlashingPruningAtBoot = enablePruningAtBoot;
+    return this;
+  }
+
   public SignerConfigurationBuilder withSlashingPruningEpochsToKeep(
       final long pruningEpochsToKeep) {
     this.pruningEpochsToKeep = pruningEpochsToKeep;
@@ -277,6 +284,7 @@ public class SignerConfigurationBuilder {
         Optional.ofNullable(slashingExportPath),
         Optional.ofNullable(slashingImportPath),
         enableSlashingPruning,
+        enableSlashingPruningAtBoot,
         pruningEpochsToKeep,
         slashingPruningSlotsPerEpoch,
         slashingPruningInterval,

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
@@ -269,6 +269,11 @@ public class CmdLineParamsConfigFileImpl implements CmdLineParamsBuilder {
               signerConfig.isSlashingProtectionPruningEnabled()));
       yamlConfig.append(
           String.format(
+              YAML_BOOLEAN_FMT,
+              "eth2.slashing-protection-pruning-at-boot-enabled",
+              signerConfig.isSlashingProtectionPruningAtBootEnabled()));
+      yamlConfig.append(
+          String.format(
               YAML_NUMERIC_FMT,
               "eth2.slashing-protection-pruning-epochs-to-keep",
               signerConfig.getSlashingProtectionPruningEpochsToKeep()));
@@ -280,7 +285,7 @@ public class CmdLineParamsConfigFileImpl implements CmdLineParamsBuilder {
       yamlConfig.append(
           String.format(
               YAML_NUMERIC_FMT,
-              "eth2.slashing-protection-pruning-schedule",
+              "eth2.slashing-protection-pruning-interval",
               signerConfig.getSlashingProtectionPruningInterval()));
     }
 

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
@@ -195,6 +195,8 @@ public class CmdLineParamsDefaultImpl implements CmdLineParamsBuilder {
     if (signerConfig.isSlashingProtectionPruningEnabled()) {
       params.add("--slashing-protection-pruning-enabled");
       params.add(Boolean.toString(signerConfig.isSlashingProtectionPruningEnabled()));
+      params.add("--slashing-protection-pruning-at-boot-enabled");
+      params.add(Boolean.toString(signerConfig.isSlashingProtectionPruningAtBootEnabled()));
       params.add("--slashing-protection-pruning-epochs-to-keep");
       params.add(Long.toString(signerConfig.getSlashingProtectionPruningEpochsToKeep()));
       params.add("--slashing-protection-pruning-slots-per-epoch");

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/slashing/SlashingPruningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/slashing/SlashingPruningAcceptanceTest.java
@@ -87,9 +87,10 @@ public class SlashingPruningAcceptanceTest extends AcceptanceTestBase {
     assertThat(attestationsBeforePruning).hasSize(2);
     assertThat(blocksBeforePruning).hasSize(2);
 
-    // start signer with pruning enabled configured to only keep one block and attestation
+    // start signer with pruning enabled at boot configured to only keep one block and attestation
     signerBuilder
         .withSlashingPruningEnabled(true)
+        .withSlashingPruningEnabledAtBoot(true)
         .withSlashingPruningEpochsToKeep(1)
         .withSlashingPruningSlotsPerEpoch(1)
         .withSlashingPruningInterval(1);

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
@@ -75,7 +75,7 @@ public class PicoCliSlashingProtectionParameters implements SlashingProtectionPa
       names = {"--slashing-protection-pruning-epochs-to-keep"},
       description = "Number of epochs to keep. (default: ${DEFAULT-VALUE})",
       arity = "1")
-  long pruningEpochsToKeep = 10_000;
+  long pruningEpochsToKeep = 250;
 
   @Option(
       names = {"--slashing-protection-pruning-slots-per-epoch"},
@@ -93,11 +93,11 @@ public class PicoCliSlashingProtectionParameters implements SlashingProtectionPa
   @Option(
       names = {"--slashing-protection-pruning-at-boot-enabled"},
       description =
-          "Set to false to disable slashing protection pruning logic at server boot"
+          "Set to true to enable slashing protection pruning logic at server boot"
               + "(default: ${DEFAULT-VALUE})",
       paramLabel = "<BOOL>",
       arity = "1")
-  boolean pruningAtBootEnabled = true;
+  boolean pruningAtBootEnabled = false;
 
   @Option(
       names = {"--slashing-protection-db-health-check-timeout-milliseconds"},

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
@@ -88,7 +88,7 @@ public class PicoCliSlashingProtectionParameters implements SlashingProtectionPa
   @Option(
       names = {"--slashing-protection-pruning-interval"},
       description = "Hours between pruning operations (default: ${DEFAULT-VALUE})")
-  long pruningInterval = 24;
+  long pruningInterval = 12;
 
   @Option(
       names = {"--slashing-protection-pruning-at-boot-enabled"},

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
@@ -69,7 +69,7 @@ public class PicoCliSlashingProtectionParameters implements SlashingProtectionPa
               + "(default: ${DEFAULT-VALUE})",
       paramLabel = "<BOOL>",
       arity = "1")
-  boolean pruningEnabled = false;
+  boolean pruningEnabled = true;
 
   @Option(
       names = {"--slashing-protection-pruning-epochs-to-keep"},


### PR DESCRIPTION
Enable pruning by default with these default values: `slashing-protection-pruning-epochs-to-keep = 250`, `slashing-protection-pruning-at-boot-enabled = false` and `slashing-protection-pruning-interval = 12`

Fixes: https://github.com/ConsenSys/web3signer/issues/598
Fixes: https://github.com/ConsenSys/web3signer/issues/630