### PR TITLE
[#662] cli option to disable connection pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 - Improved performance for slashing protection import
 
 ### Experimental
-- Introduced cli option `--Xslashing-protection-db-connection-pool-enabled` to disable internal Hikari based connection 
- pool to allow using external connection pool such as pgBouncer. `--slashing-protection-db-pool-configuration-file` and 
- `--slashing-protection-db-pool-configuration-file` can be reused to specify PG Datasource properties. 
+- Introduced cli option `--Xslashing-protection-db-connection-pool-enabled` to disable internal database connection 
+ pool (Hikari) to allow using external database connection pool such as pgBouncer. `--slashing-protection-db-pool-configuration-file` and 
+ `--slashing-protection-pruning-db-pool-configuration-file` can be reused to specify PG Datasource properties. 
  [#662](https://github.com/ConsenSys/web3signer/issues/662)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Better database pruning default values: Pruning enabled by default with `slashing-protection-pruning-epochs-to-keep = 250`, `slashing-protection-pruning-at-boot-enabled = false` and `slashing-protection-pruning-interval = 12`
 - Improved performance for slashing protection import
 
+### Experimental
+- Introduced cli option to disable internal Hikari based connection pool to allow using external connection pool such as pgBouncer [662](https://github.com/ConsenSys/web3signer/issues/662)
+
+--
 ## 22.10.0
 
 ### Features Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@
 - Improved performance for slashing protection import
 
 ### Experimental
-- Introduced cli option to disable internal Hikari based connection pool to allow using external connection pool such as pgBouncer [662](https://github.com/ConsenSys/web3signer/issues/662)
+- Introduced cli option `--Xslashing-protection-db-connection-pool-enabled` to disable internal Hikari based connection 
+ pool to allow using external connection pool such as pgBouncer. `--slashing-protection-db-pool-configuration-file` and 
+ `--slashing-protection-db-pool-configuration-file` can be reused to specify PG Datasource properties. 
+ [#662](https://github.com/ConsenSys/web3signer/issues/662)
 
---
+
+---
+
 ## 22.10.0
 
 ### Features Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,10 @@
 - Introduced cli option to specify Hikari configuration for pruning database connection [#661](https://github.com/ConsenSys/web3signer/issues/661)
 - Better database pruning default values: Pruning enabled by default with `slashing-protection-pruning-epochs-to-keep = 250`, `slashing-protection-pruning-at-boot-enabled = false` and `slashing-protection-pruning-interval = 12`
 - Improved performance for slashing protection import
-
-### Experimental
-- Introduced cli option `--Xslashing-protection-db-connection-pool-enabled` to disable internal database connection 
- pool (Hikari) to allow using external database connection pool such as pgBouncer. `--slashing-protection-db-pool-configuration-file` and 
- `--slashing-protection-pruning-db-pool-configuration-file` can be reused to specify PG Datasource properties. 
- [#662](https://github.com/ConsenSys/web3signer/issues/662)
-
+- Introduced experimental cli option `--Xslashing-protection-db-connection-pool-enabled` to disable internal database connection
+  pool (Hikari) to allow using external database connection pool such as pgBouncer. `--slashing-protection-db-pool-configuration-file` and
+  `--slashing-protection-pruning-db-pool-configuration-file` can be reused to specify PG Datasource properties.
+  [#662](https://github.com/ConsenSys/web3signer/issues/662)
 
 ---
 

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfiguration.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfiguration.java
@@ -48,6 +48,7 @@ public class SignerConfiguration {
   private final Optional<String> slashingProtectionDbUrl;
   private final String slashingProtectionDbUsername;
   private final String slashingProtectionDbPassword;
+  private final boolean slashingProtectionDbConnectionPoolEnabled;
   private final Optional<Path> slashingProtectionDbPoolConfigurationFile;
   private final Optional<Map<String, String>> web3SignerEnvironment;
   private final boolean enableSlashing;
@@ -85,6 +86,7 @@ public class SignerConfiguration {
       final Optional<String> slashingProtectionDbUrl,
       final String slashingProtectionDbUsername,
       final String slashingProtectionDbPassword,
+      final boolean slashingProtectionDbConnectionPoolEnabled,
       final String mode,
       final Optional<Map<String, String>> web3SignerEnvironment,
       final Duration startupTimeout,
@@ -120,6 +122,7 @@ public class SignerConfiguration {
     this.slashingProtectionDbUrl = slashingProtectionDbUrl;
     this.slashingProtectionDbUsername = slashingProtectionDbUsername;
     this.slashingProtectionDbPassword = slashingProtectionDbPassword;
+    this.slashingProtectionDbConnectionPoolEnabled = slashingProtectionDbConnectionPoolEnabled;
     this.mode = mode;
     this.web3SignerEnvironment = web3SignerEnvironment;
     this.startupTimeout = startupTimeout;
@@ -286,5 +289,9 @@ public class SignerConfiguration {
 
   public Duration getStartupTimeout() {
     return startupTimeout;
+  }
+
+  public boolean isSlashingProtectionDbConnectionPoolEnabled() {
+    return slashingProtectionDbConnectionPoolEnabled;
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfigurationBuilder.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfigurationBuilder.java
@@ -54,6 +54,7 @@ public class SignerConfigurationBuilder {
       Boolean.getBoolean("debugSubProcess") ? Duration.ofHours(1) : Duration.ofSeconds(30);
   private boolean enableSlashing = false;
   private String slashingProtectionDbUrl;
+  private boolean slashingProtectionDbConnectionPoolEnabled = true;
   private Path slashingExportPath;
   private Path slashingImportPath;
   private boolean enableSlashingPruning = false;
@@ -163,6 +164,12 @@ public class SignerConfigurationBuilder {
   public SignerConfigurationBuilder withSlashingProtectionDbPoolConfigurationFile(
       final Path slashingProtectionDbPoolConfigurationFile) {
     this.slashingProtectionDbPoolConfigurationFile = slashingProtectionDbPoolConfigurationFile;
+    return this;
+  }
+
+  public SignerConfigurationBuilder withSlashingProtectionDbConnectionPoolEnabled(
+      final boolean dbConnectionPoolEnabled) {
+    this.slashingProtectionDbConnectionPoolEnabled = dbConnectionPoolEnabled;
     return this;
   }
 
@@ -277,6 +284,7 @@ public class SignerConfigurationBuilder {
         Optional.ofNullable(slashingProtectionDbUrl),
         slashingProtectionDbUsername,
         slashingProtectionDbPassword,
+        slashingProtectionDbConnectionPoolEnabled,
         mode,
         Optional.ofNullable(web3SignerEnvironment),
         startupTimeout,

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
@@ -259,6 +259,15 @@ public class CmdLineParamsConfigFileImpl implements CmdLineParamsBuilder {
                 "eth2.slashing-protection-db-pool-configuration-file",
                 signerConfig.getSlashingProtectionDbPoolConfigurationFile()));
       }
+
+      // enabled by default, explicitly set when false
+      if (!signerConfig.isSlashingProtectionDbConnectionPoolEnabled()) {
+        yamlConfig.append(
+            String.format(
+                YAML_BOOLEAN_FMT,
+                "eth2.Xslashing-protection-db-connection-pool-enabled",
+                signerConfig.isSlashingProtectionDbConnectionPoolEnabled()));
+      }
     }
 
     if (signerConfig.isSlashingProtectionPruningEnabled()) {

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
@@ -180,6 +180,11 @@ public class CmdLineParamsDefaultImpl implements CmdLineParamsBuilder {
         params.add("--slashing-protection-db-pool-configuration-file");
         params.add(signerConfig.getSlashingProtectionDbPoolConfigurationFile().toString());
       }
+
+      // enabled by default, explicitly set when false
+      if (!signerConfig.isSlashingProtectionDbConnectionPoolEnabled()) {
+        params.add("--Xslashing-protection-db-connection-pool-enabled=false");
+      }
     }
 
     if (signerConfig.getSlashingExportPath().isPresent()) {

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/DatabaseUtil.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/DatabaseUtil.java
@@ -26,6 +26,7 @@ import org.jdbi.v3.core.Jdbi;
 public class DatabaseUtil {
   public static final String USERNAME = "postgres";
   public static final String PASSWORD = "postgres";
+  public static final boolean DB_CONNECTION_POOL_ENABLED = true;
 
   public static TestDatabaseInfo create() {
     try {
@@ -39,10 +40,13 @@ public class DatabaseUtil {
 
       final String databaseUrl =
           String.format("jdbc:postgresql://localhost:%d/postgres", db.getPort());
-      final boolean useConnectionPool = true;
       final Jdbi jdbi =
           DbConnection.createConnection(
-              databaseUrl, DatabaseUtil.USERNAME, DatabaseUtil.PASSWORD, null, useConnectionPool);
+              databaseUrl,
+              DatabaseUtil.USERNAME,
+              DatabaseUtil.PASSWORD,
+              null,
+              DB_CONNECTION_POOL_ENABLED);
       return new TestDatabaseInfo(db, jdbi, flyway);
     } catch (IOException e) {
       throw new UncheckedIOException("Unable to create embedded postgres database", e);

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/DatabaseUtil.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/DatabaseUtil.java
@@ -39,9 +39,10 @@ public class DatabaseUtil {
 
       final String databaseUrl =
           String.format("jdbc:postgresql://localhost:%d/postgres", db.getPort());
+      final boolean useConnectionPool = true;
       final Jdbi jdbi =
           DbConnection.createConnection(
-              databaseUrl, DatabaseUtil.USERNAME, DatabaseUtil.PASSWORD, null);
+              databaseUrl, DatabaseUtil.USERNAME, DatabaseUtil.PASSWORD, null, useConnectionPool);
       return new TestDatabaseInfo(db, jdbi, flyway);
     } catch (IOException e) {
       throw new UncheckedIOException("Unable to create embedded postgres database", e);

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
@@ -118,8 +118,10 @@ public class PicoCliSlashingProtectionParameters implements SlashingProtectionPa
   @Option(
       names = "--Xslashing-protection-db-connection-pool-enabled",
       description =
-          "Set to false to disable internal database connection pooling. (Default: ${DEFAULT-VALUE})",
-      paramLabel = "<BOOL>")
+          "Set to false to disable internal database connection pooling. Should only be disabled when using an external database connection pool. (Default: ${DEFAULT-VALUE})",
+      paramLabel = "<BOOL>",
+      arity = "1",
+      hidden = true)
   private boolean dbConnectionPoolEnabled = true;
 
   @Override

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
@@ -115,6 +115,13 @@ public class PicoCliSlashingProtectionParameters implements SlashingProtectionPa
       arity = "1")
   private long dbHealthCheckIntervalMilliseconds = 30000;
 
+  @Option(
+      names = "--slashing-protection-db-connection-pool-enabled",
+      description =
+          "Set to false to disable internal database connection pooling. (Default: ${DEFAULT-VALUE}",
+      paramLabel = "<BOOL>")
+  private boolean connectionPoolEnabled = true;
+
   @Override
   public boolean isEnabled() {
     return enabled;
@@ -183,5 +190,10 @@ public class PicoCliSlashingProtectionParameters implements SlashingProtectionPa
   @Override
   public long getDbHealthCheckIntervalMilliseconds() {
     return dbHealthCheckIntervalMilliseconds;
+  }
+
+  @Override
+  public boolean isConnectionPoolEnabled() {
+    return connectionPoolEnabled;
   }
 }

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
@@ -118,7 +118,7 @@ public class PicoCliSlashingProtectionParameters implements SlashingProtectionPa
   @Option(
       names = "--Xslashing-protection-db-connection-pool-enabled",
       description =
-          "Set to false to disable internal database connection pooling. (Default: ${DEFAULT-VALUE}",
+          "Set to false to disable internal database connection pooling. (Default: ${DEFAULT-VALUE})",
       paramLabel = "<BOOL>")
   private boolean connectionPoolEnabled = true;
 

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
@@ -116,7 +116,7 @@ public class PicoCliSlashingProtectionParameters implements SlashingProtectionPa
   private long dbHealthCheckIntervalMilliseconds = 30000;
 
   @Option(
-      names = "--slashing-protection-db-connection-pool-enabled",
+      names = "--Xslashing-protection-db-connection-pool-enabled",
       description =
           "Set to false to disable internal database connection pooling. (Default: ${DEFAULT-VALUE}",
       paramLabel = "<BOOL>")

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliSlashingProtectionParameters.java
@@ -120,7 +120,7 @@ public class PicoCliSlashingProtectionParameters implements SlashingProtectionPa
       description =
           "Set to false to disable internal database connection pooling. (Default: ${DEFAULT-VALUE})",
       paramLabel = "<BOOL>")
-  private boolean connectionPoolEnabled = true;
+  private boolean dbConnectionPoolEnabled = true;
 
   @Override
   public boolean isEnabled() {
@@ -193,7 +193,7 @@ public class PicoCliSlashingProtectionParameters implements SlashingProtectionPa
   }
 
   @Override
-  public boolean isConnectionPoolEnabled() {
-    return connectionPoolEnabled;
+  public boolean isDbConnectionPoolEnabled() {
+    return dbConnectionPoolEnabled;
   }
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbConnection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbConnection.java
@@ -25,6 +25,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Properties;
 import javax.sql.DataSource;
@@ -36,6 +37,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.argument.Arguments;
 import org.jdbi.v3.core.mapper.ColumnMappers;
 import org.jdbi.v3.core.transaction.SerializableTransactionRunner;
+import org.postgresql.ds.PGSimpleDataSource;
 
 public class DbConnection {
   // https://jdbc.postgresql.org/documentation/head/connect.html#connection-parameters
@@ -46,8 +48,14 @@ public class DbConnection {
       final String jdbcUrl,
       final String username,
       final String password,
-      final Path configurationFile) {
-    final DataSource datasource = createDataSource(jdbcUrl, username, password, configurationFile);
+      final Path configurationFile,
+      final boolean useCP) {
+    final DataSource datasource;
+    if (useCP) {
+      datasource = createHikariDataSource(jdbcUrl, username, password, configurationFile);
+    } else {
+      datasource = createPGDataSource(jdbcUrl, username, password, configurationFile);
+    }
     final Jdbi jdbi = Jdbi.create(datasource);
     configureJdbi(jdbi);
     return jdbi;
@@ -57,10 +65,17 @@ public class DbConnection {
       final String jdbcUrl,
       final String username,
       final String password,
-      final Path configurationFile) {
-    final HikariDataSource datasource =
-        createDataSource(jdbcUrl, username, password, configurationFile);
-    datasource.setMaximumPoolSize(1); // we only need 1 connection in pool for pruning
+      final Path configurationFile,
+      final boolean useCP) {
+    final DataSource datasource;
+    if (useCP) {
+      final HikariDataSource hkDatasource =
+          createHikariDataSource(jdbcUrl, username, password, configurationFile);
+      hkDatasource.setMaximumPoolSize(1); // we only need 1 connection in pool for pruning
+      datasource = hkDatasource;
+    } else {
+      datasource = createPGDataSource(jdbcUrl, username, password, configurationFile);
+    }
     final Jdbi jdbi = Jdbi.create(datasource);
     configureJdbi(jdbi);
     return jdbi;
@@ -77,7 +92,7 @@ public class DbConnection {
     jdbi.setTransactionHandler(new SerializableTransactionRunner());
   }
 
-  private static HikariDataSource createDataSource(
+  private static HikariDataSource createHikariDataSource(
       final String jdbcUrl,
       final String username,
       final String password,
@@ -97,28 +112,74 @@ public class DbConnection {
     return new HikariDataSource(hikariConfig);
   }
 
+  private static DataSource createPGDataSource(
+      final String jdbcUrl,
+      final String username,
+      final String password,
+      final Path propertiesFile) {
+    final PGSimpleDataSource pgSimpleDataSource = new PGSimpleDataSource();
+    pgSimpleDataSource.setURL(jdbcUrl);
+
+    if (!isEmpty(username)) {
+      pgSimpleDataSource.setUser(username);
+    }
+    if (!isEmpty(password)) {
+      pgSimpleDataSource.setPassword(password);
+    }
+
+    final Properties properties = loadPGConfigurationProperties(propertiesFile);
+    properties.forEach(
+        (k, v) -> {
+          try {
+            pgSimpleDataSource.setProperty(k.toString(), v.toString());
+          } catch (final SQLException e) {
+            throw new RuntimeException("Error setting Datasource Property.", e);
+          }
+        });
+
+    return pgSimpleDataSource;
+  }
+
   @VisibleForTesting
-  static Properties loadHikariConfigurationProperties(final Path hikariConfigurationFile) {
-    final Properties hikariConfigurationProperties = new Properties();
-    if (hikariConfigurationFile != null) {
-      try (FileInputStream inputStream = new FileInputStream(hikariConfigurationFile.toFile())) {
-        hikariConfigurationProperties.load(inputStream);
+  static Properties loadHikariConfigurationProperties(final Path configurationFile) {
+    return addDefaultHikariDatasourceTimeoutProperty(
+        loadDatasourcePropertiesFile(configurationFile));
+  }
+
+  static Properties loadPGConfigurationProperties(final Path configurationFile) {
+    return addDefaultPGDatasourceTimeoutProperty(loadDatasourcePropertiesFile(configurationFile));
+  }
+
+  private static Properties loadDatasourcePropertiesFile(final Path configurationFile) {
+    final Properties datasourceConfigurationProperties = new Properties();
+    if (configurationFile != null) {
+      try (FileInputStream inputStream = new FileInputStream(configurationFile.toFile())) {
+        datasourceConfigurationProperties.load(inputStream);
       } catch (final FileNotFoundException e) {
         throw new UncheckedIOException(
-            "Hikari configuration file not found: " + hikariConfigurationFile, e);
+            "Datasource configuration file not found: " + configurationFile, e);
       } catch (final IOException e) {
         final String errorMessage =
             String.format(
-                "Unexpected IO error while reading Hikari configuration file [%s]",
-                hikariConfigurationFile);
+                "Unexpected IO error while reading Datasource configuration file [%s]",
+                configurationFile);
         throw new UncheckedIOException(errorMessage, e);
       }
     }
+    return datasourceConfigurationProperties;
+  }
 
-    if (!hikariConfigurationProperties.containsKey("dataSource." + PG_SOCKET_TIMEOUT_PARAM)) {
-      hikariConfigurationProperties.put(
-          "dataSource." + PG_SOCKET_TIMEOUT_PARAM, DEFAULT_PG_SOCKET_TIMEOUT_SECONDS);
+  private static Properties addDefaultHikariDatasourceTimeoutProperty(final Properties properties) {
+    if (!properties.containsKey("dataSource." + PG_SOCKET_TIMEOUT_PARAM)) {
+      properties.put("dataSource." + PG_SOCKET_TIMEOUT_PARAM, DEFAULT_PG_SOCKET_TIMEOUT_SECONDS);
     }
-    return hikariConfigurationProperties;
+    return properties;
+  }
+
+  private static Properties addDefaultPGDatasourceTimeoutProperty(final Properties properties) {
+    if (!properties.containsKey(PG_SOCKET_TIMEOUT_PARAM)) {
+      properties.put(PG_SOCKET_TIMEOUT_PARAM, DEFAULT_PG_SOCKET_TIMEOUT_SECONDS);
+    }
+    return properties;
   }
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbConnection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbConnection.java
@@ -49,9 +49,9 @@ public class DbConnection {
       final String username,
       final String password,
       final Path configurationFile,
-      final boolean useCP) {
+      final boolean dbConnectionPoolEnabled) {
     final DataSource datasource;
-    if (useCP) {
+    if (dbConnectionPoolEnabled) {
       datasource = createHikariDataSource(jdbcUrl, username, password, configurationFile);
     } else {
       datasource = createPGDataSource(jdbcUrl, username, password, configurationFile);
@@ -66,9 +66,9 @@ public class DbConnection {
       final String username,
       final String password,
       final Path configurationFile,
-      final boolean useCP) {
+      final boolean dbConnectionPoolEnabled) {
     final DataSource datasource;
-    if (useCP) {
+    if (dbConnectionPoolEnabled) {
       final HikariDataSource hkDatasource =
           createHikariDataSource(jdbcUrl, username, password, configurationFile);
       hkDatasource.setMaximumPoolSize(1); // we only need 1 connection in pool for pruning

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactory.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactory.java
@@ -32,7 +32,8 @@ public class SlashingProtectionContextFactory {
             slashingProtectionParameters.getDbUrl(),
             slashingProtectionParameters.getDbUsername(),
             slashingProtectionParameters.getDbPassword(),
-            slashingProtectionParameters.getDbPoolConfigurationFile());
+            slashingProtectionParameters.getDbPoolConfigurationFile(),
+            slashingProtectionParameters.isConnectionPoolEnabled());
     verifyVersion(jdbi);
 
     // create separate Jdbi instance for pruning operations
@@ -41,7 +42,8 @@ public class SlashingProtectionContextFactory {
             slashingProtectionParameters.getDbUrl(),
             slashingProtectionParameters.getDbUsername(),
             slashingProtectionParameters.getDbPassword(),
-            slashingProtectionParameters.getPruningDbPoolConfigurationFile());
+            slashingProtectionParameters.getPruningDbPoolConfigurationFile(),
+            slashingProtectionParameters.isConnectionPoolEnabled());
 
     final ValidatorsDao validatorsDao = new ValidatorsDao();
     final RegisteredValidators registeredValidators = new RegisteredValidators(jdbi, validatorsDao);

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactory.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactory.java
@@ -33,7 +33,7 @@ public class SlashingProtectionContextFactory {
             slashingProtectionParameters.getDbUsername(),
             slashingProtectionParameters.getDbPassword(),
             slashingProtectionParameters.getDbPoolConfigurationFile(),
-            slashingProtectionParameters.isConnectionPoolEnabled());
+            slashingProtectionParameters.isDbConnectionPoolEnabled());
     verifyVersion(jdbi);
 
     // create separate Jdbi instance for pruning operations
@@ -43,7 +43,7 @@ public class SlashingProtectionContextFactory {
             slashingProtectionParameters.getDbUsername(),
             slashingProtectionParameters.getDbPassword(),
             slashingProtectionParameters.getPruningDbPoolConfigurationFile(),
-            slashingProtectionParameters.isConnectionPoolEnabled());
+            slashingProtectionParameters.isDbConnectionPoolEnabled());
 
     final ValidatorsDao validatorsDao = new ValidatorsDao();
     final RegisteredValidators registeredValidators = new RegisteredValidators(jdbi, validatorsDao);

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionParameters.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionParameters.java
@@ -44,4 +44,6 @@ public interface SlashingProtectionParameters {
   long getDbHealthCheckTimeoutMilliseconds();
 
   long getDbHealthCheckIntervalMilliseconds();
+
+  boolean isConnectionPoolEnabled();
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionParameters.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionParameters.java
@@ -45,5 +45,5 @@ public interface SlashingProtectionParameters {
 
   long getDbHealthCheckIntervalMilliseconds();
 
-  boolean isConnectionPoolEnabled();
+  boolean isDbConnectionPoolEnabled();
 }

--- a/slashing-protection/src/testFixtures/java/db/DatabaseUtil.java
+++ b/slashing-protection/src/testFixtures/java/db/DatabaseUtil.java
@@ -26,6 +26,7 @@ public class DatabaseUtil {
   public static final String USERNAME = "postgres";
   public static final String PASSWORD = "postgres";
   public static final String MIGRATIONS_LOCATION = "/migrations/postgresql/";
+  public static final boolean DB_CONNECTION_POOL_ENABLED = true;
 
   public static TestDatabaseInfo create() {
     final TestDatabaseInfo testDatabaseInfo = createWithoutMigration();
@@ -44,10 +45,13 @@ public class DatabaseUtil {
       final EmbeddedPostgres db = EmbeddedPostgres.start();
       final String databaseUrl =
           String.format("jdbc:postgresql://localhost:%d/postgres", db.getPort());
-      final boolean useConnectionPool = true;
       final Jdbi jdbi =
           DbConnection.createConnection(
-              databaseUrl, DatabaseUtil.USERNAME, DatabaseUtil.PASSWORD, null, useConnectionPool);
+              databaseUrl,
+              DatabaseUtil.USERNAME,
+              DatabaseUtil.PASSWORD,
+              null,
+              DB_CONNECTION_POOL_ENABLED);
       return new TestDatabaseInfo(db, jdbi, Optional.empty());
     } catch (IOException e) {
       throw new UncheckedIOException("Unable to create embedded postgres database", e);

--- a/slashing-protection/src/testFixtures/java/db/DatabaseUtil.java
+++ b/slashing-protection/src/testFixtures/java/db/DatabaseUtil.java
@@ -44,9 +44,10 @@ public class DatabaseUtil {
       final EmbeddedPostgres db = EmbeddedPostgres.start();
       final String databaseUrl =
           String.format("jdbc:postgresql://localhost:%d/postgres", db.getPort());
+      final boolean useConnectionPool = true;
       final Jdbi jdbi =
           DbConnection.createConnection(
-              databaseUrl, DatabaseUtil.USERNAME, DatabaseUtil.PASSWORD, null);
+              databaseUrl, DatabaseUtil.USERNAME, DatabaseUtil.PASSWORD, null, useConnectionPool);
       return new TestDatabaseInfo(db, jdbi, Optional.empty());
     } catch (IOException e) {
       throw new UncheckedIOException("Unable to create embedded postgres database", e);

--- a/slashing-protection/src/testFixtures/java/dsl/TestSlashingProtectionParameters.java
+++ b/slashing-protection/src/testFixtures/java/dsl/TestSlashingProtectionParameters.java
@@ -35,7 +35,7 @@ public class TestSlashingProtectionParameters implements SlashingProtectionParam
 
   private final int dbHealthCheckIntervalMilliseconds;
 
-  private final boolean connectionPoolEnabled;
+  private final boolean dbConnectionPoolEnabled;
 
   public TestSlashingProtectionParameters(
       final String dbUrl, final String dbUser, final String dbPassword) {
@@ -83,7 +83,7 @@ public class TestSlashingProtectionParameters implements SlashingProtectionParam
       final long pruningInterval,
       final int dbHealthCheckTimeoutMilliseconds,
       final int dbHealthCheckIntervalMilliseconds,
-      final boolean connectionPoolEnabled) {
+      final boolean dbConnectionPoolEnabled) {
     this.dbUrl = dbUrl;
     this.dbUser = dbUser;
     this.dbPassword = dbPassword;
@@ -96,7 +96,7 @@ public class TestSlashingProtectionParameters implements SlashingProtectionParam
     this.pruningInterval = pruningInterval;
     this.dbHealthCheckTimeoutMilliseconds = dbHealthCheckTimeoutMilliseconds;
     this.dbHealthCheckIntervalMilliseconds = dbHealthCheckIntervalMilliseconds;
-    this.connectionPoolEnabled = connectionPoolEnabled;
+    this.dbConnectionPoolEnabled = dbConnectionPoolEnabled;
   }
 
   @Override
@@ -170,7 +170,7 @@ public class TestSlashingProtectionParameters implements SlashingProtectionParam
   }
 
   @Override
-  public boolean isConnectionPoolEnabled() {
-    return connectionPoolEnabled;
+  public boolean isDbConnectionPoolEnabled() {
+    return dbConnectionPoolEnabled;
   }
 }

--- a/slashing-protection/src/testFixtures/java/dsl/TestSlashingProtectionParameters.java
+++ b/slashing-protection/src/testFixtures/java/dsl/TestSlashingProtectionParameters.java
@@ -35,6 +35,8 @@ public class TestSlashingProtectionParameters implements SlashingProtectionParam
 
   private final int dbHealthCheckIntervalMilliseconds;
 
+  private final boolean connectionPoolEnabled;
+
   public TestSlashingProtectionParameters(
       final String dbUrl, final String dbUser, final String dbPassword) {
     this(dbUrl, dbUser, dbPassword, 0, 0);
@@ -66,7 +68,8 @@ public class TestSlashingProtectionParameters implements SlashingProtectionParam
         pruningSlotsPerEpoch,
         pruningInterval,
         3000,
-        3000);
+        3000,
+        true);
   }
 
   public TestSlashingProtectionParameters(
@@ -79,7 +82,8 @@ public class TestSlashingProtectionParameters implements SlashingProtectionParam
       final int pruningSlotsPerEpoch,
       final long pruningInterval,
       final int dbHealthCheckTimeoutMilliseconds,
-      final int dbHealthCheckIntervalMilliseconds) {
+      final int dbHealthCheckIntervalMilliseconds,
+      final boolean connectionPoolEnabled) {
     this.dbUrl = dbUrl;
     this.dbUser = dbUser;
     this.dbPassword = dbPassword;
@@ -92,6 +96,7 @@ public class TestSlashingProtectionParameters implements SlashingProtectionParam
     this.pruningInterval = pruningInterval;
     this.dbHealthCheckTimeoutMilliseconds = dbHealthCheckTimeoutMilliseconds;
     this.dbHealthCheckIntervalMilliseconds = dbHealthCheckIntervalMilliseconds;
+    this.connectionPoolEnabled = connectionPoolEnabled;
   }
 
   @Override
@@ -162,5 +167,10 @@ public class TestSlashingProtectionParameters implements SlashingProtectionParam
   @Override
   public long getDbHealthCheckIntervalMilliseconds() {
     return dbHealthCheckIntervalMilliseconds;
+  }
+
+  @Override
+  public boolean isConnectionPoolEnabled() {
+    return connectionPoolEnabled;
   }
 }


### PR DESCRIPTION
## PR Description
Introduce cli option to disable internal database connection pooling library (i.e. Hikari). This can be used to use an external connection pool mechanism such as pgBouncer.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
See #662
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
