### PR TITLE
Improve handling of large number of Hashicorp signing metadata configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bugs Fixed
 - Upgrade jackson and vertx to upgrade snakeyaml to 2.0 to fix CVE-2022-1471
+- Fixed handling of very large number of signing metadata files with Hashicorp connection (30000+). [#736](https://github.com/ConsenSys/web3signer/issues/736)
 
 ---
 ## 23.3.1

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -93,7 +93,7 @@ def getOsArchForVault() {
   switch(osdetector.arch) {
     case "aarch_64":
       "arm64"
-       break
+      break
     default: osdetector.arch
   }
 }

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -89,12 +89,12 @@ def vaultBinary () {
   }
 }
 
-def getOsArchForVault() {
+def getOsXArchForVault() {
   switch(osdetector.arch) {
     case "aarch_64":
       "arm64"
       break
-    default: osdetector.arch
+    default: "amd64"
   }
 }
 
@@ -108,7 +108,7 @@ def vaultDownloadUrl() {
       return "${hashicorpVaultUrl}/${hashicorpVaultVersion}/vault_${hashicorpVaultVersion}_linux_amd64.zip"
       break
     case "osx":
-      return "${hashicorpVaultUrl}/${hashicorpVaultVersion}/vault_${hashicorpVaultVersion}_darwin_${getOsArchForVault()}.zip"
+      return "${hashicorpVaultUrl}/${hashicorpVaultVersion}/vault_${hashicorpVaultVersion}_darwin_${getOsXArchForVault()}.zip"
       break
   }
 }

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -13,7 +13,7 @@
 
 plugins {
   id "de.undercouch.download" version "4.1.0"
-  id "com.google.osdetector" version "1.6.2"
+  id "com.google.osdetector" version "1.7.3"
   id "io.gatling.gradle" version "3.7.0-M1"
 }
 
@@ -89,6 +89,15 @@ def vaultBinary () {
   }
 }
 
