### PR TITLE
Revert Java 17 changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   executor_med:  # 2cpu, 4G ram
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:11.0
         auth: &docker-auth
           # Don't panic, throw away account to avoid Docker rate limits when downloading.
           # Second reason we're doing this is so that forked PRs from external contributors works ie env vars aren't visible to forked PRs from within contexts
@@ -21,7 +21,7 @@ executors:
 
   executor_large: # 4cpu, 8G ram
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:11.0
         auth:
           <<: *docker-auth   
     resource_class: large
@@ -33,7 +33,7 @@ executors:
   executor_large_with_fc_devnet: # 4cpu, 8G ram
     docker:
       # Primary container
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:11.0
         auth:
           <<: *docker-auth     
       # Secondary container running lotus as devnet on port 7777
@@ -55,7 +55,7 @@ executors:
 
   machine_executor_arm64:
     machine:
-      image: ubuntu-2204:current # https://circleci.com/developer/machine/image/ubuntu-2204
+      image: ubuntu-2004:202201-02 # Ubuntu 20.04, Docker v20.10.12, Docker Compose v1.29.2
     resource_class: arm.medium
     environment:
       architecture: "arm64"
@@ -63,7 +63,7 @@ executors:
 
   machine_executor_amd64:
     machine:
-      image: ubuntu-2204:current # https://circleci.com/developer/machine/image/ubuntu-2204
+      image: ubuntu-2004:202201-02 # Ubuntu 20.04, Docker v20.10.12, Docker Compose v1.29.2
       docker_layer_caching: true
     working_directory: ~/project
     environment:
@@ -81,15 +81,7 @@ commands:
             - deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
             - deps-{{ checksum "build.gradle" }}
             - deps-
-  machine_java_17:
-    description: "Install Java 17 on machine executors"
-    steps:
-      - run:
-          name: Java 17
-          command: |
-            sudo apt update
-            sudo apt install -q --assume-yes openjdk-17-jre-headless openjdk-17-jdk-headless
-            sudo update-java-alternatives -a
+
   capture_test_results:
     description: "Capture test results"
     steps:
@@ -261,7 +253,6 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/project
-      - machine_java_17
       - run:
           name: build and test Docker image
           command: |
@@ -274,7 +265,6 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/project
-      - machine_java_17
       - docker_trust_sign
       - docker_publish_images
       - notify
@@ -285,7 +275,6 @@ jobs:
       - prepare
       - attach_workspace:
           at: ~/project
-      - machine_java_17
       - docker_trust_sign
       - docker_publish_images
       - notify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,7 @@
 # Changelog
-
 ## Upcoming release
-### Breaking Changes
-- Using Java 17 for build and runtime. Removing Java 11 variant of docker image. zip/tar.gz distributions will require 
-Java 17 or above to run Web3Signer.
-
 ### Features Added
 - Optional Azure bulk loading tags support using cli option `--azure-secrets-tags`.
-- Java 17 for build and runtime.
 
 ---
 ## 23.3.1

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -14,7 +14,7 @@
 plugins {
   id "de.undercouch.download" version "4.1.0"
   id "com.google.osdetector" version "1.6.2"
-  id "io.gatling.gradle" version "3.9.3.1"
+  id "io.gatling.gradle" version "3.7.0-M1"
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,8 @@ plugins {
   id 'org.ajoberstar.grgit' version '4.1.1'
 }
 
-if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
-  throw new GradleException("Java 17 or later is required to build Web3Signer.\n" +
+if (!JavaVersion.current().java11Compatible) {
+  throw new GradleException("Java 11 or later is required to build Web3Signer.\n" +
   "  Detected version ${JavaVersion.current()}")
 }
 
@@ -109,8 +109,8 @@ allprojects {
     from javadoc.destinationDir
   }
 
-  sourceCompatibility = 17
-  targetCompatibility = 17
+  sourceCompatibility = 11
+  targetCompatibility = 11
 
   repositories {
     mavenCentral()
@@ -461,7 +461,7 @@ tasks.register("dockerDistUntar") {
 }
 
 def dockerImage = "consensys/web3signer"
-def dockerJdkVariants = ["jdk17",]
+def dockerJdkVariants = ["jdk17", "jdk11",]
 def dockerBuildDir = "build/docker-web3signer/"
 
 task distDocker  {

--- a/docker/jdk11/Dockerfile
+++ b/docker/jdk11/Dockerfile
@@ -1,0 +1,50 @@
+FROM eclipse-temurin:11 as jre-build
+
+# Create a custom Java runtime
+RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" $JAVA_HOME/bin/jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+FROM ubuntu:latest
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
+
+RUN apt-get -y update && apt-get -y install libssl3 curl iputils-ping net-tools && rm -rf /var/lib/api/lists/*
+RUN adduser --disabled-password --gecos "" --home /opt/web3signer web3signer && \
+    chown web3signer:web3signer /opt/web3signer && chmod 755 /opt/web3signer
+
+USER web3signer
+WORKDIR /opt/web3signer
+
+# copy application (with libraries inside)
+COPY --chown=web3signer:web3signer web3signer /opt/web3signer/
+
+ENV WEB3SIGNER_HTTP_LISTEN_HOST="0.0.0.0"
+ENV WEB3SIGNER_METRICS_HOST="0.0.0.0"
+
+# List Exposed Ports
+# Metrics, Rest API
+EXPOSE 9001 9000 9000/udp
+
+# specify default command
+ENTRYPOINT ["/opt/web3signer/bin/web3signer"]
+
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="Web3Signer" \
+      org.label-schema.description="Ethereum 2.0 Signing Service" \
+      org.label-schema.url="https://docs.web3signer.consensys.net" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/ConsenSys/web3signer.git" \
+      org.label-schema.vendor="ConsenSys" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.schema-version="1.0"

--- a/gradle/license-report-config/license-normalizer.json
+++ b/gradle/license-report-config/license-normalizer.json
@@ -7,7 +7,6 @@
   ],
   "transformationRules" : [
     { "bundleName" : "MIT", "licenseNamePattern" : "\"MIT\\sLicense\"" },
-    { "bundleName" : "MIT", "licenseNamePattern" : "(.*)SPDX-License-Identifier: MIT(.*)" },
     { "bundleName" : "BSD", "licenseNamePattern" : "BSD licence" },
     { "bundleName" : "CDDL-1.1", "licenseNamePattern" : "(.*)Dual license consisting of the CDDL v1.1 and GPL v2(.*)" },
     { "bundleName" : "Apache-2.0", "licenseNamePattern" : "(.*)Apache-2.0(.*)" }


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Reverting changes to Java 17 as Azure remote signing for secp256k1 keys is broken in Java 17.
This reverts commit 7a2e0debf397fd1f6e3051835e8405cea8cab985.

Any documentation changes related to Java 17 needs to be reverted as well (@bgravenorst).

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
