### PR TITLE
Implement Healthcheck status for keys loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Upcoming version
+### Features Added
+- Enhanced Healthcheck endpoint reporting status of loading of signers keys [#738](https://github.com/ConsenSys/web3signer/pull/738)
+- Optional AWS endpoint overriding for bulk loading `--aws-endpoint-override`. Useful for local testing against localstack. [#730](https://github.com/ConsenSys/web3signer/issues/730)
+
 ### Bugs Fixed
 - Update of Azure libraries (transitive via signers library) and manual override to fix CVE-2023-1370
 

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/Signer.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/Signer.java
@@ -61,6 +61,7 @@ public class Signer extends FilecoinJsonRpcEndpoint {
   public static final ObjectMapper ETH_2_INTERFACE_OBJECT_MAPPER =
       SigningObjectMapperFactory.createObjectMapper().setSerializationInclusion(Include.NON_NULL);
   private static final String METRICS_ENDPOINT = "/metrics";
+  private static final String HEALTHCHECK_ENDPOINT = "/healthcheck";
 
   private final SignerConfiguration signerConfig;
   private final Web3SignerRunner runner;
@@ -184,5 +185,9 @@ public class Signer extends FilecoinJsonRpcEndpoint {
 
   public Response callReload() {
     return given().baseUri(getUrl()).post(RELOAD_ENDPOINT);
+  }
+
+  public Response healthcheck() {
+    return given().baseUri(getUrl()).get(HEALTHCHECK_ENDPOINT);
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.web3signer.dsl.signer.runner;
 
+import static tech.pegasys.web3signer.commandline.PicoCliAwsSecretsManagerParameters.AWS_ENDPOINT_OVERRIDE_OPTION;
 import static tech.pegasys.web3signer.commandline.PicoCliAwsSecretsManagerParameters.AWS_SECRETS_ACCESS_KEY_ID_OPTION;
 import static tech.pegasys.web3signer.commandline.PicoCliAwsSecretsManagerParameters.AWS_SECRETS_AUTH_MODE_OPTION;
 import static tech.pegasys.web3signer.commandline.PicoCliAwsSecretsManagerParameters.AWS_SECRETS_ENABLED_OPTION;
@@ -421,6 +422,16 @@ public class CmdLineParamsConfigFileImpl implements CmdLineParamsBuilder {
               "eth2." + AWS_SECRETS_TAG_VALUES_FILTER_OPTION.substring(2),
               String.join(",", awsSecretsManagerParameters.getTagValuesFilter())));
     }
+
+    awsSecretsManagerParameters
+        .getEndpointOverride()
+        .ifPresent(
+            uri ->
+                yamlConfig.append(
+                    String.format(
+                        YAML_STRING_FMT,
+                        "eth2." + AWS_ENDPOINT_OVERRIDE_OPTION.substring(2),
+                        uri)));
 
     return yamlConfig.toString();
   }

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.web3signer.dsl.signer.runner;
 
+import static tech.pegasys.web3signer.commandline.PicoCliAwsSecretsManagerParameters.AWS_ENDPOINT_OVERRIDE_OPTION;
 import static tech.pegasys.web3signer.commandline.PicoCliAwsSecretsManagerParameters.AWS_SECRETS_ACCESS_KEY_ID_OPTION;
 import static tech.pegasys.web3signer.commandline.PicoCliAwsSecretsManagerParameters.AWS_SECRETS_AUTH_MODE_OPTION;
 import static tech.pegasys.web3signer.commandline.PicoCliAwsSecretsManagerParameters.AWS_SECRETS_ENABLED_OPTION;
@@ -254,6 +255,14 @@ public class CmdLineParamsDefaultImpl implements CmdLineParamsBuilder {
       params.add(AWS_SECRETS_REGION_OPTION);
       params.add(awsSecretsManagerParameters.getRegion());
     }
+
+    awsSecretsManagerParameters
+        .getEndpointOverride()
+        .ifPresent(
+            uri -> {
+              params.add(AWS_ENDPOINT_OVERRIDE_OPTION);
+              params.add(uri.toString());
+            });
 
     if (!awsSecretsManagerParameters.getPrefixesFilter().isEmpty()) {
       params.add(AWS_SECRETS_PREFIXES_FILTER_OPTION);

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AwsSecretsManagerAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AwsSecretsManagerAcceptanceTest.java
@@ -24,6 +24,7 @@ import tech.pegasys.web3signer.signing.config.AwsSecretsManagerParameters;
 import tech.pegasys.web3signer.signing.config.AwsSecretsManagerParametersBuilder;
 import tech.pegasys.web3signer.tests.AcceptanceTestBase;
 
+import java.net.URI;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
@@ -69,13 +70,20 @@ public class AwsSecretsManagerAcceptanceTest extends AcceptanceTestBase {
   private static final String RO_AWS_SECRET_ACCESS_KEY = System.getenv("AWS_SECRET_ACCESS_KEY");
   private static final String AWS_REGION =
       Optional.ofNullable(System.getenv("AWS_REGION")).orElse("us-east-2");
+
+  // can be pointed to localstack
+  private final Optional<URI> awsEndpointOverride =
+      System.getenv("AWS_ENDPOINT_OVERRIDE") != null
+          ? Optional.of(URI.create(System.getenv("AWS_ENDPOINT_OVERRIDE")))
+          : Optional.empty();
   private AwsSecretsManagerUtil awsSecretsManagerUtil;
   private final List<BLSKeyPair> blsKeyPairs = new ArrayList<>();
 
   @BeforeAll
   void setupAwsResources() {
     awsSecretsManagerUtil =
-        new AwsSecretsManagerUtil(AWS_REGION, RW_AWS_ACCESS_KEY_ID, RW_AWS_SECRET_ACCESS_KEY);
+        new AwsSecretsManagerUtil(
+            AWS_REGION, RW_AWS_ACCESS_KEY_ID, RW_AWS_SECRET_ACCESS_KEY, awsEndpointOverride);
     final SecureRandom secureRandom = new SecureRandom();
 
     for (int i = 0; i < 4; i++) {
@@ -100,6 +108,7 @@ public class AwsSecretsManagerAcceptanceTest extends AcceptanceTestBase {
             .withPrefixesFilter(List.of(awsSecretsManagerUtil.getSecretsManagerPrefix()))
             .withTagNamesFilter(List.of("TagName0", "TagName1"))
             .withTagValuesFilter(List.of("TagValue0", "TagValue1", "TagValue2"))
+            .withEndpointOverride(awsEndpointOverride)
             .build();
 
     final SignerConfigurationBuilder configBuilder =

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AwsSecretsManagerAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AwsSecretsManagerAcceptanceTest.java
@@ -96,7 +96,7 @@ public class AwsSecretsManagerAcceptanceTest extends AcceptanceTestBase {
     }
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{index} - Using config file: {0}")
   @ValueSource(booleans = {true, false})
   void secretsAreLoadedFromAWSSecretsManagerAndReportedByPublicApi(final boolean useConfigFile) {
     final AwsSecretsManagerParameters awsSecretsManagerParameters =
@@ -133,7 +133,7 @@ public class AwsSecretsManagerAcceptanceTest extends AcceptanceTestBase {
             hasSize(2));
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{index} - Using config file: {0}")
   @ValueSource(booleans = {true, false})
   void secretsAreLoadedFromAWSSecretsManagerWithEnvironmentAuthModeAndReportedByPublicApi(
       final boolean useConfigFile) {
@@ -143,6 +143,7 @@ public class AwsSecretsManagerAcceptanceTest extends AcceptanceTestBase {
             .withPrefixesFilter(List.of(awsSecretsManagerUtil.getSecretsManagerPrefix()))
             .withTagNamesFilter(List.of("TagName2", "TagName3"))
             .withTagValuesFilter(List.of("TagValue0", "TagValue2", "TagValue3"))
+            .withEndpointOverride(awsEndpointOverride)
             .build();
 
     final SignerConfigurationBuilder configBuilder =

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AwsSecretsManagerAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AwsSecretsManagerAcceptanceTest.java
@@ -13,6 +13,7 @@
 package tech.pegasys.web3signer.tests.bulkloading;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 import tech.pegasys.teku.bls.BLSKeyPair;
@@ -118,6 +119,13 @@ public class AwsSecretsManagerAcceptanceTest extends AcceptanceTestBase {
             .withAwsSecretsManagerParameters(awsSecretsManagerParameters);
 
     startSigner(configBuilder.build());
+
+    signer
+        .healthcheck()
+        .then()
+        .statusCode(200)
+        .contentType(ContentType.JSON)
+        .body("status", equalTo("UP"));
 
     signer
         .callApiPublicKeys(KeyType.BLS)

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AwsSecretsManagerMultiValueAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AwsSecretsManagerMultiValueAcceptanceTest.java
@@ -25,6 +25,7 @@ import tech.pegasys.web3signer.signing.config.AwsSecretsManagerParameters;
 import tech.pegasys.web3signer.signing.config.AwsSecretsManagerParametersBuilder;
 import tech.pegasys.web3signer.tests.AcceptanceTestBase;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +71,12 @@ public class AwsSecretsManagerMultiValueAcceptanceTest extends AcceptanceTestBas
   private static final String RO_AWS_SECRET_ACCESS_KEY = System.getenv("AWS_SECRET_ACCESS_KEY");
   private static final String AWS_REGION =
       Optional.ofNullable(System.getenv("AWS_REGION")).orElse("us-east-2");
+
+  // can be pointed to localstack
+  private final Optional<URI> awsEndpointOverride =
+      System.getenv("AWS_ENDPOINT_OVERRIDE") != null
+          ? Optional.of(URI.create(System.getenv("AWS_ENDPOINT_OVERRIDE")))
+          : Optional.empty();
   private AwsSecretsManagerUtil awsSecretsManagerUtil;
   private final List<BLSKeyPair> blsKeyPairList = new ArrayList<>(400);
 
@@ -80,7 +87,8 @@ public class AwsSecretsManagerMultiValueAcceptanceTest extends AcceptanceTestBas
     }
 
     awsSecretsManagerUtil =
-        new AwsSecretsManagerUtil(AWS_REGION, RW_AWS_ACCESS_KEY_ID, RW_AWS_SECRET_ACCESS_KEY);
+        new AwsSecretsManagerUtil(
+            AWS_REGION, RW_AWS_ACCESS_KEY_ID, RW_AWS_SECRET_ACCESS_KEY, awsEndpointOverride);
 
     for (int i = 0; i < 4; i++) {
       String multilinePrivKeys =
@@ -103,6 +111,7 @@ public class AwsSecretsManagerMultiValueAcceptanceTest extends AcceptanceTestBas
             .withSecretAccessKey(RO_AWS_SECRET_ACCESS_KEY)
             .withPrefixesFilter(List.of(awsSecretsManagerUtil.getSecretsManagerPrefix()))
             .withTagNamesFilter(List.of("multivalue"))
+            .withEndpointOverride(awsEndpointOverride)
             .build();
 
     final SignerConfigurationBuilder configBuilder =

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AzureKeyVaultAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AzureKeyVaultAcceptanceTest.java
@@ -13,6 +13,7 @@
 package tech.pegasys.web3signer.tests.bulkloading;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 import tech.pegasys.web3signer.dsl.signer.SignerConfigurationBuilder;
@@ -72,6 +73,13 @@ public class AzureKeyVaultAcceptanceTest extends AcceptanceTestBase {
 
     final Response response = signer.callApiPublicKeys(KeyType.BLS);
     response.then().statusCode(200).contentType(ContentType.JSON).body("", hasSize(0));
+
+    signer
+        .healthcheck()
+        .then()
+        .statusCode(503)
+        .contentType(ContentType.JSON)
+        .body("status", equalTo("DOWN"));
   }
 
   @Test

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AzureKeyVaultAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AzureKeyVaultAcceptanceTest.java
@@ -59,6 +59,13 @@ public class AzureKeyVaultAcceptanceTest extends AcceptanceTestBase {
 
     final Response response = signer.callApiPublicKeys(KeyType.BLS);
     response.then().statusCode(200).contentType(ContentType.JSON).body("", contains(EXPECTED_KEY));
+
+    signer
+        .healthcheck()
+        .then()
+        .statusCode(200)
+        .contentType(ContentType.JSON)
+        .body("status", equalTo("UP"));
   }
 
   @Test

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/publickeys/AwsKeyIdentifiersAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/publickeys/AwsKeyIdentifiersAcceptanceTest.java
@@ -17,6 +17,7 @@ import static tech.pegasys.web3signer.signing.KeyType.BLS;
 
 import tech.pegasys.web3signer.AwsSecretsManagerUtil;
 
+import java.net.URI;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -59,6 +60,12 @@ public class AwsKeyIdentifiersAcceptanceTest extends KeyIdentifiersAcceptanceTes
   private static final String AWS_REGION =
       Optional.ofNullable(System.getenv("AWS_REGION")).orElse("us-east-2");
 
+  // can be pointed to localstack
+  private final Optional<URI> awsEndpointOverride =
+      System.getenv("AWS_ENDPOINT_OVERRIDE") != null
+          ? Optional.of(URI.create(System.getenv("AWS_ENDPOINT_OVERRIDE")))
+          : Optional.empty();
+
   private final String privateKey = privateKeys(BLS)[0]; // secret value
   private final String publicKey = BLS_PUBLIC_KEY_1;
 
@@ -67,7 +74,8 @@ public class AwsKeyIdentifiersAcceptanceTest extends KeyIdentifiersAcceptanceTes
   @BeforeAll
   void setup() {
     awsSecretsManagerUtil =
-        new AwsSecretsManagerUtil(AWS_REGION, RW_AWS_ACCESS_KEY_ID, RW_AWS_SECRET_ACCESS_KEY);
+        new AwsSecretsManagerUtil(
+            AWS_REGION, RW_AWS_ACCESS_KEY_ID, RW_AWS_SECRET_ACCESS_KEY, awsEndpointOverride);
     awsSecretsManagerUtil.createSecret(publicKey, privateKey, Collections.emptyMap());
   }
 

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/BlsSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/BlsSigningAcceptanceTest.java
@@ -35,6 +35,7 @@ import tech.pegasys.web3signer.dsl.utils.Eth2RequestUtils;
 import tech.pegasys.web3signer.dsl.utils.MetadataFileHelpers;
 import tech.pegasys.web3signer.signing.KeyType;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Optional;
@@ -178,10 +179,16 @@ public class BlsSigningAcceptanceTest extends SigningAcceptanceTestBase {
     final String roAwsAccessKeyId = System.getenv("AWS_ACCESS_KEY_ID");
     final String roAwsSecretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY");
     final String region = Optional.ofNullable(System.getenv("AWS_REGION")).orElse("us-east-2");
+    // can be pointed to localstack
+    final Optional<URI> awsEndpointOverride =
+        System.getenv("AWS_ENDPOINT_OVERRIDE") != null
+            ? Optional.of(URI.create(System.getenv("AWS_ENDPOINT_OVERRIDE")))
+            : Optional.empty();
     final String publicKey = KEY_PAIR.getPublicKey().toString();
 
     final AwsSecretsManagerUtil awsSecretsManagerUtil =
-        new AwsSecretsManagerUtil(region, rwAwsAccessKeyId, rwAwsSecretAccessKey);
+        new AwsSecretsManagerUtil(
+            region, rwAwsAccessKeyId, rwAwsSecretAccessKey, awsEndpointOverride);
 
     awsSecretsManagerUtil.createSecret(publicKey, PRIVATE_KEY, Collections.emptyMap());
     final String fullyPrefixKeyName = awsSecretsManagerUtil.getSecretsManagerPrefix() + publicKey;

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,6 @@ allprojects {
   targetCompatibility = 11
 
   repositories {
-    mavenLocal() //TODO: Remove me
     mavenCentral()
     maven { url "https://artifacts.consensys.net/public/maven/maven/" }
     maven { url "https://artifacts.consensys.net/public/teku/maven/" }

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,7 @@ allprojects {
   targetCompatibility = 11
 
   repositories {
+    mavenLocal() //TODO: Remove me
     mavenCentral()
     maven { url "https://artifacts.consensys.net/public/maven/maven/" }
     maven { url "https://artifacts.consensys.net/public/teku/maven/" }

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliAwsSecretsManagerParameters.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliAwsSecretsManagerParameters.java
@@ -15,9 +15,11 @@ package tech.pegasys.web3signer.commandline;
 import tech.pegasys.web3signer.signing.config.AwsAuthenticationMode;
 import tech.pegasys.web3signer.signing.config.AwsSecretsManagerParameters;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
@@ -29,6 +31,7 @@ public class PicoCliAwsSecretsManagerParameters implements AwsSecretsManagerPara
   public static final String AWS_SECRETS_SECRET_ACCESS_KEY_OPTION =
       "--aws-secrets-secret-access-key";
   public static final String AWS_SECRETS_REGION_OPTION = "--aws-secrets-region";
+  public static final String AWS_ENDPOINT_OVERRIDE_OPTION = "--aws-endpoint-override";
   public static final String AWS_SECRETS_PREFIXES_FILTER_OPTION = "--aws-secrets-prefixes-filter";
   public static final String AWS_SECRETS_TAG_NAMES_FILTER_OPTION = "--aws-secrets-tag-names-filter";
   public static final String AWS_SECRETS_TAG_VALUES_FILTER_OPTION =
@@ -71,6 +74,12 @@ public class PicoCliAwsSecretsManagerParameters implements AwsSecretsManagerPara
           "AWS region where Secrets Manager service is available. Required for SPECIFIED authentication mode.",
       paramLabel = "<Region>")
   private String region;
+
+  @Option(
+      names = {AWS_ENDPOINT_OVERRIDE_OPTION},
+      description = "Override AWS endpoint.",
+      paramLabel = "<URI>")
+  private Optional<URI> endpointOverride;
 
   @Option(
       names = AWS_SECRETS_PREFIXES_FILTER_OPTION,
@@ -146,5 +155,10 @@ public class PicoCliAwsSecretsManagerParameters implements AwsSecretsManagerPara
   @Override
   public Collection<String> getTagValuesFilter() {
     return tagValuesFilter;
+  }
+
+  @Override
+  public Optional<URI> getEndpointOverride() {
+    return endpointOverride;
   }
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -106,7 +106,8 @@ public class Eth1Runner extends Runner {
                     "yaml",
                     new YamlSignerParser(
                         List.of(ethSecpArtifactSignerFactory),
-                        YamlMapperFactory.createYamlMapper(config.getKeyStoreConfigFileMaxSize())));
+                        YamlMapperFactory.createYamlMapper(config.getKeyStoreConfigFileMaxSize())))
+                .getValues();
           }
         });
   }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -27,7 +27,7 @@ import static tech.pegasys.web3signer.signing.KeyType.BLS;
 
 import tech.pegasys.signers.aws.AwsSecretsManagerProvider;
 import tech.pegasys.signers.azure.AzureKeyVault;
-import tech.pegasys.signers.common.SecretValueResult;
+import tech.pegasys.signers.common.MappedResults;
 import tech.pegasys.signers.hashicorp.HashicorpConnectionFactory;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSecretKey;
@@ -281,7 +281,7 @@ public class Eth2Runner extends Runner {
                     (args) ->
                         new BlsArtifactSigner(args.getKeyPair(), args.getOrigin(), args.getPath()));
 
-            final SecretValueResult<ArtifactSigner> results =
+            final MappedResults<ArtifactSigner> results =
                 new SignerLoader()
                     .load(
                         config.getKeyConfigPath(),
@@ -296,7 +296,7 @@ public class Eth2Runner extends Runner {
 
           if (azureKeyVaultParameters.isAzureKeyVaultEnabled()) {
             LOG.info("Bulk loading keys from Azure key vault ... ");
-            final SecretValueResult<ArtifactSigner> azureResult = loadAzureSigners();
+            final MappedResults<ArtifactSigner> azureResult = loadAzureSigners();
             LOG.info(
                 "Keys loaded from Azure: [{}], with error count: [{}]",
                 azureResult.getValues().size(),
@@ -308,7 +308,7 @@ public class Eth2Runner extends Runner {
           if (keystoresParameters.isEnabled()) {
             LOG.info("Bulk loading keys from local keystores ... ");
             final BlsKeystoreBulkLoader blsKeystoreBulkLoader = new BlsKeystoreBulkLoader();
-            final SecretValueResult<ArtifactSigner> keystoreSignersResult =
+            final MappedResults<ArtifactSigner> keystoreSignersResult =
                 keystoresParameters.hasKeystoresPasswordsPath()
                     ? blsKeystoreBulkLoader.loadKeystoresUsingPasswordDir(
                         keystoresParameters.getKeystoresPath(),
@@ -331,7 +331,7 @@ public class Eth2Runner extends Runner {
             final AWSBulkLoadingArtifactSignerProvider awsBulkLoadingArtifactSignerProvider =
                 new AWSBulkLoadingArtifactSignerProvider();
 
-            final SecretValueResult<ArtifactSigner> awsResult =
+            final MappedResults<ArtifactSigner> awsResult =
                 awsBulkLoadingArtifactSignerProvider.load(awsSecretsManagerParameters);
             LOG.info(
                 "Keys loaded from AWS Secrets Manager: [{}], with error count: [{}]",
@@ -357,7 +357,7 @@ public class Eth2Runner extends Runner {
   }
 
   private void registerSignerLoadingHealthCheck(
-      final String name, final SecretValueResult<ArtifactSigner> result) {
+      final String name, final MappedResults<ArtifactSigner> result) {
     super.registerHealthCheckProcedure(
         name,
         promise -> {
@@ -408,7 +408,7 @@ public class Eth2Runner extends Runner {
     dbPrunerRunner.schedule();
   }
 
-  final SecretValueResult<ArtifactSigner> loadAzureSigners() {
+  final MappedResults<ArtifactSigner> loadAzureSigners() {
     final AzureKeyVault keyVault =
         AzureKeyVaultFactory.createAzureKeyVault(azureKeyVaultParameters);
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
@@ -152,7 +152,8 @@ public class FilecoinRunner extends Runner {
                     "yaml",
                     new YamlSignerParser(
                         List.of(blsArtifactSignerFactory, secpArtifactSignerFactory),
-                        YamlMapperFactory.createYamlMapper(config.getKeyStoreConfigFileMaxSize())));
+                        YamlMapperFactory.createYamlMapper(config.getKeyStoreConfigFileMaxSize())))
+                .getValues();
           }
         });
   }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -13,6 +13,7 @@
 package tech.pegasys.web3signer.core;
 
 import static tech.pegasys.web3signer.core.config.HealthCheckNames.DEFAULT_CHECK;
+import static tech.pegasys.web3signer.core.config.HealthCheckNames.KEYS_CHECK_UNEXPECTED;
 import static tech.pegasys.web3signer.core.service.http.OpenApiOperationsId.HEALTHCHECK;
 import static tech.pegasys.web3signer.core.service.http.OpenApiOperationsId.UPCHECK;
 
@@ -116,6 +117,8 @@ public abstract class Runner implements Runnable {
         artifactSignerProvider.load().get(); // wait for signers to get loaded ...
       } catch (final InterruptedException | ExecutionException e) {
         LOG.error("Error loading signers", e);
+        registerHealthCheckProcedure(
+            KEYS_CHECK_UNEXPECTED, promise -> promise.complete(Status.KO()));
       }
 
       final OpenApiSpecsExtractor openApiSpecsExtractor =

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.web3signer.core;
 
+import static tech.pegasys.web3signer.core.config.HealthCheckNames.DEFAULT_CHECK;
 import static tech.pegasys.web3signer.core.service.http.OpenApiOperationsId.HEALTHCHECK;
 import static tech.pegasys.web3signer.core.service.http.OpenApiOperationsId.UPCHECK;
 
@@ -157,7 +158,7 @@ public abstract class Runner implements Runnable {
           .handler(healthCheckHandler)
           .failureHandler(errorHandler);
 
-      registerHealthCheckProcedure("default-check", promise -> promise.complete(Status.OK()));
+      registerHealthCheckProcedure(DEFAULT_CHECK, promise -> promise.complete(Status.OK()));
 
       final Context context =
           new Context(routerBuilder, metricsSystem, errorHandler, vertx, artifactSignerProvider);

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -104,6 +104,8 @@ public abstract class Runner implements Runnable {
 
     final Vertx vertx = Vertx.vertx(createVertxOptions(metricsSystem));
     final LogErrorHandler errorHandler = new LogErrorHandler();
+    healthCheckHandler = HealthCheckHandler.create(vertx);
+
     final ArtifactSignerProvider artifactSignerProvider =
         createArtifactSignerProvider(vertx, metricsSystem);
 
@@ -152,7 +154,6 @@ public abstract class Runner implements Runnable {
       registerUpcheckRoute(routerBuilder, errorHandler);
       registerHttpHostAllowListHandler(routerBuilder);
 
-      healthCheckHandler = HealthCheckHandler.create(vertx);
       routerBuilder
           .operation(HEALTHCHECK.name())
           .handler(healthCheckHandler)

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/HealthCheckNames.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/HealthCheckNames.java
@@ -17,4 +17,5 @@ public interface HealthCheckNames {
   String SLASHING_PROTECTION_DB = "slashing-protection-db-health-check";
   String KEYS_CHECK_AWS_BULK_LOADING = "keys-check/aws-bulk-loading";
   String KEYS_CHECK_AZURE_BULK_LOADING = "keys-check/azure-bulk-loading";
+  String KEYS_CHECK_KEYSTORE_BULK_LOADING = "keys-check/keystores-bulk-loading";
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/HealthCheckNames.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/HealthCheckNames.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.config;
+
+public interface HealthCheckNames {
+  String DEFAULT_CHECK = "default-check";
+  String SLASHING_PROTECTION_DB = "slashing-protection-db-health-check";
+  String KEYS_CHECK_AWS_BULK_LOADING = "keys-check/aws-bulk-loading";
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/HealthCheckNames.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/HealthCheckNames.java
@@ -18,4 +18,5 @@ public interface HealthCheckNames {
   String KEYS_CHECK_AWS_BULK_LOADING = "keys-check/aws-bulk-loading";
   String KEYS_CHECK_AZURE_BULK_LOADING = "keys-check/azure-bulk-loading";
   String KEYS_CHECK_KEYSTORE_BULK_LOADING = "keys-check/keystores-bulk-loading";
+  String KEYS_CHECK_CONFIG_FILE_LOADING = "keys-check/config-files-loading";
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/HealthCheckNames.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/HealthCheckNames.java
@@ -16,4 +16,5 @@ public interface HealthCheckNames {
   String DEFAULT_CHECK = "default-check";
   String SLASHING_PROTECTION_DB = "slashing-protection-db-health-check";
   String KEYS_CHECK_AWS_BULK_LOADING = "keys-check/aws-bulk-loading";
+  String KEYS_CHECK_AZURE_BULK_LOADING = "keys-check/azure-bulk-loading";
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/HealthCheckNames.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/HealthCheckNames.java
@@ -15,6 +15,7 @@ package tech.pegasys.web3signer.core.config;
 public interface HealthCheckNames {
   String DEFAULT_CHECK = "default-check";
   String SLASHING_PROTECTION_DB = "slashing-protection-db-health-check";
+  String KEYS_CHECK_UNEXPECTED = "keys-check/unexpected";
   String KEYS_CHECK_AWS_BULK_LOADING = "keys-check/aws-bulk-loading";
   String KEYS_CHECK_AZURE_BULK_LOADING = "keys-check/azure-bulk-loading";
   String KEYS_CHECK_KEYSTORE_BULK_LOADING = "keys-check/keystores-bulk-loading";

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -99,9 +99,7 @@ dependencyManagement {
 
     dependency 'tech.pegasys:jblst:0.3.8'
 
-    // TODO: Fix the version once Signers is reviewed and released
-    // Version is build for local dev testing, will not work in CI
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '2.2.7.1') {
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '2.2.8') {
       entry 'bls-keystore'
       entry 'keystorage-hashicorp'
       entry 'keystorage-azure'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -123,8 +123,8 @@ dependencyManagement {
     dependency 'com.github.arteam:simple-json-rpc-server:1.3'
     dependency 'com.github.arteam:simple-json-rpc-client:1.3'
 
-    dependency 'com.azure:azure-security-keyvault-secrets:4.5.2'
-    dependency 'com.azure:azure-identity:1.7.2'
+    dependency 'com.azure:azure-security-keyvault-secrets:4.6.0'
+    dependency 'com.azure:azure-identity:1.8.1'
 
     dependency 'com.zaxxer:HikariCP:5.0.1'
     dependency 'org.postgresql:postgresql:42.5.3'
@@ -180,5 +180,17 @@ dependencyManagement {
        \-- org.apache.tuweni:tuweni-net:2.3.1
      */
     dependency 'commons-net:commons-net:3.9.0'
+
+    // manual overriding of json-smart and nimbus-jost-kwt to avoid CVE-2023-1370
+    /*
+     +--- com.azure:azure-identity -> 1.8.1
+     |    +--- com.microsoft.azure:msal4j:1.13.5
+     |    |    +--- com.nimbusds:oauth2-oidc-sdk:9.35
+     |    |    |    +--- net.minidev:json-smart:[1.3.3,2.4.8] -> 2.4.8
+     |    |    +--- net.minidev:json-smart:2.4.8 (*)
+     */
+
+    dependency 'net.minidev:json-smart:2.4.10'
+    dependency 'com.nimbusds:nimbus-jose-jwt:9.31'
   }
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -99,7 +99,7 @@ dependencyManagement {
 
     dependency 'tech.pegasys:jblst:0.3.8'
 
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '2.2.6') {
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '2.2.6.1') { //TODO: Fix the version
       entry 'bls-keystore'
       entry 'keystorage-hashicorp'
       entry 'keystorage-azure'

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/AWSBulkLoadingArtifactSignerProvider.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/AWSBulkLoadingArtifactSignerProvider.java
@@ -14,7 +14,7 @@ package tech.pegasys.web3signer.signing;
 
 import tech.pegasys.signers.aws.AwsSecretsManager;
 import tech.pegasys.signers.aws.AwsSecretsManagerProvider;
-import tech.pegasys.signers.common.SecretValueResult;
+import tech.pegasys.signers.common.MappedResults;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSecretKey;
 import tech.pegasys.web3signer.signing.config.AwsSecretsManagerFactory;
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes32;
 
 public class AWSBulkLoadingArtifactSignerProvider {
 
-  public SecretValueResult<ArtifactSigner> load(final AwsSecretsManagerParameters parameters) {
+  public MappedResults<ArtifactSigner> load(final AwsSecretsManagerParameters parameters) {
     try (final AwsSecretsManagerProvider awsSecretsManagerProvider =
         new AwsSecretsManagerProvider(parameters.getCacheMaximumSize())) {
       final AwsSecretsManager awsSecretsManager =

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/AWSBulkLoadingArtifactSignerProvider.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/AWSBulkLoadingArtifactSignerProvider.java
@@ -14,20 +14,19 @@ package tech.pegasys.web3signer.signing;
 
 import tech.pegasys.signers.aws.AwsSecretsManager;
 import tech.pegasys.signers.aws.AwsSecretsManagerProvider;
+import tech.pegasys.signers.common.SecretValueResult;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSecretKey;
 import tech.pegasys.web3signer.signing.config.AwsSecretsManagerFactory;
 import tech.pegasys.web3signer.signing.config.AwsSecretsManagerParameters;
 import tech.pegasys.web3signer.signing.config.metadata.SignerOrigin;
 
-import java.util.Collection;
-
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
 public class AWSBulkLoadingArtifactSignerProvider {
 
-  public Collection<ArtifactSigner> load(final AwsSecretsManagerParameters parameters) {
+  public SecretValueResult<ArtifactSigner> load(final AwsSecretsManagerParameters parameters) {
     try (final AwsSecretsManagerProvider awsSecretsManagerProvider =
         new AwsSecretsManagerProvider(parameters.getCacheMaximumSize())) {
       final AwsSecretsManager awsSecretsManager =

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/BlsArtifactSigner.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/BlsArtifactSigner.java
@@ -17,6 +17,7 @@ import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.web3signer.signing.config.metadata.SignerOrigin;
 import tech.pegasys.web3signer.signing.util.IdentifierUtils;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -57,5 +58,18 @@ public class BlsArtifactSigner implements ArtifactSigner {
   // only signers loaded from key store files are editable, everything else is read only
   public boolean isReadOnlyKey() {
     return origin != SignerOrigin.FILE_KEYSTORE;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    BlsArtifactSigner that = (BlsArtifactSigner) o;
+    return keyPair.equals(that.keyPair);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(keyPair);
   }
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/BlsKeystoreBulkLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/BlsKeystoreBulkLoader.java
@@ -24,8 +24,9 @@ import tech.pegasys.web3signer.signing.config.metadata.SignerOrigin;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -55,7 +56,7 @@ public class BlsKeystoreBulkLoader {
                     keystoreFile,
                     key -> Files.readString(passwordsDirectory.resolve(key + ".txt"))))
         .reduce(
-            SecretValueResult.newInstance(new ArrayList<>(), 0),
+            SecretValueResult.newInstance(new HashSet<>(), 0),
             (r1, r2) -> {
               r1.merge(r2);
               return r1;
@@ -83,7 +84,7 @@ public class BlsKeystoreBulkLoader {
     return keystoreFiles.parallelStream()
         .map(keystoreFile -> createSignerForKeystore(keystoreFile, key -> password))
         .reduce(
-            SecretValueResult.newInstance(new ArrayList<>(), 0),
+            SecretValueResult.newInstance(new HashSet<>(), 0),
             (r1, r2) -> {
               r1.merge(r2);
               return r1;
@@ -101,7 +102,7 @@ public class BlsKeystoreBulkLoader {
       final BLSKeyPair keyPair = new BLSKeyPair(BLSSecretKey.fromBytes(Bytes32.wrap(privateKey)));
       final BlsArtifactSigner artifactSigner =
           new BlsArtifactSigner(keyPair, SignerOrigin.FILE_KEYSTORE);
-      return SecretValueResult.newInstance(List.of(artifactSigner), 0);
+      return SecretValueResult.newInstance(Set.of(artifactSigner), 0);
     } catch (final KeyStoreValidationException | IOException e) {
       LOG.error("Keystore could not be loaded {}", keystoreFile, e);
       return SecretValueResult.errorResult();

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/BlsKeystoreBulkLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/BlsKeystoreBulkLoader.java
@@ -16,17 +16,17 @@ import tech.pegasys.signers.bls.keystore.KeyStore;
 import tech.pegasys.signers.bls.keystore.KeyStoreLoader;
 import tech.pegasys.signers.bls.keystore.KeyStoreValidationException;
 import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
+import tech.pegasys.signers.common.SecretValueResult;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSecretKey;
 import tech.pegasys.web3signer.signing.config.metadata.SignerOrigin;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -39,36 +39,66 @@ import org.apache.tuweni.bytes.Bytes32;
 public class BlsKeystoreBulkLoader {
   private static final Logger LOG = LogManager.getLogger();
 
-  public Collection<ArtifactSigner> loadKeystoresUsingPasswordDir(
+  public SecretValueResult<ArtifactSigner> loadKeystoresUsingPasswordDir(
       final Path keystoresDirectory, final Path passwordsDirectory) {
-    final List<Path> keystoreFiles = keystoreFiles(keystoresDirectory);
-    return keystoreFiles.parallelStream()
-        .map(
-            keystoreFile ->
-                createSignerForKeystore(
-                    keystoreFile,
-                    key -> Files.readString(passwordsDirectory.resolve(key + ".txt"))))
-        .flatMap(Optional::stream)
-        .collect(Collectors.toList());
+    final List<Path> keystoreFiles;
+    try {
+      keystoreFiles = keystoreFiles(keystoresDirectory);
+    } catch (final IOException e) {
+      LOG.error("Error reading keystore files", e);
+      return new SecretValueResult<>(Collections.emptyList(), 1);
+    }
+
+    final List<SecretValueResult<ArtifactSigner>> resultList =
+        keystoreFiles.parallelStream()
+            .map(
+                keystoreFile ->
+                    createSignerForKeystore(
+                        keystoreFile,
+                        key -> Files.readString(passwordsDirectory.resolve(key + ".txt"))))
+            .collect(Collectors.toList());
+
+    return combineResults(resultList);
   }
 
-  public Collection<ArtifactSigner> loadKeystoresUsingPasswordFile(
+  public SecretValueResult<ArtifactSigner> loadKeystoresUsingPasswordFile(
       final Path keystoresDirectory, final Path passwordFile) {
-    final List<Path> keystoreFiles = keystoreFiles(keystoresDirectory);
+    final List<Path> keystoreFiles;
+    try {
+      keystoreFiles = keystoreFiles(keystoresDirectory);
+    } catch (final IOException e) {
+      LOG.error("Error reading keystore files", e);
+      return new SecretValueResult<>(Collections.emptyList(), 1);
+    }
+
     final String password;
     try {
       password = Files.readString(passwordFile);
     } catch (final IOException e) {
-      throw new UncheckedIOException("Unable to read the password file", e);
+      LOG.error("Unable to read password file", e);
+      return new SecretValueResult<>(Collections.emptyList(), 1);
     }
 
-    return keystoreFiles.parallelStream()
-        .map(keystoreFile -> createSignerForKeystore(keystoreFile, key -> password))
-        .flatMap(Optional::stream)
-        .collect(Collectors.toList());
+    final List<SecretValueResult<ArtifactSigner>> resultList =
+        keystoreFiles.parallelStream()
+            .map(keystoreFile -> createSignerForKeystore(keystoreFile, key -> password))
+            .collect(Collectors.toList());
+
+    return combineResults(resultList);
   }
 
-  private Optional<? extends ArtifactSigner> createSignerForKeystore(
+  private static SecretValueResult<ArtifactSigner> combineResults(
+      List<SecretValueResult<ArtifactSigner>> resultList) {
+    final Collection<ArtifactSigner> combinedValues =
+        resultList.stream()
+            .flatMap(result -> result.getValues().stream())
+            .collect(Collectors.toList());
+    final int totalErrorCount =
+        resultList.stream().mapToInt(SecretValueResult::getErrorCount).sum();
+    return new SecretValueResult<>(combinedValues, totalErrorCount);
+  }
+
+  private SecretValueResult<ArtifactSigner> createSignerForKeystore(
       final Path keystoreFile, final PasswordRetriever passwordRetriever) {
     try {
       LOG.debug("Loading keystore {}", keystoreFile);
@@ -79,10 +109,10 @@ public class BlsKeystoreBulkLoader {
       final BLSKeyPair keyPair = new BLSKeyPair(BLSSecretKey.fromBytes(Bytes32.wrap(privateKey)));
       final BlsArtifactSigner artifactSigner =
           new BlsArtifactSigner(keyPair, SignerOrigin.FILE_KEYSTORE);
-      return Optional.of(artifactSigner);
+      return new SecretValueResult<>(List.of(artifactSigner), 0);
     } catch (final KeyStoreValidationException | IOException e) {
       LOG.error("Keystore could not be loaded {}", keystoreFile, e);
-      return Optional.empty();
+      return new SecretValueResult<>(Collections.emptyList(), 1);
     }
   }
 
@@ -91,13 +121,11 @@ public class BlsKeystoreBulkLoader {
     String retrievePassword(final String key) throws IOException;
   }
 
-  private List<Path> keystoreFiles(final Path keystoresPath) {
+  private List<Path> keystoreFiles(final Path keystoresPath) throws IOException {
     try (final Stream<Path> fileStream = Files.list(keystoresPath)) {
       return fileStream
           .filter(path -> FilenameUtils.getExtension(path.toString()).equalsIgnoreCase("json"))
           .collect(Collectors.toList());
-    } catch (final IOException e) {
-      throw new UncheckedIOException("Unable to access the supplied keystore directory", e);
     }
   }
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/EthSecpArtifactSigner.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/EthSecpArtifactSigner.java
@@ -16,6 +16,8 @@ import tech.pegasys.signers.secp256k1.EthPublicKeyUtils;
 import tech.pegasys.signers.secp256k1.api.Signer;
 import tech.pegasys.web3signer.signing.util.IdentifierUtils;
 
+import java.util.Objects;
+
 import org.apache.tuweni.bytes.Bytes;
 
 public class EthSecpArtifactSigner implements ArtifactSigner {
@@ -34,5 +36,18 @@ public class EthSecpArtifactSigner implements ArtifactSigner {
   @Override
   public SecpArtifactSignature sign(final Bytes message) {
     return new SecpArtifactSignature(signer.sign(message.toArray()));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EthSecpArtifactSigner that = (EthSecpArtifactSigner) o;
+    return getIdentifier().equals(that.getIdentifier());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getIdentifier());
   }
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/FcBlsArtifactSigner.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/FcBlsArtifactSigner.java
@@ -18,6 +18,8 @@ import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.web3signer.signing.filecoin.FilecoinAddress;
 import tech.pegasys.web3signer.signing.filecoin.FilecoinNetwork;
 
+import java.util.Objects;
+
 import org.apache.tuweni.bytes.Bytes;
 
 public class FcBlsArtifactSigner implements ArtifactSigner {
@@ -41,5 +43,18 @@ public class FcBlsArtifactSigner implements ArtifactSigner {
   public BlsArtifactSignature sign(final Bytes message) {
     final BLSSignature blsSignature = BLS.sign(keyPair.getSecretKey(), message, FC_DST);
     return new BlsArtifactSignature(blsSignature);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    FcBlsArtifactSigner that = (FcBlsArtifactSigner) o;
+    return keyPair.equals(that.keyPair);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(keyPair);
   }
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/FcSecpArtifactSigner.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/FcSecpArtifactSigner.java
@@ -20,6 +20,7 @@ import tech.pegasys.web3signer.signing.util.Blake2b;
 
 import java.math.BigInteger;
 import java.security.interfaces.ECPublicKey;
+import java.util.Objects;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.bouncycastle.asn1.ASN1Sequence;
@@ -57,5 +58,18 @@ public class FcSecpArtifactSigner implements ArtifactSigner {
             ethSignature.getS());
 
     return new SecpArtifactSignature(fcSignature);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EthSecpArtifactSigner that = (EthSecpArtifactSigner) o;
+    return getIdentifier().equals(that.getIdentifier());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getIdentifier());
   }
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/AwsSecretsManagerFactory.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/AwsSecretsManagerFactory.java
@@ -25,9 +25,11 @@ public class AwsSecretsManagerFactory {
         return awsSecretsManagerProvider.createAwsSecretsManager(
             awsSecretsManagerParameters.getAccessKeyId(),
             awsSecretsManagerParameters.getSecretAccessKey(),
-            awsSecretsManagerParameters.getRegion());
+            awsSecretsManagerParameters.getRegion(),
+            awsSecretsManagerParameters.getEndpointOverride());
       default:
-        return awsSecretsManagerProvider.createAwsSecretsManager();
+        return awsSecretsManagerProvider.createAwsSecretsManager(
+            awsSecretsManagerParameters.getEndpointOverride());
     }
   }
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/AwsSecretsManagerParameters.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/AwsSecretsManagerParameters.java
@@ -12,8 +12,10 @@
  */
 package tech.pegasys.web3signer.signing.config;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 
 public interface AwsSecretsManagerParameters {
   boolean isEnabled();
@@ -41,4 +43,11 @@ public interface AwsSecretsManagerParameters {
   default Collection<String> getTagValuesFilter() {
     return Collections.emptyList();
   }
+
+  /**
+   * Can be used to override AWS endpoint to localstack
+   *
+   * @return optional URI
+   */
+  Optional<URI> getEndpointOverride();
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.web3signer.signing.config;
 
-import tech.pegasys.signers.common.SecretValueResult;
+import tech.pegasys.signers.common.MappedResults;
 import tech.pegasys.web3signer.signing.ArtifactSigner;
 import tech.pegasys.web3signer.signing.config.metadata.parser.SignerParser;
 
@@ -49,7 +49,7 @@ public class SignerLoader {
 
   private static final Map<Path, FileTime> metadataConfigFilesPathCache = new HashMap<>();
 
-  public SecretValueResult<ArtifactSigner> load(
+  public MappedResults<ArtifactSigner> load(
       final Path configsDirectory, final String fileExtension, final SignerParser signerParser) {
     final Instant start = Instant.now();
     LOG.info("Loading signer configuration metadata files from {}", configsDirectory);
@@ -66,7 +66,7 @@ public class SignerLoader {
         configFilesContentMap.size(),
         timeTaken);
 
-    final SecretValueResult<ArtifactSigner> metadataResult =
+    final MappedResults<ArtifactSigner> metadataResult =
         processMetadataFilesInParallel(configFilesContentMap, signerParser);
     metadataResult.mergeErrorCount(configFileErrorCount);
     return metadataResult;
@@ -125,7 +125,7 @@ public class SignerLoader {
     return new SimpleEntry<>(path, Files.readString(path, StandardCharsets.UTF_8));
   }
 
-  private SecretValueResult<ArtifactSigner> processMetadataFilesInParallel(
+  private MappedResults<ArtifactSigner> processMetadataFilesInParallel(
       final Map<Path, String> configFilesContent, final SignerParser signerParser) {
     // use custom fork-join pool instead of common. Limit number of threads to avoid Azure bug
     ForkJoinPool forkJoinPool = null;
@@ -135,7 +135,7 @@ public class SignerLoader {
     } catch (final Exception e) {
       LOG.error(
           "Unexpected error in processing configuration files in parallel: {}", e.getMessage(), e);
-      return SecretValueResult.errorResult();
+      return MappedResults.errorResult();
     } finally {
       if (forkJoinPool != null) {
         forkJoinPool.shutdown();
@@ -143,7 +143,7 @@ public class SignerLoader {
     }
   }
 
-  private SecretValueResult<ArtifactSigner> parseMetadataFiles(
+  private MappedResults<ArtifactSigner> parseMetadataFiles(
       final Map<Path, String> configFilesContents, final SignerParser signerParser) {
     LOG.info("Parsing configuration metadata files");
 
@@ -176,7 +176,7 @@ public class SignerLoader {
         "Total signers loaded from configuration files: {} in {}",
         artifactSigners.size(),
         timeTaken);
-    return SecretValueResult.newInstance(artifactSigners, errorCount.get());
+    return MappedResults.newInstance(artifactSigners, errorCount.get());
   }
 
   private boolean matchesFileExtension(final String validFileExtension, final Path filename) {

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
@@ -12,8 +12,6 @@
  */
 package tech.pegasys.web3signer.signing.config;
 
-import static java.util.Collections.emptyMap;
-
 import tech.pegasys.signers.common.SecretValueResult;
 import tech.pegasys.web3signer.signing.ArtifactSigner;
 import tech.pegasys.web3signer.signing.config.metadata.parser.SignerParser;
@@ -77,10 +75,10 @@ public class SignerLoader {
   private Pair<Map<Path, String>, Integer> getNewOrModifiedConfigFilesContents(
       final Path configsDirectory, final String fileExtension) {
     final AtomicInteger errorCount = new AtomicInteger(0);
-
+    final Map<Path, String> configFileMap = new HashMap<>();
     // read configuration files without converting them to signers first.
     try (final Stream<Path> fileStream = Files.list(configsDirectory)) {
-      final Map<Path, String> mapOfConfigFiles =
+      final Map<Path, String> _map =
           fileStream
               .filter(path -> matchesFileExtension(fileExtension, path))
               .filter(this::isNewOrModifiedMetadataFile)
@@ -96,11 +94,12 @@ public class SignerLoader {
                   })
               .filter(Objects::nonNull)
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-      return Pair.of(mapOfConfigFiles, errorCount.get());
+      configFileMap.putAll(_map);
     } catch (final IOException e) {
       LOG.error("Unable to access the supplied key directory", e);
-      return Pair.of(emptyMap(), errorCount.get());
+      errorCount.incrementAndGet();
     }
+    return Pair.of(configFileMap, errorCount.get());
   }
 
   private boolean isNewOrModifiedMetadataFile(final Path path) {

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
@@ -173,9 +173,10 @@ public class SignerLoader {
         DurationFormatUtils.formatDurationHMS(Duration.between(start, Instant.now()).toMillis());
     LOG.info("Total configuration metadata files processed: {}", configFilesHandled.get());
     LOG.info(
-        "Total signers loaded from configuration files: {} in {}",
+        "Total signers loaded from configuration files: {} in {} with error count {}",
         artifactSigners.size(),
-        timeTaken);
+        timeTaken,
+        errorCount.get());
     return MappedResults.newInstance(artifactSigners, errorCount.get());
   }
 

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AwsKeySigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AwsKeySigningMetadata.java
@@ -17,6 +17,9 @@ import tech.pegasys.web3signer.signing.KeyType;
 import tech.pegasys.web3signer.signing.config.AwsAuthenticationMode;
 import tech.pegasys.web3signer.signing.config.AwsSecretsManagerParameters;
 
+import java.net.URI;
+import java.util.Optional;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(using = AwsKeySigningMetadataDeserializer.class)
@@ -27,19 +30,22 @@ public class AwsKeySigningMetadata extends SigningMetadata implements AwsSecrets
   private final String accessKeyId;
   private final String secretAccessKey;
   private final String secretName;
+  private final Optional<URI> endpointOverride;
 
   public AwsKeySigningMetadata(
       final AwsAuthenticationMode authenticationMode,
       final String region,
       final String accessKeyId,
       final String secretAccessKey,
-      final String secretName) {
+      final String secretName,
+      final Optional<URI> endpointOverride) {
     super(KeyType.BLS);
     this.authenticationMode = authenticationMode;
     this.region = region;
     this.accessKeyId = accessKeyId;
     this.secretAccessKey = secretAccessKey;
     this.secretName = secretName;
+    this.endpointOverride = endpointOverride;
   }
 
   @Override
@@ -74,5 +80,10 @@ public class AwsKeySigningMetadata extends SigningMetadata implements AwsSecrets
   @Override
   public ArtifactSigner createSigner(final ArtifactSignerFactory factory) {
     return factory.create(this);
+  }
+
+  @Override
+  public Optional<URI> getEndpointOverride() {
+    return endpointOverride;
   }
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AwsKeySigningMetadataDeserializer.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AwsKeySigningMetadataDeserializer.java
@@ -15,8 +15,10 @@ package tech.pegasys.web3signer.signing.config.metadata;
 import tech.pegasys.web3signer.signing.config.AwsAuthenticationMode;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -31,6 +33,7 @@ public class AwsKeySigningMetadataDeserializer extends StdDeserializer<AwsKeySig
   public static final String ACCESS_KEY_ID = "accessKeyId";
   public static final String SECRET_ACCESS_KEY = "secretAccessKey";
   public static final String SECRET_NAME = "secretName";
+  public static final String ENDPOINT_OVERRIDE = "endpointOverride";
 
   @SuppressWarnings("Unused")
   public AwsKeySigningMetadataDeserializer() {
@@ -50,6 +53,7 @@ public class AwsKeySigningMetadataDeserializer extends StdDeserializer<AwsKeySig
     String accessKeyId = null;
     String secretAccessKey = null;
     String secretName = null;
+    Optional<URI> endpointOverride = Optional.empty();
 
     final JsonNode node = parser.getCodec().readTree(parser);
 
@@ -78,8 +82,13 @@ public class AwsKeySigningMetadataDeserializer extends StdDeserializer<AwsKeySig
       secretName = node.get(SECRET_NAME).asText();
     }
 
+    if (node.get(ENDPOINT_OVERRIDE) != null) {
+      endpointOverride = Optional.of(URI.create(node.get(ENDPOINT_OVERRIDE).asText()));
+    }
+
     final AwsKeySigningMetadata awsKeySigningMetadata =
-        new AwsKeySigningMetadata(authMode, region, accessKeyId, secretAccessKey, secretName);
+        new AwsKeySigningMetadata(
+            authMode, region, accessKeyId, secretAccessKey, secretName, endpointOverride);
 
     validate(parser, awsKeySigningMetadata);
 

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/BlsArtifactSignerFactory.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/BlsArtifactSignerFactory.java
@@ -40,7 +40,6 @@ import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer.TimingContext;
 
 public class BlsArtifactSignerFactory extends AbstractArtifactSignerFactory {
-
   private final LabelledMetric<OperationTimer> privateKeyRetrievalTimer;
   private final Function<BlsArtifactSignerArgs, ArtifactSigner> signerFactory;
   private final AwsSecretsManagerProvider awsSecretsManagerProvider;

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/parser/YamlSignerParser.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/parser/YamlSignerParser.java
@@ -44,7 +44,9 @@ public class YamlSignerParser implements SignerParser {
   public List<ArtifactSigner> parse(final String fileContent) {
     try {
       final List<SigningMetadata> metadataInfoList = readSigningMetadata(fileContent);
-
+      if (metadataInfoList == null || metadataInfoList.isEmpty()) {
+        throw new SigningMetadataException("Invalid signing metadata file format");
+      }
       return metadataInfoList.stream()
           .flatMap(
               metadataInfo ->

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/BlsKeystoreBulkLoaderTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/BlsKeystoreBulkLoaderTest.java
@@ -13,14 +13,13 @@
 package tech.pegasys.web3signer.signing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import tech.pegasys.signers.common.SecretValueResult;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.web3signer.BLSTestUtil;
 import tech.pegasys.web3signer.KeystoreUtil;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -39,20 +38,25 @@ class BlsKeystoreBulkLoaderTest {
   @Test
   void loadingEmptyKeystoreDirReturnsNoSigners(
       final @TempDir Path keystoreDir, final @TempDir Path passwordDir) {
-    final Collection<ArtifactSigner> signers =
+    SecretValueResult<ArtifactSigner> result =
         loader.loadKeystoresUsingPasswordDir(keystoreDir, passwordDir);
-    assertThat(signers).isEmpty();
+    assertThat(result.getValues()).isEmpty();
+    assertThat(result.getErrorCount()).isEqualTo(0);
   }
 
   @Test
   void loadsMultipleKeystores(final @TempDir Path keystoreDir, final @TempDir Path passwordDir) {
     KeystoreUtil.createKeystore(KEY_PAIR_1, keystoreDir, passwordDir, "password1");
     KeystoreUtil.createKeystore(KEY_PAIR_2, keystoreDir, passwordDir, KEYSTORE_PASSWORD_2);
-    final Collection<ArtifactSigner> signers =
+    final SecretValueResult<ArtifactSigner> result =
         loader.loadKeystoresUsingPasswordDir(keystoreDir, passwordDir);
+    final Collection<ArtifactSigner> signers = result.getValues();
+
     assertThat(signers).hasSize(2);
     assertThatSignerHasPublicKey(signers, KEY_PAIR_1);
     assertThatSignerHasPublicKey(signers, KEY_PAIR_2);
+
+    assertThat(result.getErrorCount()).isEqualTo(0);
   }
 
   @Test
@@ -65,11 +69,14 @@ class BlsKeystoreBulkLoaderTest {
     final Path passwordFile = tempDir.resolve("password.txt");
     Files.writeString(passwordFile, KEYSTORE_PASSWORD_1);
 
-    final Collection<ArtifactSigner> signers =
+    final SecretValueResult<ArtifactSigner> result =
         loader.loadKeystoresUsingPasswordFile(keystoreDir, passwordFile);
+    final Collection<ArtifactSigner> signers = result.getValues();
     assertThat(signers).hasSize(2);
     assertThatSignerHasPublicKey(signers, KEY_PAIR_1);
     assertThatSignerHasPublicKey(signers, KEY_PAIR_2);
+
+    assertThat(result.getErrorCount()).isEqualTo(0);
   }
 
   @Test
@@ -83,22 +90,28 @@ class BlsKeystoreBulkLoaderTest {
     final Path targetPath = keystoreDir.resolve(KEY_PAIR_1.getPublicKey() + ".ignored");
     Files.move(sourcePath, targetPath);
 
-    final Collection<ArtifactSigner> signers =
+    final SecretValueResult<ArtifactSigner> result =
         loader.loadKeystoresUsingPasswordDir(keystoreDir, passwordDir);
+    final Collection<ArtifactSigner> signers = result.getValues();
     assertThat(signers).hasSize(1);
     assertThatSignerHasPublicKey(signers, KEY_PAIR_2);
+
+    assertThat(result.getErrorCount()).isEqualTo(0);
   }
 
   @Test
-  void keystoreWithoutPasswordIsIgnoredAndRemainingKeystoresAreLoaded(
+  void keystoreWithoutPasswordCausesErrorCountAndRemainingKeystoresAreLoaded(
       final @TempDir Path keystoreDir, final @TempDir Path passwordDir) {
     KeystoreUtil.createKeystoreFile(KEY_PAIR_1, keystoreDir, KEYSTORE_PASSWORD_1);
     KeystoreUtil.createKeystore(KEY_PAIR_2, keystoreDir, passwordDir, KEYSTORE_PASSWORD_2);
 
-    final Collection<ArtifactSigner> signers =
+    final SecretValueResult<ArtifactSigner> result =
         loader.loadKeystoresUsingPasswordDir(keystoreDir, passwordDir);
+    final Collection<ArtifactSigner> signers = result.getValues();
     assertThat(signers).hasSize(1);
     assertThatSignerHasPublicKey(signers, KEY_PAIR_2);
+
+    assertThat(result.getErrorCount()).isEqualTo(1);
   }
 
   @Test
@@ -108,33 +121,36 @@ class BlsKeystoreBulkLoaderTest {
     KeystoreUtil.createKeystorePasswordFile(KEY_PAIR_1, passwordDir, KEYSTORE_PASSWORD_1);
     KeystoreUtil.createKeystore(KEY_PAIR_2, keystoreDir, passwordDir, KEYSTORE_PASSWORD_2);
 
-    final Collection<ArtifactSigner> signers =
+    final SecretValueResult<ArtifactSigner> result =
         loader.loadKeystoresUsingPasswordDir(keystoreDir, passwordDir);
+    final Collection<ArtifactSigner> signers = result.getValues();
     assertThat(signers).hasSize(1);
     assertThatSignerHasPublicKey(signers, KEY_PAIR_2);
+
+    assertThat(result.getErrorCount()).isEqualTo(1);
   }
 
   @Test
-  void invalidKeystoreDirectoryThrowsError(
+  void invalidKeystoreDirectoryReturnsErrorCount(
       final @TempDir Path keystoreDir, final @TempDir Path passwordDir) {
-    assertThatThrownBy(
-            () ->
-                loader.loadKeystoresUsingPasswordDir(
-                    keystoreDir.resolve("invalidKeystorePath"), passwordDir))
-        .isInstanceOf(UncheckedIOException.class)
-        .hasMessage("Unable to access the supplied keystore directory");
+    final SecretValueResult<ArtifactSigner> result =
+        loader.loadKeystoresUsingPasswordDir(
+            keystoreDir.resolve("invalidKeystorePath"), passwordDir);
+    assertThat(result.getValues()).isEmpty();
+    assertThat(result.getErrorCount()).isEqualTo(1);
   }
 
   @Test
-  void invalidKeystorePasswordFileThrowsError(final @TempDir Path tempDir) throws IOException {
+  void invalidKeystorePasswordFileReturnsErrorCount(final @TempDir Path tempDir)
+      throws IOException {
     final Path keystoreDir = tempDir.resolve("keystores");
     Files.createDirectory(keystoreDir);
-    assertThatThrownBy(
-            () ->
-                loader.loadKeystoresUsingPasswordFile(
-                    keystoreDir, tempDir.resolve("invalidPasswordFilePath")))
-        .isInstanceOf(UncheckedIOException.class)
-        .hasMessage("Unable to read the password file");
+
+    final SecretValueResult<ArtifactSigner> result =
+        loader.loadKeystoresUsingPasswordFile(
+            keystoreDir, tempDir.resolve("invalidPasswordFilePath"));
+    assertThat(result.getValues()).isEmpty();
+    assertThat(result.getErrorCount()).isEqualTo(1);
   }
 
   private void assertThatSignerHasPublicKey(

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/BlsKeystoreBulkLoaderTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/BlsKeystoreBulkLoaderTest.java
@@ -111,7 +111,7 @@ class BlsKeystoreBulkLoaderTest {
     assertThat(signers).hasSize(1);
     assertThatSignerHasPublicKey(signers, KEY_PAIR_2);
 
-    assertThat(result.getErrorCount()).isEqualTo(1);
+    assertThat(result.getErrorCount()).isEqualTo(2);
   }
 
   @Test
@@ -127,7 +127,7 @@ class BlsKeystoreBulkLoaderTest {
     assertThat(signers).hasSize(1);
     assertThatSignerHasPublicKey(signers, KEY_PAIR_2);
 
-    assertThat(result.getErrorCount()).isEqualTo(1);
+    assertThat(result.getErrorCount()).isEqualTo(2);
   }
 
   @Test

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/BlsKeystoreBulkLoaderTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/BlsKeystoreBulkLoaderTest.java
@@ -14,7 +14,7 @@ package tech.pegasys.web3signer.signing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import tech.pegasys.signers.common.SecretValueResult;
+import tech.pegasys.signers.common.MappedResults;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.web3signer.BLSTestUtil;
 import tech.pegasys.web3signer.KeystoreUtil;
@@ -38,7 +38,7 @@ class BlsKeystoreBulkLoaderTest {
   @Test
   void loadingEmptyKeystoreDirReturnsNoSigners(
       final @TempDir Path keystoreDir, final @TempDir Path passwordDir) {
-    SecretValueResult<ArtifactSigner> result =
+    MappedResults<ArtifactSigner> result =
         loader.loadKeystoresUsingPasswordDir(keystoreDir, passwordDir);
     assertThat(result.getValues()).isEmpty();
     assertThat(result.getErrorCount()).isEqualTo(0);
@@ -48,7 +48,7 @@ class BlsKeystoreBulkLoaderTest {
   void loadsMultipleKeystores(final @TempDir Path keystoreDir, final @TempDir Path passwordDir) {
     KeystoreUtil.createKeystore(KEY_PAIR_1, keystoreDir, passwordDir, "password1");
     KeystoreUtil.createKeystore(KEY_PAIR_2, keystoreDir, passwordDir, KEYSTORE_PASSWORD_2);
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         loader.loadKeystoresUsingPasswordDir(keystoreDir, passwordDir);
     final Collection<ArtifactSigner> signers = result.getValues();
 
@@ -69,7 +69,7 @@ class BlsKeystoreBulkLoaderTest {
     final Path passwordFile = tempDir.resolve("password.txt");
     Files.writeString(passwordFile, KEYSTORE_PASSWORD_1);
 
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         loader.loadKeystoresUsingPasswordFile(keystoreDir, passwordFile);
     final Collection<ArtifactSigner> signers = result.getValues();
     assertThat(signers).hasSize(2);
@@ -90,7 +90,7 @@ class BlsKeystoreBulkLoaderTest {
     final Path targetPath = keystoreDir.resolve(KEY_PAIR_1.getPublicKey() + ".ignored");
     Files.move(sourcePath, targetPath);
 
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         loader.loadKeystoresUsingPasswordDir(keystoreDir, passwordDir);
     final Collection<ArtifactSigner> signers = result.getValues();
     assertThat(signers).hasSize(1);
@@ -105,13 +105,13 @@ class BlsKeystoreBulkLoaderTest {
     KeystoreUtil.createKeystoreFile(KEY_PAIR_1, keystoreDir, KEYSTORE_PASSWORD_1);
     KeystoreUtil.createKeystore(KEY_PAIR_2, keystoreDir, passwordDir, KEYSTORE_PASSWORD_2);
 
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         loader.loadKeystoresUsingPasswordDir(keystoreDir, passwordDir);
     final Collection<ArtifactSigner> signers = result.getValues();
     assertThat(signers).hasSize(1);
     assertThatSignerHasPublicKey(signers, KEY_PAIR_2);
 
-    assertThat(result.getErrorCount()).isEqualTo(2);
+    assertThat(result.getErrorCount()).isEqualTo(1);
   }
 
   @Test
@@ -121,19 +121,19 @@ class BlsKeystoreBulkLoaderTest {
     KeystoreUtil.createKeystorePasswordFile(KEY_PAIR_1, passwordDir, KEYSTORE_PASSWORD_1);
     KeystoreUtil.createKeystore(KEY_PAIR_2, keystoreDir, passwordDir, KEYSTORE_PASSWORD_2);
 
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         loader.loadKeystoresUsingPasswordDir(keystoreDir, passwordDir);
     final Collection<ArtifactSigner> signers = result.getValues();
     assertThat(signers).hasSize(1);
     assertThatSignerHasPublicKey(signers, KEY_PAIR_2);
 
-    assertThat(result.getErrorCount()).isEqualTo(2);
+    assertThat(result.getErrorCount()).isEqualTo(1);
   }
 
   @Test
   void invalidKeystoreDirectoryReturnsErrorCount(
       final @TempDir Path keystoreDir, final @TempDir Path passwordDir) {
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         loader.loadKeystoresUsingPasswordDir(
             keystoreDir.resolve("invalidKeystorePath"), passwordDir);
     assertThat(result.getValues()).isEmpty();
@@ -146,7 +146,7 @@ class BlsKeystoreBulkLoaderTest {
     final Path keystoreDir = tempDir.resolve("keystores");
     Files.createDirectory(keystoreDir);
 
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         loader.loadKeystoresUsingPasswordFile(
             keystoreDir, tempDir.resolve("invalidPasswordFilePath"));
     assertThat(result.getValues()).isEmpty();

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/config/SignerLoaderTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/config/SignerLoaderTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import tech.pegasys.signers.common.SecretValueResult;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSecretKey;
 import tech.pegasys.web3signer.FileHiddenUtil;
@@ -84,7 +85,8 @@ class SignerLoaderTest {
     when(signerParser.parse(Files.readString(metadataFile, StandardCharsets.UTF_8)))
         .thenReturn(artifactSigner);
     final List<ArtifactSigner> signerList =
-        Lists.newArrayList(new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser));
+        Lists.newArrayList(
+            new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser).getValues());
 
     verify(signerParser).parse(Files.readString(metadataFile, StandardCharsets.UTF_8));
     assertThat(signerList.size()).isOne();
@@ -97,7 +99,8 @@ class SignerLoaderTest {
     final Path metadataFile = createFileInConfigsDirectory(filename, PRIVATE_KEY1);
     when(signerParser.parse(ArgumentMatchers.any())).thenReturn(artifactSigner);
     final List<ArtifactSigner> signerList =
-        Lists.newArrayList(new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser));
+        Lists.newArrayList(
+            new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser).getValues());
 
     assertThat(signerList.size()).isOne();
     assertThat(signerList.get(0).getIdentifier()).isEqualTo("0x" + PUBLIC_KEY1);
@@ -110,7 +113,8 @@ class SignerLoaderTest {
     final Path metadataFile = createFileInConfigsDirectory(filename, PRIVATE_KEY1);
     when(signerParser.parse(ArgumentMatchers.any())).thenReturn(artifactSigner);
     final List<ArtifactSigner> signerList =
-        Lists.newArrayList(new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser));
+        Lists.newArrayList(
+            new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser).getValues());
 
     assertThat(signerList.size()).isOne();
     assertThat(signerList.get(0).getIdentifier()).isEqualTo("0x" + PUBLIC_KEY1);
@@ -123,10 +127,11 @@ class SignerLoaderTest {
     final String filename = PUBLIC_KEY1 + ".nothing";
     createFileInConfigsDirectory(filename, PRIVATE_KEY1);
 
-    final List<ArtifactSigner> signerList =
-        Lists.newArrayList(new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser));
+    final SecretValueResult<ArtifactSigner> result =
+        new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
-    assertThat(signerList).isEmpty();
+    assertThat(result.getValues()).isEmpty();
+    assertThat(result.getErrorCount()).isZero();
     verifyNoMoreInteractions(signerParser);
   }
 
@@ -134,20 +139,23 @@ class SignerLoaderTest {
   void failedParserReturnsEmptySigner() throws IOException {
     createFileInConfigsDirectory(PUBLIC_KEY1 + "." + FILE_EXTENSION, "NOT_A_VALID_KEY");
 
-    final List<ArtifactSigner> signerList =
-        Lists.newArrayList(new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser));
+    final SecretValueResult<ArtifactSigner> result =
+        new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
-    assertThat(signerList).isEmpty();
+    assertThat(result.getValues()).isEmpty();
   }
 
   @Test
   void failedWithDirectoryErrorReturnEmptySigner() throws IOException {
     final Path missingDir = configsDirectory.resolve("idontexist");
     createFileInConfigsDirectory(PUBLIC_KEY1 + "." + FILE_EXTENSION, PRIVATE_KEY1);
-    final List<ArtifactSigner> signerList =
-        Lists.newArrayList(new SignerLoader().load(missingDir, FILE_EXTENSION, signerParser));
+    final SecretValueResult<ArtifactSigner> result =
+        new SignerLoader().load(missingDir, FILE_EXTENSION, signerParser);
 
-    assertThat(signerList).isEmpty();
+    assertThat(result.getValues()).isEmpty();
+    // TODO: Should we return result with errorCount 1 if config directory is missing? Currently it
+    // is being treated as no error encountered
+    assertThat(result.getErrorCount()).isZero();
   }
 
   @Test
@@ -162,10 +170,10 @@ class SignerLoaderTest {
     when(signerParser.parse(Files.readString(metadataFile2, StandardCharsets.UTF_8)))
         .thenReturn(createArtifactSigner(PRIVATE_KEY1));
 
-    final List<ArtifactSigner> signerList =
-        Lists.newArrayList(new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser));
+    SecretValueResult<ArtifactSigner> result =
+        new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
-    assertThat(signerList.size()).isEqualTo(1);
+    assertThat(result.getValues()).hasSize(1);
   }
 
   @Test
@@ -174,11 +182,12 @@ class SignerLoaderTest {
     final Path metadataFile = createFileInConfigsDirectory(filename, PRIVATE_KEY1);
     when(signerParser.parse(ArgumentMatchers.any())).thenReturn(artifactSigner);
 
-    final List<ArtifactSigner> signerList =
-        Lists.newArrayList(new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser));
+    final SecretValueResult<ArtifactSigner> result =
+        new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
-    assertThat(signerList.size()).isOne();
-    assertThat(signerList.get(0).getIdentifier()).isEqualTo("0x" + PUBLIC_KEY1);
+    assertThat(result.getValues()).hasSize(1);
+    assertThat(result.getValues().stream().findFirst().orElseThrow().getIdentifier())
+        .isEqualTo("0x" + PUBLIC_KEY1);
     verify(signerParser).parse(Files.readString(metadataFile, StandardCharsets.UTF_8));
   }
 
@@ -186,9 +195,10 @@ class SignerLoaderTest {
   void signerIdentifiersNotReturnedInvalidMetadataFile() throws IOException {
     createEmptyFileInConfigsDirectory(PUBLIC_KEY1 + "." + FILE_EXTENSION);
     createEmptyFileInConfigsDirectory(PUBLIC_KEY2 + "." + FILE_EXTENSION);
-    final List<ArtifactSigner> signerList =
-        Lists.newArrayList(new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser));
-    assertThat(signerList).isEmpty();
+    final SecretValueResult<ArtifactSigner> result =
+        new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
+
+    assertThat(result.getValues()).isEmpty();
   }
 
   @Test
@@ -212,11 +222,12 @@ class SignerLoaderTest {
     when(signerParser.parse(Files.readString(key2, StandardCharsets.UTF_8)))
         .thenReturn(createArtifactSigner(PRIVATE_KEY2));
 
-    final List<ArtifactSigner> signerList =
-        Lists.newArrayList(new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser));
+    final SecretValueResult<ArtifactSigner> result =
+        new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
-    assertThat(signerList.size()).isOne();
-    assertThat(signerList.get(0).getIdentifier()).isEqualTo("0x" + PUBLIC_KEY2);
+    assertThat(result.getValues()).hasSize(1);
+    assertThat(result.getValues().stream().findFirst().orElseThrow().getIdentifier())
+        .isEqualTo("0x" + PUBLIC_KEY2);
 
     verify(signerParser, Mockito.never()).parse(yamlContentKey1);
     verify(signerParser).parse(Files.readString(key2, StandardCharsets.UTF_8));
@@ -226,11 +237,14 @@ class SignerLoaderTest {
   void signerIdentifiersReturnedForAllValidMetadataFilesInDirectory() throws IOException {
     createSignerConfigFiles();
 
-    final List<ArtifactSigner> signerList =
-        Lists.newArrayList(new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser));
+    SecretValueResult<ArtifactSigner> result =
+        new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
-    assertThat(signerList).hasSize(3);
-    assertThat(signerList.stream().map(ArtifactSigner::getIdentifier).collect(Collectors.toList()))
+    assertThat(result.getValues()).hasSize(3);
+    assertThat(
+            result.getValues().stream()
+                .map(ArtifactSigner::getIdentifier)
+                .collect(Collectors.toList()))
         .containsOnly("0x" + PUBLIC_KEY1, "0x" + PUBLIC_KEY2, "0x" + PUBLIC_KEY3);
   }
 
@@ -255,16 +269,19 @@ class SignerLoaderTest {
   void callingLoadTwiceDoesNotReloadUnmodifiedConfigFiles() throws IOException {
     createSignerConfigFiles();
 
-    final List<ArtifactSigner> signerList =
-        Lists.newArrayList(new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser));
+    final SecretValueResult<ArtifactSigner> result =
+        new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
-    assertThat(signerList).hasSize(3);
-    assertThat(signerList.stream().map(ArtifactSigner::getIdentifier).collect(Collectors.toList()))
+    assertThat(result.getValues()).hasSize(3);
+    assertThat(
+            result.getValues().stream()
+                .map(ArtifactSigner::getIdentifier)
+                .collect(Collectors.toList()))
         .containsOnly("0x" + PUBLIC_KEY1, "0x" + PUBLIC_KEY2, "0x" + PUBLIC_KEY3);
 
-    final Collection<ArtifactSigner> reloadedArtifactSigner =
+    final SecretValueResult<ArtifactSigner> reloadedResult =
         new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
-    assertThat(reloadedArtifactSigner).isEmpty();
+    assertThat(reloadedResult.getValues()).isEmpty();
   }
 
   @Test
@@ -272,7 +289,8 @@ class SignerLoaderTest {
     createSignerConfigFiles();
 
     final List<ArtifactSigner> signerList =
-        Lists.newArrayList(new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser));
+        Lists.newArrayList(
+            new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser).getValues());
 
     assertThat(signerList).hasSize(3);
     assertThat(signerList.stream().map(ArtifactSigner::getIdentifier).collect(Collectors.toList()))
@@ -282,7 +300,7 @@ class SignerLoaderTest {
     createFileInConfigsDirectory(PUBLIC_KEY3 + "." + FILE_EXTENSION, PRIVATE_KEY3);
 
     final Collection<ArtifactSigner> reloadedArtifactSigner =
-        new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
+        new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser).getValues();
     assertThat(reloadedArtifactSigner).hasSize(1);
     assertThat(reloadedArtifactSigner.stream().findFirst().get().getIdentifier())
         .isEqualTo("0x" + PUBLIC_KEY3);
@@ -326,10 +344,10 @@ class SignerLoaderTest {
     createFileInConfigsDirectory(PUBLIC_KEY1 + "." + FILE_EXTENSION, PRIVATE_KEY1);
     when(signerParser.parse(ArgumentMatchers.any())).thenThrow(SigningMetadataException.class);
 
-    final List<ArtifactSigner> signerList =
-        Lists.newArrayList(new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser));
+    final SecretValueResult<ArtifactSigner> result =
+        new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
-    assertThat(signerList).isEmpty();
+    assertThat(result.getValues()).isEmpty();
   }
 
   private Path createFileInConfigsDirectory(final String filename, final String privateKey)

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/config/SignerLoaderTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/config/SignerLoaderTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import tech.pegasys.signers.common.SecretValueResult;
+import tech.pegasys.signers.common.MappedResults;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSecretKey;
 import tech.pegasys.web3signer.FileHiddenUtil;
@@ -127,7 +127,7 @@ class SignerLoaderTest {
     final String filename = PUBLIC_KEY1 + ".nothing";
     createFileInConfigsDirectory(filename, PRIVATE_KEY1);
 
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
     assertThat(result.getValues()).isEmpty();
@@ -139,7 +139,7 @@ class SignerLoaderTest {
   void failedParserReturnsEmptySigner() throws IOException {
     createFileInConfigsDirectory(PUBLIC_KEY1 + "." + FILE_EXTENSION, "NOT_A_VALID_KEY");
 
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
     assertThat(result.getValues()).isEmpty();
@@ -149,7 +149,7 @@ class SignerLoaderTest {
   void failedWithDirectoryErrorReturnEmptySigner() throws IOException {
     final Path missingDir = configsDirectory.resolve("idontexist");
     createFileInConfigsDirectory(PUBLIC_KEY1 + "." + FILE_EXTENSION, PRIVATE_KEY1);
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         new SignerLoader().load(missingDir, FILE_EXTENSION, signerParser);
 
     assertThat(result.getValues()).isEmpty();
@@ -168,7 +168,7 @@ class SignerLoaderTest {
     when(signerParser.parse(Files.readString(metadataFile2, StandardCharsets.UTF_8)))
         .thenReturn(createArtifactSigner(PRIVATE_KEY1));
 
-    SecretValueResult<ArtifactSigner> result =
+    MappedResults<ArtifactSigner> result =
         new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
     assertThat(result.getValues()).hasSize(1);
@@ -180,7 +180,7 @@ class SignerLoaderTest {
     final Path metadataFile = createFileInConfigsDirectory(filename, PRIVATE_KEY1);
     when(signerParser.parse(ArgumentMatchers.any())).thenReturn(artifactSigner);
 
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
     assertThat(result.getValues()).hasSize(1);
@@ -193,7 +193,7 @@ class SignerLoaderTest {
   void signerIdentifiersNotReturnedInvalidMetadataFile() throws IOException {
     createEmptyFileInConfigsDirectory(PUBLIC_KEY1 + "." + FILE_EXTENSION);
     createEmptyFileInConfigsDirectory(PUBLIC_KEY2 + "." + FILE_EXTENSION);
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
     assertThat(result.getValues()).isEmpty();
@@ -220,7 +220,7 @@ class SignerLoaderTest {
     when(signerParser.parse(Files.readString(key2, StandardCharsets.UTF_8)))
         .thenReturn(createArtifactSigner(PRIVATE_KEY2));
 
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
     assertThat(result.getValues()).hasSize(1);
@@ -235,7 +235,7 @@ class SignerLoaderTest {
   void signerIdentifiersReturnedForAllValidMetadataFilesInDirectory() throws IOException {
     createSignerConfigFiles();
 
-    SecretValueResult<ArtifactSigner> result =
+    MappedResults<ArtifactSigner> result =
         new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
     assertThat(result.getValues()).hasSize(3);
@@ -267,7 +267,7 @@ class SignerLoaderTest {
   void callingLoadTwiceDoesNotReloadUnmodifiedConfigFiles() throws IOException {
     createSignerConfigFiles();
 
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
     assertThat(result.getValues()).hasSize(3);
@@ -277,7 +277,7 @@ class SignerLoaderTest {
                 .collect(Collectors.toList()))
         .containsOnly("0x" + PUBLIC_KEY1, "0x" + PUBLIC_KEY2, "0x" + PUBLIC_KEY3);
 
-    final SecretValueResult<ArtifactSigner> reloadedResult =
+    final MappedResults<ArtifactSigner> reloadedResult =
         new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
     assertThat(reloadedResult.getValues()).isEmpty();
   }
@@ -342,7 +342,7 @@ class SignerLoaderTest {
     createFileInConfigsDirectory(PUBLIC_KEY1 + "." + FILE_EXTENSION, PRIVATE_KEY1);
     when(signerParser.parse(ArgumentMatchers.any())).thenThrow(SigningMetadataException.class);
 
-    final SecretValueResult<ArtifactSigner> result =
+    final MappedResults<ArtifactSigner> result =
         new SignerLoader().load(configsDirectory, FILE_EXTENSION, signerParser);
 
     assertThat(result.getValues()).isEmpty();

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/config/SignerLoaderTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/config/SignerLoaderTest.java
@@ -153,9 +153,7 @@ class SignerLoaderTest {
         new SignerLoader().load(missingDir, FILE_EXTENSION, signerParser);
 
     assertThat(result.getValues()).isEmpty();
-    // TODO: Should we return result with errorCount 1 if config directory is missing? Currently it
-    // is being treated as no error encountered
-    assertThat(result.getErrorCount()).isZero();
+    assertThat(result.getErrorCount()).isOne();
   }
 
   @Test

--- a/signing/src/test/resources/log4j2-test.xml
+++ b/signing/src/test/resources/log4j2-test.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Properties>
+        <Property name="root.log.level">DEBUG</Property>
+        <Property name="dependency.log.level">WARN</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSSZZZ} | %t | %-5level | %c{1} | %msg%n" />
+        </Console>
+        <Console name="SubProcessConsole" target="SYSTEM_OUT">
+            <PatternLayout pattern="SubProcess | %msg%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.zaxxer.hikari" level="${sys:dependency.log.level}" additivity="false">
+            <AppenderRef ref="Console" />
+        </Logger>
+        <Logger name="org.flywaydb.core" level="${sys:dependency.log.level}" additivity="false">
+            <AppenderRef ref="Console" />
+        </Logger>
+        <Logger name="org.apache.http" level="${sys:dependency.log.level}" additivity="false">
+            <AppenderRef ref="Console" />
+        </Logger>
+        <Logger name="io.restassured.internal" level="${sys:dependency.log.level}" additivity="false">
+            <AppenderRef ref="Console" />
+        </Logger>
+        <Logger name="io.netty" level="${sys:dependency.log.level}" additivity="false">
+            <AppenderRef ref="Console" />
+        </Logger>
+        <Logger name="io.swagger.v3" level="${sys:dependency.log.level}" additivity="false">
+            <AppenderRef ref="Console" />
+        </Logger>
+        <Logger name="com.atlassian.oai" level="${sys:dependency.log.level}" additivity="false">
+            <AppenderRef ref="Console" />
+        </Logger>
+        <Root level="${sys:root.log.level}">
+            <AppenderRef ref="Console" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/signing/src/testFixtures/java/tech/pegasys/web3signer/signing/config/AwsSecretsManagerParametersBuilder.java
+++ b/signing/src/testFixtures/java/tech/pegasys/web3signer/signing/config/AwsSecretsManagerParametersBuilder.java
@@ -12,8 +12,10 @@
  */
 package tech.pegasys.web3signer.signing.config;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 
 public final class AwsSecretsManagerParametersBuilder {
   private AwsAuthenticationMode authenticationMode = AwsAuthenticationMode.SPECIFIED;
@@ -24,6 +26,8 @@ public final class AwsSecretsManagerParametersBuilder {
   private Collection<String> tagNamesFilter = Collections.emptyList();
   private Collection<String> tagValuesFilter = Collections.emptyList();
   private long cacheMaximumSize = 1;
+
+  private Optional<URI> endpointURI = Optional.empty();
 
   private AwsSecretsManagerParametersBuilder() {}
 
@@ -75,6 +79,12 @@ public final class AwsSecretsManagerParametersBuilder {
     return this;
   }
 
+  public AwsSecretsManagerParametersBuilder withEndpointOverride(
+      final Optional<URI> endpointOverride) {
+    this.endpointURI = endpointOverride;
+    return this;
+  }
+
   public AwsSecretsManagerParameters build() {
     if (authenticationMode == AwsAuthenticationMode.SPECIFIED) {
       if (accessKeyId == null) {
@@ -98,7 +108,8 @@ public final class AwsSecretsManagerParametersBuilder {
         prefixesFilter,
         tagNamesFilter,
         tagValuesFilter,
-        cacheMaximumSize);
+        cacheMaximumSize,
+        endpointURI);
   }
 
   private static class TestAwsSecretsManagerParameters implements AwsSecretsManagerParameters {
@@ -110,6 +121,7 @@ public final class AwsSecretsManagerParametersBuilder {
     private final Collection<String> tagNamesFilter;
     private final Collection<String> tagValuesFilter;
     private final long cacheMaximumSize;
+    private final Optional<URI> endpointOverride;
 
     TestAwsSecretsManagerParameters(
         final AwsAuthenticationMode authenticationMode,
@@ -119,7 +131,8 @@ public final class AwsSecretsManagerParametersBuilder {
         final Collection<String> prefixesFilter,
         final Collection<String> tagNamesFilter,
         final Collection<String> tagValuesFilter,
-        final long cacheMaximumSize) {
+        final long cacheMaximumSize,
+        final Optional<URI> endpointOverride) {
       this.authenticationMode = authenticationMode;
       this.accessKeyId = accessKeyId;
       this.secretAccessKey = secretAccessKey;
@@ -128,6 +141,7 @@ public final class AwsSecretsManagerParametersBuilder {
       this.tagNamesFilter = tagNamesFilter;
       this.tagValuesFilter = tagValuesFilter;
       this.cacheMaximumSize = cacheMaximumSize;
+      this.endpointOverride = endpointOverride;
     }
 
     @Override
@@ -173,6 +187,11 @@ public final class AwsSecretsManagerParametersBuilder {
     @Override
     public Collection<String> getTagValuesFilter() {
       return tagValuesFilter;
+    }
+
+    @Override
+    public Optional<URI> getEndpointOverride() {
+      return endpointOverride;
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->
## PR Description
- Implement Healthcheck status for keys loading.
- Add AWS endpoint override cli option `--aws-endpoint-override` (useful for testing against localstack).

Sample healthcheck:
```
{
	"status": "UP",
	"checks": [
		{
			"id": "default-check",
			"status": "UP"
		},
		{
			"id": "keys-check",
			"status": "UP",
			"checks": [
				{
					"id": "aws-bulk-loading",
					"status": "UP",
					"data": {
						"keys-loaded": 2,
						"error-count": 0
					}
				},
				{
					"id": "config-files-loading",
					"status": "UP",
					"data": {
						"keys-loaded": 0,
						"error-count": 0
					}
				}
			]
		}
	],
	"outcome": "UP"
}
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#715 
#730 
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
