### PR TITLE
[WIP] feat(CST-2526): add loaded key check to health check

### DIFF
--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -295,6 +295,8 @@ public class Eth2Runner extends Runner {
                         keystoresParameters.getKeystoresPath(),
                         keystoresParameters.getKeystoresPasswordFile());
             signers.addAll(keystoreSigners);
+
+            super.registerHealthCheckProcedure("loaded-keys", promise -> promise.complete(blsKeystoreBulkLoader.loadedKeys() ? Status.OK() : Status.KO()));
           }
 
           if (awsSecretsManagerParameters.isEnabled()) {
@@ -305,6 +307,8 @@ public class Eth2Runner extends Runner {
                 awsBulkLoadingArtifactSignerProvider.load(awsSecretsManagerParameters);
             LOG.info("Keys loaded from AWS Secrets Manager: [{}]", awsSigners.size());
             signers.addAll(awsSigners);
+
+            super.registerHealthCheckProcedure("loaded-keys", promise -> promise.complete(awsBulkLoadingArtifactSignerProvider.loadedKeys() ? Status.OK() : Status.KO()));
           }
 
           final List<Bytes> validators =

--- a/core/src/main/resources/openapi-specs/eth2/signing/paths/healthcheck.yaml
+++ b/core/src/main/resources/openapi-specs/eth2/signing/paths/healthcheck.yaml
@@ -5,6 +5,13 @@ get:
   description: |
     Checks the Web3Signer server health status. Confirms if Web3Signer is healthy. Not used by validator clients.
   operationId: 'HEALTHCHECK'
+  parameters:
+    - name: 'loadedKeyCount'
+      in: 'path'
+      required: false
+      description: 'Optional check for expected loaded bls key count'
+      schema:
+        type: 'integer'
   responses:
     '200':
       description: 'System is healthy'

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/AWSBulkLoadingArtifactSignerProvider.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/AWSBulkLoadingArtifactSignerProvider.java
@@ -26,6 +26,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
 public class AWSBulkLoadingArtifactSignerProvider {
+  private static Integer loadedKeyCount = 0;
 
   public Collection<ArtifactSigner> load(final AwsSecretsManagerParameters parameters) {
     try (final AwsSecretsManagerProvider awsSecretsManagerProvider =
@@ -37,11 +38,16 @@ public class AWSBulkLoadingArtifactSignerProvider {
           parameters.getTagNamesFilter(),
           parameters.getTagValuesFilter(),
           (key, value) -> {
+            loadedKeyCount++;
             final Bytes privateKeyBytes = Bytes.fromHexString(value);
             final BLSKeyPair keyPair =
                 new BLSKeyPair(BLSSecretKey.fromBytes(Bytes32.wrap(privateKeyBytes)));
             return new BlsArtifactSigner(keyPair, SignerOrigin.AWS);
           });
     }
+  }
+
+  public boolean loadedKeys() {
+      return loadedKeyCount > 0;
   }
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/BlsKeystoreBulkLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/BlsKeystoreBulkLoader.java
@@ -38,10 +38,12 @@ import org.apache.tuweni.bytes.Bytes32;
 
 public class BlsKeystoreBulkLoader {
   private static final Logger LOG = LogManager.getLogger();
+  private static Integer loadedKeyCount = 0;
 
   public Collection<ArtifactSigner> loadKeystoresUsingPasswordDir(
       final Path keystoresDirectory, final Path passwordsDirectory) {
     final List<Path> keystoreFiles = keystoreFiles(keystoresDirectory);
+    loadedKeyCount = keystoreFiles.size();
     return keystoreFiles.parallelStream()
         .map(
             keystoreFile ->
@@ -62,10 +64,15 @@ public class BlsKeystoreBulkLoader {
       throw new UncheckedIOException("Unable to read the password file", e);
     }
 
+    loadedKeyCount = keystoreFiles.size();
     return keystoreFiles.parallelStream()
         .map(keystoreFile -> createSignerForKeystore(keystoreFile, key -> password))
         .flatMap(Optional::stream)
         .collect(Collectors.toList());
+  }
+
+  public boolean loadedKeys() {
+    return loadedKeyCount > 0;
   }
 
   private Optional<? extends ArtifactSigner> createSignerForKeystore(


### PR DESCRIPTION
## PR Description

Add loaded keys check to health check endpoint,
that way when loading 0 keys health check would fail 
and would allow Kubernetes to restart the pod

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.