+def getOsArchForVault() {
+  switch(osdetector.arch) {
+    case "aarch_64":
+      "arm64"
+       break
+    default: osdetector.arch
+  }
+}
+
 def vaultDownloadUrl() {
   // see gradle.properties for Hashicorp Vault URL
   switch (osdetector.os) {
@@ -99,7 +108,7 @@ def vaultDownloadUrl() {
       return "${hashicorpVaultUrl}/${hashicorpVaultVersion}/vault_${hashicorpVaultVersion}_linux_amd64.zip"
       break
     case "osx":
-      return "${hashicorpVaultUrl}/${hashicorpVaultVersion}/vault_${hashicorpVaultVersion}_darwin_amd64.zip"
+      return "${hashicorpVaultUrl}/${hashicorpVaultVersion}/vault_${hashicorpVaultVersion}_darwin_${getOsArchForVault()}.zip"
       break
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ allprojects {
   targetCompatibility = 11
 
   repositories {
-    mavenLocal() //for local testing only, must be removed before PR to be merged.
+    mavenLocal() //for local testing only, uncomment while testing locally build signers.
     mavenCentral()
     maven { url "https://artifacts.consensys.net/public/maven/maven/" }
     maven { url "https://artifacts.consensys.net/public/teku/maven/" }

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,7 @@ allprojects {
   targetCompatibility = 11
 
   repositories {
+    mavenLocal() //for local testing only, must be removed before PR to be merged.
     mavenCentral()
     maven { url "https://artifacts.consensys.net/public/maven/maven/" }
     maven { url "https://artifacts.consensys.net/public/teku/maven/" }

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ allprojects {
   targetCompatibility = 11
 
   repositories {
-    mavenLocal() //for local testing only, uncomment while testing locally build signers.
+    // mavenLocal() //for local testing only, uncomment while testing locally build signers.
     mavenCentral()
     maven { url "https://artifacts.consensys.net/public/maven/maven/" }
     maven { url "https://artifacts.consensys.net/public/teku/maven/" }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -86,7 +86,7 @@ public class Eth1Runner extends Runner {
         () -> {
           final AzureKeyVaultSignerFactory azureFactory = new AzureKeyVaultSignerFactory();
           final HashicorpConnectionFactory hashicorpConnectionFactory =
-              new HashicorpConnectionFactory(vertx);
+              new HashicorpConnectionFactory();
           try (final InterlockKeyProvider interlockKeyProvider = new InterlockKeyProvider(vertx);
               final YubiHsmOpaqueDataProvider yubiHsmOpaqueDataProvider =
                   new YubiHsmOpaqueDataProvider()) {

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -262,7 +262,7 @@ public class Eth2Runner extends Runner {
         () -> {
           final List<ArtifactSigner> signers = Lists.newArrayList();
           try (final HashicorpConnectionFactory hashicorpConnectionFactory =
-                  new HashicorpConnectionFactory(vertx);
+                  new HashicorpConnectionFactory();
               final InterlockKeyProvider interlockKeyProvider = new InterlockKeyProvider(vertx);
               final YubiHsmOpaqueDataProvider yubiHsmOpaqueDataProvider =
                   new YubiHsmOpaqueDataProvider();

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -261,10 +261,9 @@ public class Eth2Runner extends Runner {
     return new DefaultArtifactSignerProvider(
         () -> {
           final List<ArtifactSigner> signers = Lists.newArrayList();
-          final HashicorpConnectionFactory hashicorpConnectionFactory =
-              new HashicorpConnectionFactory(vertx);
-
-          try (final InterlockKeyProvider interlockKeyProvider = new InterlockKeyProvider(vertx);
+          try (final HashicorpConnectionFactory hashicorpConnectionFactory =
+                  new HashicorpConnectionFactory(vertx);
+              final InterlockKeyProvider interlockKeyProvider = new InterlockKeyProvider(vertx);
               final YubiHsmOpaqueDataProvider yubiHsmOpaqueDataProvider =
                   new YubiHsmOpaqueDataProvider();
               final AwsSecretsManagerProvider awsSecretsManagerProvider =

--- a/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
@@ -117,10 +117,10 @@ public class FilecoinRunner extends Runner {
     return new DefaultArtifactSignerProvider(
         () -> {
           final AzureKeyVaultSignerFactory azureFactory = new AzureKeyVaultSignerFactory();
-          final HashicorpConnectionFactory hashicorpConnectionFactory =
-              new HashicorpConnectionFactory(vertx);
 
-          try (final InterlockKeyProvider interlockKeyProvider = new InterlockKeyProvider(vertx);
+          try (final HashicorpConnectionFactory hashicorpConnectionFactory =
+                  new HashicorpConnectionFactory();
+              final InterlockKeyProvider interlockKeyProvider = new InterlockKeyProvider(vertx);
               final YubiHsmOpaqueDataProvider yubiHsmOpaqueDataProvider =
                   new YubiHsmOpaqueDataProvider();
               final AwsSecretsManagerProvider awsSecretsManagerProvider =

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -100,7 +100,7 @@ dependencyManagement {
     dependency 'tech.pegasys:jblst:0.3.8'
 
     // locally published signers version, must be fixed before PR is merged.
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '2.2.10-local') {
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '2.2.13-local') {
       entry 'bls-keystore'
       entry 'keystorage-hashicorp'
       entry 'keystorage-azure'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -135,8 +135,8 @@ dependencyManagement {
 
     dependency 'org.flywaydb:flyway-core:6.1.1'
 
-    dependency 'io.zonky.test.postgres:embedded-postgres-binaries-bom:11.18.0'
-    dependency 'io.zonky.test:embedded-postgres:2.0.1'
+    dependency 'io.zonky.test.postgres:embedded-postgres-binaries-bom:11.19.0'
+    dependency 'io.zonky.test:embedded-postgres:2.0.3'
 
     dependency 'com.github.ipld:java-cid:1.3.3'
     dependency 'net.jodah:failsafe:2.4.4'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -99,7 +99,8 @@ dependencyManagement {
 
     dependency 'tech.pegasys:jblst:0.3.8'
 
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '2.2.9') {
+    // locally published signers version, must be fixed before PR is merged.
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '2.2.10-local') {
       entry 'bls-keystore'
       entry 'keystorage-hashicorp'
       entry 'keystorage-azure'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -99,7 +99,6 @@ dependencyManagement {
 
     dependency 'tech.pegasys:jblst:0.3.8'
 
-    // locally published signers version, must be fixed before PR is merged.
     dependencySet(group: 'tech.pegasys.signers.internal', version: '2.2.13-local') {
       entry 'bls-keystore'
       entry 'keystorage-hashicorp'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -99,7 +99,7 @@ dependencyManagement {
 
     dependency 'tech.pegasys:jblst:0.3.8'
 
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '2.2.13-local') {
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '2.2.10') {
       entry 'bls-keystore'
       entry 'keystorage-hashicorp'
       entry 'keystorage-azure'

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/ConfigFileContent.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/ConfigFileContent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.signing.config;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+class ConfigFileContent {
+  private final Map<Path, String> contentMap;
+  private final int errorCount;
+
+  public ConfigFileContent(final Map<Path, String> contentMap, final int errorCount) {
+    this.contentMap = contentMap;
+    this.errorCount = errorCount;
+  }
+
+  public Map<Path, String> getContentMap() {
+    return contentMap;
+  }
+
+  public int getErrorCount() {
+    return errorCount;
+  }
+}

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/ConfigFileContent.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/ConfigFileContent.java
@@ -13,6 +13,7 @@
 package tech.pegasys.web3signer.signing.config;
 
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Map;
 
 class ConfigFileContent {
@@ -22,6 +23,10 @@ class ConfigFileContent {
   public ConfigFileContent(final Map<Path, String> contentMap, final int errorCount) {
     this.contentMap = contentMap;
     this.errorCount = errorCount;
+  }
+
+  static ConfigFileContent withSingleErrorCount() {
+    return new ConfigFileContent(Collections.emptyMap(), 1);
   }
 
   public Map<Path, String> getContentMap() {

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
@@ -62,7 +62,7 @@ public class SignerLoader {
     LOG.info(
         "Signer configuration metadata files read in memory {} in {}",
         configFileContent.getContentMap().size(),
-            calculateTimeTaken(start));
+        calculateTimeTaken(start));
 
     final Instant conversionStartInstant = Instant.now();
     // convert yaml file content to list of SigningMetadata

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
@@ -14,6 +14,7 @@ package tech.pegasys.web3signer.signing.config;
 
 import tech.pegasys.signers.common.MappedResults;
 import tech.pegasys.web3signer.signing.ArtifactSigner;
+import tech.pegasys.web3signer.signing.config.metadata.SigningMetadata;
 import tech.pegasys.web3signer.signing.config.metadata.parser.SignerParser;
 
 import java.io.IOException;
@@ -25,6 +26,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -181,7 +183,9 @@ public class SignerLoader {
                     LOG.info("{} metadata configuration files processed", filesProcessed);
                   }
                   try {
-                    return signerParser.parse(metadataContent.getValue()).stream();
+                    final List<SigningMetadata> signingMetadata =
+                        signerParser.readSigningMetadata(metadataContent.getValue());
+                    return signerParser.parse(signingMetadata).stream();
                   } catch (final Exception e) {
                     renderException(e, metadataContent.getKey().toString());
                     errorCount.incrementAndGet();

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
@@ -92,7 +92,7 @@ public class SignerLoader {
     metadataResult.mergeErrorCount(configFileContent.getErrorCount());
 
     LOG.info(
-        "Total Artifact Signer loaded via configuration files: {}\n, Error count {}\nTime Taken: {}.",
+        "Total Artifact Signer loaded via configuration files: {}\nError count {}\nTime Taken: {}.",
         metadataResult.getValues().size(),
         metadataResult.getErrorCount(),
         calculateTimeTaken(conversionStartInstant));

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
@@ -106,7 +106,7 @@ public class SignerLoader {
       final Map<Path, String> contentMap, final SignerParser signerParser) {
     final AtomicInteger errorCount = new AtomicInteger(0);
     final List<SigningMetadata> signingMetadataList =
-        contentMap.entrySet().stream()
+        contentMap.entrySet().parallelStream()
             .flatMap(
                 entry -> {
                   try {

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
@@ -103,7 +103,7 @@ public class SignerLoader {
   private MappedResults<SigningMetadata> convertConfigFileContent(
       final Map<Path, String> contentMap, final SignerParser signerParser) {
     final AtomicInteger errorCount = new AtomicInteger(0);
-    List<SigningMetadata> signingMetadataList =
+    final List<SigningMetadata> signingMetadataList =
         contentMap.entrySet().stream()
             .flatMap(
                 entry -> {

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AwsKeySigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AwsKeySigningMetadata.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(using = AwsKeySigningMetadataDeserializer.class)
 public class AwsKeySigningMetadata extends SigningMetadata implements AwsSecretsManagerParameters {
-
+  public static final String TYPE = "aws-secret";
   private final AwsAuthenticationMode authenticationMode;
   private final String region;
   private final String accessKeyId;
@@ -39,7 +39,7 @@ public class AwsKeySigningMetadata extends SigningMetadata implements AwsSecrets
       final String secretAccessKey,
       final String secretName,
       final Optional<URI> endpointOverride) {
-    super(KeyType.BLS);
+    super(TYPE, KeyType.BLS);
     this.authenticationMode = authenticationMode;
     this.region = region;
     this.accessKeyId = accessKeyId;

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AzureKeySigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AzureKeySigningMetadata.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class AzureKeySigningMetadata extends SigningMetadata {
-
+  public static final String TYPE = "azure-key";
   private final String clientId;
   private final String clientSecret;
   private final String tenantId;
@@ -34,7 +34,7 @@ public class AzureKeySigningMetadata extends SigningMetadata {
       @JsonProperty("vaultName") final String vaultName,
       @JsonProperty("keyName") final String keyName,
       @JsonProperty(value = "keyType") final KeyType keyType) {
-    super(keyType != null ? keyType : KeyType.SECP256K1);
+    super(TYPE, keyType != null ? keyType : KeyType.SECP256K1);
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.tenantId = tenantId;

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AzureSecretSigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AzureSecretSigningMetadata.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(using = AzureSecretSigningMetadataDeserializer.class)
 public class AzureSecretSigningMetadata extends SigningMetadata implements AzureKeyVaultParameters {
-
+  public static final String TYPE = "azure-secret";
   private final String clientId;
   private final String clientSecret;
   private final String tenantId;
@@ -40,7 +40,7 @@ public class AzureSecretSigningMetadata extends SigningMetadata implements Azure
       final String secretName,
       final AzureAuthenticationMode azureAuthenticationMode,
       final KeyType keyType) {
-    super(keyType != null ? keyType : KeyType.BLS);
+    super(TYPE, keyType != null ? keyType : KeyType.BLS);
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.tenantId = tenantId;

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/FileKeyStoreMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/FileKeyStoreMetadata.java
@@ -20,7 +20,7 @@ import java.nio.file.Path;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class FileKeyStoreMetadata extends SigningMetadata {
-
+  public static final String TYPE = "file-keystore";
   private final Path keystoreFile;
   private final Path keystorePasswordFile;
 
@@ -29,7 +29,7 @@ public class FileKeyStoreMetadata extends SigningMetadata {
       @JsonProperty(value = "keystorePasswordFile", required = true)
           final Path keystorePasswordFile,
       @JsonProperty(value = "keyType") final KeyType keyType) {
-    super(keyType != null ? keyType : KeyType.BLS);
+    super(TYPE, keyType != null ? keyType : KeyType.BLS);
     this.keystoreFile = keystoreFile;
     this.keystorePasswordFile = keystorePasswordFile;
   }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/FileRawSigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/FileRawSigningMetadata.java
@@ -19,13 +19,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.tuweni.bytes.Bytes32;
 
 public class FileRawSigningMetadata extends SigningMetadata {
-
+  public static final String TYPE = "file-raw";
   private final Bytes32 privateKey;
 
   public FileRawSigningMetadata(
       @JsonProperty(value = "privateKey", required = true) final Bytes32 privateKey,
       @JsonProperty(value = "keyType") final KeyType keyType) {
-    super(keyType != null ? keyType : KeyType.BLS);
+    super(TYPE, keyType != null ? keyType : KeyType.BLS);
     this.privateKey = privateKey;
   }
 

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/HashicorpSigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/HashicorpSigningMetadata.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 public class HashicorpSigningMetadata extends SigningMetadata {
-
+  public static final String TYPE = "hashicorp";
   private final String serverHost;
   private final String token;
   private final String keyPath;
@@ -41,7 +41,7 @@ public class HashicorpSigningMetadata extends SigningMetadata {
       @JsonProperty(value = "keyPath", required = true) final String keyPath,
       @JsonProperty(value = "token", required = true) final String token,
       @JsonProperty(value = "keyType") final KeyType keyType) {
-    super(keyType != null ? keyType : KeyType.BLS);
+    super(TYPE, keyType != null ? keyType : KeyType.BLS);
     this.serverHost = serverHost;
     this.token = token;
     this.keyPath = keyPath;

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/InterlockSigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/InterlockSigningMetadata.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class InterlockSigningMetadata extends SigningMetadata {
+  public static final String TYPE = "interlock";
   private final URI interlockUrl;
   private final Path knownServersFile;
 
@@ -37,7 +38,7 @@ public class InterlockSigningMetadata extends SigningMetadata {
       @JsonProperty(value = "password", required = true) final String password,
       @JsonProperty(value = "keyPath", required = true) final String keyPath,
       @JsonProperty(value = "keyType") final KeyType keyType) {
-    super(keyType != null ? keyType : KeyType.BLS);
+    super(TYPE, keyType != null ? keyType : KeyType.BLS);
 
     this.interlockUrl = URI.create(interlockUrl);
     this.knownServersFile = Path.of(knownServersFile);

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/SigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/SigningMetadata.java
@@ -15,25 +15,34 @@ package tech.pegasys.web3signer.signing.config.metadata;
 import tech.pegasys.web3signer.signing.ArtifactSigner;
 import tech.pegasys.web3signer.signing.KeyType;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
-  @JsonSubTypes.Type(value = FileRawSigningMetadata.class, name = "file-raw"),
-  @JsonSubTypes.Type(value = FileKeyStoreMetadata.class, name = "file-keystore"),
-  @JsonSubTypes.Type(value = HashicorpSigningMetadata.class, name = "hashicorp"),
-  @JsonSubTypes.Type(value = AzureSecretSigningMetadata.class, name = "azure-secret"),
-  @JsonSubTypes.Type(value = AzureKeySigningMetadata.class, name = "azure-key"),
-  @JsonSubTypes.Type(value = InterlockSigningMetadata.class, name = "interlock"),
-  @JsonSubTypes.Type(value = YubiHsmSigningMetadata.class, name = "yubihsm"),
-  @JsonSubTypes.Type(value = AwsKeySigningMetadata.class, name = "aws-secret")
+  @JsonSubTypes.Type(value = FileRawSigningMetadata.class, name = FileRawSigningMetadata.TYPE),
+  @JsonSubTypes.Type(value = FileKeyStoreMetadata.class, name = FileKeyStoreMetadata.TYPE),
+  @JsonSubTypes.Type(value = HashicorpSigningMetadata.class, name = HashicorpSigningMetadata.TYPE),
+  @JsonSubTypes.Type(
+      value = AzureSecretSigningMetadata.class,
+      name = AzureSecretSigningMetadata.TYPE),
+  @JsonSubTypes.Type(value = AzureKeySigningMetadata.class, name = AzureKeySigningMetadata.TYPE),
+  @JsonSubTypes.Type(value = InterlockSigningMetadata.class, name = InterlockSigningMetadata.TYPE),
+  @JsonSubTypes.Type(value = YubiHsmSigningMetadata.class, name = YubiHsmSigningMetadata.TYPE),
+  @JsonSubTypes.Type(value = AwsKeySigningMetadata.class, name = AwsKeySigningMetadata.TYPE)
 })
 public abstract class SigningMetadata {
 
   private final KeyType keyType;
 
-  protected SigningMetadata(final KeyType keyType) {
+  @JsonProperty("type")
+  @JsonInclude
+  private final String type;
+
+  protected SigningMetadata(final String type, final KeyType keyType) {
+    this.type = type;
     this.keyType = keyType;
   }
 
@@ -41,5 +50,9 @@ public abstract class SigningMetadata {
 
   public KeyType getKeyType() {
     return keyType;
+  }
+
+  public String getType() {
+    return type;
   }
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/YubiHsmSigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/YubiHsmSigningMetadata.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class YubiHsmSigningMetadata extends SigningMetadata {
+  public static final String TYPE = "yubihsm";
   private final String pkcs11ModulePath;
   private final String connectorUrl;
   private final String additionalInitConfig;
@@ -37,7 +38,7 @@ public class YubiHsmSigningMetadata extends SigningMetadata {
       @JsonProperty(value = "password", required = true) final String password,
       @JsonProperty(value = "opaqueDataId", required = true) final short opaqueDataId,
       @JsonProperty(value = "keyType") final KeyType keyType) {
-    super(keyType != null ? keyType : KeyType.BLS);
+    super(TYPE, keyType != null ? keyType : KeyType.BLS);
 
     this.pkcs11ModulePath = pkcs11ModulePath;
     this.connectorUrl = connectorUrl;

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/parser/SignerParser.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/parser/SignerParser.java
@@ -13,11 +13,16 @@
 package tech.pegasys.web3signer.signing.config.metadata.parser;
 
 import tech.pegasys.web3signer.signing.ArtifactSigner;
+import tech.pegasys.web3signer.signing.config.metadata.SigningMetadata;
 import tech.pegasys.web3signer.signing.config.metadata.SigningMetadataException;
 
 import java.util.List;
 
 public interface SignerParser {
 
-  List<ArtifactSigner> parse(String fileContent) throws SigningMetadataException;
+  List<SigningMetadata> readSigningMetadata(final String fileContent)
+      throws SigningMetadataException;
+
+  List<ArtifactSigner> parse(List<SigningMetadata> signingMetadataList)
+      throws SigningMetadataException;
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/parser/YamlSignerParser.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/parser/YamlSignerParser.java
@@ -41,19 +41,13 @@ public class YamlSignerParser implements SignerParser {
   }
 
   @Override
-  public List<ArtifactSigner> parse(final String fileContent) {
+  public List<SigningMetadata> readSigningMetadata(final String fileContent) {
+    final List<SigningMetadata> metadataInfoList;
     try {
-      final List<SigningMetadata> metadataInfoList = readSigningMetadata(fileContent);
+      metadataInfoList = readYaml(fileContent);
       if (metadataInfoList == null || metadataInfoList.isEmpty()) {
         throw new SigningMetadataException("Invalid signing metadata file format");
       }
-      return metadataInfoList.stream()
-          .flatMap(
-              metadataInfo ->
-                  signerFactories.stream()
-                      .filter(factory -> factory.getKeyType() == metadataInfo.getKeyType())
-                      .map(metadataInfo::createSigner))
-          .collect(Collectors.toList());
     } catch (final JsonParseException | JsonMappingException e) {
       throw new SigningMetadataException("Invalid signing metadata file format", e);
     } catch (final IOException e) {
@@ -64,9 +58,28 @@ public class YamlSignerParser implements SignerParser {
     } catch (final Exception e) {
       throw new SigningMetadataException("Unknown failure", e);
     }
+
+    return metadataInfoList;
   }
 
-  private List<SigningMetadata> readSigningMetadata(String fileContent) throws IOException {
+  @Override
+  public List<ArtifactSigner> parse(final List<SigningMetadata> metadataInfoList) {
+    try {
+      return metadataInfoList.stream()
+          .flatMap(
+              metadataInfo ->
+                  signerFactories.stream()
+                      .filter(factory -> factory.getKeyType() == metadataInfo.getKeyType())
+                      .map(metadataInfo::createSigner))
+          .collect(Collectors.toList());
+    } catch (final SigningMetadataException e) {
+      throw e;
+    } catch (final Exception e) {
+      throw new SigningMetadataException("Unknown failure", e);
+    }
+  }
+
+  private List<SigningMetadata> readYaml(String fileContent) throws IOException {
     try (final MappingIterator<SigningMetadata> iterator =
         yamlMapper.readValues(yamlMapper.createParser(fileContent), new TypeReference<>() {})) {
       return iterator.readAll();

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/parser/YamlSignerParser.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/parser/YamlSignerParser.java
@@ -75,7 +75,8 @@ public class YamlSignerParser implements SignerParser {
     } catch (final SigningMetadataException e) {
       throw e;
     } catch (final Exception e) {
-      throw new SigningMetadataException("Unknown failure", e);
+      throw new SigningMetadataException(
+          "Unexpected error while converting SigningMetadata to ArtifactSigner", e);
     }
   }
 

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/config/metadata/BlsArtifactSignerFactoryTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/config/metadata/BlsArtifactSignerFactoryTest.java
@@ -90,7 +90,7 @@ class BlsArtifactSignerFactoryTest {
         new BlsArtifactSignerFactory(
             configDir,
             new NoOpMetricsSystem(),
-            new HashicorpConnectionFactory(vertx),
+            new HashicorpConnectionFactory(),
             interlockKeyProvider,
             yubiHsmOpaqueDataProvider,
             awsSecretsManagerProvider,

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/config/metadata/parser/YamlSignerParserMultiReadTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/config/metadata/parser/YamlSignerParserMultiReadTest.java
@@ -110,7 +110,8 @@ class YamlSignerParserMultiReadTest {
                 + "type: \"file-raw\"",
             prvKey1, prvKey2);
 
-    final List<ArtifactSigner> signingMetadataList = signerParser.parse(multiYaml);
+    final List<ArtifactSigner> signingMetadataList =
+        signerParser.parse(signerParser.readSigningMetadata(multiYaml));
 
     assertThat(signingMetadataList).hasSize(2);
   }
@@ -132,7 +133,8 @@ class YamlSignerParserMultiReadTest {
         String.format("%s%n%s", fileKeystoreMetadataYaml, rawKeystoreMetadataYaml);
 
     // parse and assert results
-    final List<ArtifactSigner> result = signerParser.parse(multiDocYaml);
+    final List<ArtifactSigner> result =
+        signerParser.parse(signerParser.readSigningMetadata(multiDocYaml));
     final Set<String> publicKeyIdentifiers =
         result.stream().map(ArtifactSigner::getIdentifier).collect(Collectors.toSet());
 
@@ -158,7 +160,7 @@ class YamlSignerParserMultiReadTest {
             prvKey1, prvKey2);
 
     assertThatExceptionOfType(SigningMetadataException.class)
-        .isThrownBy(() -> signerParser.parse(multiYaml))
+        .isThrownBy(() -> signerParser.parse(signerParser.readSigningMetadata(multiYaml)))
         .withMessage("Invalid signing metadata file format");
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->
## PR Description
Improve handling of very large number (30000+) of Hashicorp signing metadata configuration files.
- Update signers library to use Java HttpClient instead of Vertx HttpClient
- Update Web3Signer to handle Hashicorp signing metadata configuration file sequentially while handle other types using parallel/multi-threading.
- Refactoring of related unit and acceptance tests.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #736 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
