### PR TITLE
Add consensys/errorprone-checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,10 @@ allprojects {
     maven { url "https://jitpack.io" }
   }
 
-  dependencies { errorprone("com.google.errorprone:error_prone_core") }
+  dependencies {
+    errorprone("com.google.errorprone:error_prone_core")
+    errorprone("tech.pegasys.tools.epchecks:errorprone-checks")
+  }
 
   apply plugin: 'com.diffplug.spotless'
   spotless {
@@ -195,6 +198,13 @@ allprojects {
 
       check('InsecureCryptoUsage', CheckSeverity.WARN)
       check('WildcardImport', CheckSeverity.WARN)
+
+      // TODO: Review/fix/enable checks from errorprone-checks.
+      check('DoNotCreateSecureRandomDirectly', CheckSeverity.OFF)
+      check('DoNotInvokeMessageDigestDirectly', CheckSeverity.OFF)
+      check('DoNotReturnNullOptionals', CheckSeverity.OFF)
+      check('JavaCase', CheckSeverity.OFF)
+      check('MethodInputParametersMustBeFinal', CheckSeverity.OFF)
     }
 
     options.encoding = 'UTF-8'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -23,6 +23,8 @@ dependencyManagement {
       entry 'error_prone_test_helpers'
     }
 
+    dependency 'tech.pegasys.tools.epchecks:errorprone-checks:1.1.1'
+
     dependency 'com.google.guava:guava:31.1-jre'
 
     dependency 'commons-cli:commons-cli:1.5.0'


### PR DESCRIPTION
## PR Description

This PR enables the custom checks in [`ConsenSys/errorprone-checks`](https://github.com/ConsenSys/errorprone-checks).

I've disabled the checks with findings. I think those should be fixed in separate PRs.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
