### PR TITLE
Improve performance of slashing data import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
 ## Next Release
+### Breaking Changes
+- Slashing protection imports will now only fail for an individual validator instead for all validators allowing partial import if there is valid and invalid data.
 
 ### Features Added
 - Introduced cli option to specify Hikari configuration for pruning database connection [#661](https://github.com/ConsenSys/web3signer/issues/661)
 - Better database pruning default values: Pruning enabled by default with `slashing-protection-pruning-epochs-to-keep = 250`, `slashing-protection-pruning-at-boot-enabled = false` and `slashing-protection-pruning-interval = 12`
+- Improved performance for slashing protection import
 
 ## 22.10.0
 

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeImportBadJsonFormattingIntegrationTestBase.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/InterchangeImportBadJsonFormattingIntegrationTestBase.java
@@ -12,12 +12,19 @@
  */
 package tech.pegasys.web3signer.slashingprotection;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestation;
+import tech.pegasys.web3signer.slashingprotection.dao.SignedBlock;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Optional;
 
 import com.google.common.io.Resources;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt64;
 import org.junit.jupiter.api.Test;
 
 public class InterchangeImportBadJsonFormattingIntegrationTestBase extends IntegrationTestBase {
@@ -50,28 +57,79 @@ public class InterchangeImportBadJsonFormattingIntegrationTestBase extends Integ
   }
 
   @Test
-  void anErrorInSubsequentBlockRollsbackToAnEmptyDatabase() {
+  void anErrorInSubsequentBlockRollsbackToAnEmptyDatabase() throws IOException {
     final URL importFile = Resources.getResource("interchange/errorInSecondBlock.json");
-    assertThatThrownBy(
-            () ->
-                slashingProtectionContext
-                    .getSlashingProtection()
-                    .importData(importFile.openStream()))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessage(("Failed to import database content"));
+    slashingProtectionContext.getSlashingProtection().importData(importFile.openStream());
     assertDbIsEmpty(jdbi);
   }
 
   @Test
-  void missingPublicKeyFieldThrowsExceptionAndLeavesDbEmpty() {
+  void anErrorInValidatorIsSkippedAndContinuesToImportsOtherValidators() throws IOException {
+    final URL importFile = Resources.getResource("interchange/errorInSecondValidator.json");
+    slashingProtectionContext.getSlashingProtection().importData(importFile.openStream());
+
+    // blocks
+    assertThat(findAllBlocks()).hasSize(2);
+
+    final Bytes validator1PubKey =
+        Bytes.fromHexString(
+            "0xb845089a1457f811bfc000588fbb4e713669be8ce060ea6be3c6ece09afc3794106c91ca73acda5e5457122d58723bed");
+    final Bytes validator2PubKey =
+        Bytes.fromHexString(
+            "0xb845089a1457f811bfc000588fbb4e713669be8ce060ea6be3c6ece09afc3794106c91ca73acda5e5457122d58723bee");
+    final Bytes validator3PubKey =
+        Bytes.fromHexString(
+            "0xb845089a1457f811bfc000588fbb4e713669be8ce060ea6be3c6ece09afc3794106c91ca73acda5e5457122d58723bef");
+
+    final Optional<SignedBlock> validator1Block = findBlockByPublicKey(validator1PubKey);
+    assertThat(validator1Block).isPresent();
+    assertThat(validator1Block.get().getSlot()).isEqualTo(UInt64.valueOf(12345));
+    assertThat(validator1Block.get().getSigningRoot())
+        .isEqualTo(
+            Optional.of(
+                Bytes.fromHexString(
+                    "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b")));
+
+    final Optional<SignedBlock> validator2Block = findBlockByPublicKey(validator2PubKey);
+    assertThat(validator2Block).isEmpty();
+
+    final Optional<SignedBlock> validator3Block = findBlockByPublicKey(validator3PubKey);
+    assertThat(validator3Block).isPresent();
+    assertThat(validator3Block.get().getSlot()).isEqualTo(UInt64.valueOf(12347));
+    assertThat(validator3Block.get().getSigningRoot())
+        .isEqualTo(
+            Optional.of(
+                Bytes.fromHexString(
+                    "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850c")));
+
+    // attestations
+    assertThat(findAllAttestations()).hasSize(2);
+
+    final Optional<SignedAttestation> validator1Attestation =
+        findAttestationByPublicKey(validator1PubKey);
+    assertThat(validator1Attestation).isPresent();
+    assertThat(validator1Attestation.get().getSourceEpoch()).isEqualTo(UInt64.valueOf(5));
+    assertThat(validator1Attestation.get().getTargetEpoch()).isEqualTo(UInt64.valueOf(6));
+    assertThat(validator1Attestation.get().getSigningRoot())
+        .isEqualTo(Optional.of(Bytes.fromHexString("0x123456")));
+
+    final Optional<SignedAttestation> validator2Attestation =
+        findAttestationByPublicKey(validator2PubKey);
+    assertThat(validator2Attestation).isEmpty();
+
+    final Optional<SignedAttestation> validator3Attestation =
+        findAttestationByPublicKey(validator3PubKey);
+    assertThat(validator3Attestation).isPresent();
+    assertThat(validator3Attestation.get().getSourceEpoch()).isEqualTo(UInt64.valueOf(7));
+    assertThat(validator3Attestation.get().getTargetEpoch()).isEqualTo(UInt64.valueOf(8));
+    assertThat(validator3Attestation.get().getSigningRoot())
+        .isEqualTo(Optional.of(Bytes.fromHexString("0x123457")));
+  }
+
+  @Test
+  void missingPublicKeyFieldThrowsExceptionAndLeavesDbEmpty() throws IOException {
     final URL importFile = Resources.getResource("interchange/missingPublicKey.json");
-    assertThatThrownBy(
-            () ->
-                slashingProtectionContext
-                    .getSlashingProtection()
-                    .importData(importFile.openStream()))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessage(("Failed to import database content"));
+    slashingProtectionContext.getSlashingProtection().importData(importFile.openStream());
     assertDbIsEmpty(jdbi);
   }
 }

--- a/slashing-protection/src/integration-test/resources/interchange/errorInSecondValidator.json
+++ b/slashing-protection/src/integration-test/resources/interchange/errorInSecondValidator.json
@@ -1,0 +1,51 @@
+{
+  "metadata": {
+    "interchange_format_version": "5",
+    "genesis_validators_root": "0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673"
+  },
+  "data": [
+    {
+      "pubkey": "0xb845089a1457f811bfc000588fbb4e713669be8ce060ea6be3c6ece09afc3794106c91ca73acda5e5457122d58723bed",
+      "signed_blocks": [
+        {
+          "slot": "12345",
+          "signing_root": "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b"
+        }
+      ],
+      "signed_attestations": [{
+        "source_epoch": "5",
+        "target_epoch": "6",
+        "signing_root": "0x123456"
+      }
+      ]
+    },
+    {
+      "pubkey": "0xb845089a1457f811bfc000588fbb4e713669be8ce060ea6be3c6ece09afc3794106c91ca73acda5e5457122d58723bee",
+      "signed_blocks": [
+        {
+          "slot": "12345"
+        }
+      ],
+      "signed_attestations": [{
+        "source_epoch": "5",
+        "signing_root": "0x123456"
+      }
+      ]
+    },
+    {
+      "pubkey": "0xb845089a1457f811bfc000588fbb4e713669be8ce060ea6be3c6ece09afc3794106c91ca73acda5e5457122d58723bef",
+      "signed_blocks": [
+        {
+          "slot": "12347",
+          "signing_root": "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850c"
+        }
+      ],
+      "signed_attestations": [{
+        "source_epoch": "7",
+        "target_epoch": "8",
+        "signing_root": "0x123457"
+      }
+      ]
+    }
+  ]
+}

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/AttestationImporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/AttestationImporter.java
@@ -137,11 +137,11 @@ public class AttestationImporter {
                 watermark -> Optional.ofNullable(watermark.getTargetEpoch())));
 
     if (newSourceWatermark.isPresent() && newTargetWatermark.isPresent()) {
-      LOG.info(
+      LOG.debug(
           "Updating validator {} source epoch to {}",
           validator.getPublicKey(),
           newSourceWatermark.get());
-      LOG.info(
+      LOG.debug(
           "Updating validator {} target epoch to {}",
           validator.getPublicKey(),
           newTargetWatermark.get());

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/BlockImporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/BlockImporter.java
@@ -90,7 +90,7 @@ public class BlockImporter {
         lowWatermarkDao.findLowWatermarkForValidator(handle, validator.getId());
 
     if (minSlotTracker.compareTrackedValueTo(watermark.map(SigningWatermark::getSlot)) > 0) {
-      LOG.warn(
+      LOG.debug(
           "Updating Block slot low watermark to {}", minSlotTracker.getTrackedMinValue().get());
       lowWatermarkDao.updateSlotWatermarkFor(
           handle, validator.getId(), minSlotTracker.getTrackedMinValue().get());

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Importer.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Importer.java
@@ -111,8 +111,11 @@ public class InterchangeV5Importer {
                         final JsonNode validatorNode = dataNode.get(i);
                         importValidator(h, validatorNode, pubkeys);
                       });
-                } catch (Exception e) {
-                  LOG.error("Failed importing slashing protection data for validator {}", i);
+                } catch (final Exception e) {
+                  LOG.error(
+                      "Failed importing slashing protection data for validator {} caused by:{}",
+                      i,
+                      e.getMessage());
                 }
               });
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
This improves the performance of slashing data import by parallelising the import of multiple validators at the same time. To do this the import transaction is now done per validator instead of for all the validators so that multiple database connections can be used. Because of this the import now allows the partial import of valid data. That is any invalid data for a validator import now only affects that validator not all of the import.

In my local testing importing a slashing protection file with 4395 validators.
Current import takes: 1:31:14
With #671 changes takes: 0:19:20

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #670 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
