### PR TITLE
Fix slf4j 2 logging

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,5 +33,5 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-api'
 
   runtimeOnly 'org.apache.logging.log4j:log4j-core'
-  runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
+  runtimeOnly 'org.apache.logging.log4j:log4j-slf4j2-impl'
 }

--- a/commandline/build.gradle
+++ b/commandline/build.gradle
@@ -35,7 +35,7 @@ dependencies {
   implementation 'tech.pegasys.teku.internal:json'
   implementation 'tech.pegasys.teku.internal:jackson'
 
-  runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
+  runtimeOnly 'org.apache.logging.log4j:log4j-slf4j2-impl'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
   testImplementation 'org.assertj:assertj-core'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -46,11 +46,11 @@ dependencyManagement {
 
     dependency 'javax.activation:activation:1.1.1'
 
-    dependencySet(group: 'org.apache.logging.log4j', version: '2.19.0') {
+    dependencySet(group: 'org.apache.logging.log4j', version: '2.20.0') {
       entry 'log4j-api'
       entry 'log4j'
       entry 'log4j-core'
-      entry 'log4j-slf4j-impl'
+      entry 'log4j-slf4j2-impl'
     }
 
     dependencySet(group: 'org.apache.tuweni', version: '2.3.1') {

--- a/signing/build.gradle
+++ b/signing/build.gradle
@@ -41,7 +41,7 @@ dependencies {
   implementation 'tech.pegasys.teku.internal:jackson'
   implementation 'tech.pegasys.teku.internal:spec'
   implementation 'tech.pegasys.teku.internal:unsigned'
-  runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
+  runtimeOnly 'org.apache.logging.log4j:log4j-slf4j2-impl'
   runtimeOnly 'org.bouncycastle:bcpkix-jdk15on'
   runtimeOnly 'tech.pegasys:jblst'
 

--- a/slashing-protection/build.gradle
+++ b/slashing-protection/build.gradle
@@ -34,8 +34,10 @@ dependencies {
   implementation 'org.jdbi:jdbi3-sqlobject'
   implementation 'org.postgresql:postgresql'
 
-  runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
+  runtimeOnly 'org.apache.logging.log4j:log4j-slf4j2-impl'
 
+  testImplementation 'org.apache.logging.log4j:log4j-api'
+  testImplementation 'org.apache.logging.log4j:log4j-core'
   testImplementation 'io.zonky.test:embedded-postgres'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.flywaydb:flyway-core'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Use slf4j2 API in the log4j bridge. This allows logging from libraries that are using slf4j2 in particular jdbi logs weren't being logged.

The slf4j 2 API is backwards compatible with slf4j 1.

It also fixes the errors on startup complaining about missing SLF4J providers
```
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J: Ignoring binding found at [jar:file:/Users/jframe/.gradle/caches/modules-2/files-2.1/org.apache.logging.log4j/log4j-slf4j-impl/2.19.0/1a0c9615ba9fd5b96db8c1136afbef4394286e93/log4j-slf4j-impl-2.19.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
