### PR TITLE
Eth RPC proxy

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/KeyLoadAndSignAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/KeyLoadAndSignAcceptanceTest.java
@@ -59,9 +59,9 @@ public class KeyLoadAndSignAcceptanceTest extends SigningAcceptanceTestBase {
   public void receiveA404IfRequestedKeyDoesNotExist(final KeyType keyType)
       throws JsonProcessingException {
     if (keyType == KeyType.BLS) {
-      setupEth1Signer();
+      setupEth2Signer(Eth2Network.MINIMAL, SpecMilestone.PHASE0);
     } else {
-      setupEth2Signer(Eth2Network.MAINNET, SpecMilestone.ALTAIR);
+      setupEth1Signer();
     }
     final String body = createBody(keyType);
     given()

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/DefaultCommandValues.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/DefaultCommandValues.java
@@ -15,10 +15,10 @@ package tech.pegasys.web3signer.commandline;
 public interface DefaultCommandValues {
   String CONFIG_FILE_OPTION_NAME = "--config-file";
 
-  String MANDATORY_FILE_FORMAT_HELP = "<FILE>";
-  String MANDATORY_PATH_FORMAT_HELP = "<PATH>";
-  String MANDATORY_HOST_FORMAT_HELP = "<HOST>";
-  String MANDATORY_PORT_FORMAT_HELP = "<PORT>";
-  String MANDATORY_BOOL_FORMAT_HELP = "<BOOL>";
-  String MANDATORY_LONG_FORMAT_HELP = "<LONG>";
+  String FILE_FORMAT_HELP = "<FILE>";
+  String PATH_FORMAT_HELP = "<PATH>";
+  String HOST_FORMAT_HELP = "<HOST>";
+  String PORT_FORMAT_HELP = "<PORT>";
+  String BOOL_FORMAT_HELP = "<BOOL>";
+  String LONG_FORMAT_HELP = "<LONG>";
 }

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/DefaultCommandValues.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/DefaultCommandValues.java
@@ -15,12 +15,10 @@ package tech.pegasys.web3signer.commandline;
 public interface DefaultCommandValues {
   String CONFIG_FILE_OPTION_NAME = "--config-file";
 
-  // TODO JF these are used for optional values as well?
   String MANDATORY_FILE_FORMAT_HELP = "<FILE>";
   String MANDATORY_PATH_FORMAT_HELP = "<PATH>";
   String MANDATORY_HOST_FORMAT_HELP = "<HOST>";
   String MANDATORY_PORT_FORMAT_HELP = "<PORT>";
   String MANDATORY_BOOL_FORMAT_HELP = "<BOOL>";
-
   String MANDATORY_LONG_FORMAT_HELP = "<LONG>";
 }

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
@@ -13,9 +13,9 @@
 package tech.pegasys.web3signer.commandline;
 
 import static tech.pegasys.web3signer.commandline.DefaultCommandValues.CONFIG_FILE_OPTION_NAME;
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_HOST_FORMAT_HELP;
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_PORT_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.FILE_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.HOST_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.PORT_FORMAT_HELP;
 import static tech.pegasys.web3signer.common.Web3SignerMetricCategory.DEFAULT_METRIC_CATEGORIES;
 
 import tech.pegasys.web3signer.commandline.config.AllowListHostsProperty;
@@ -71,21 +71,21 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
   @SuppressWarnings("UnusedVariable")
   @CommandLine.Option(
       names = {CONFIG_FILE_OPTION_NAME},
-      paramLabel = MANDATORY_FILE_FORMAT_HELP,
+      paramLabel = FILE_FORMAT_HELP,
       description = "Config file in yaml format (default: none)")
   private final File configFile = null;
 
   @Option(
       names = {"--data-path"},
       description = "The path to a directory to store temporary files",
-      paramLabel = DefaultCommandValues.MANDATORY_PATH_FORMAT_HELP,
+      paramLabel = DefaultCommandValues.PATH_FORMAT_HELP,
       arity = "1")
   private Path dataPath;
 
   @Option(
       names = {"--key-store-path"},
       description = "The path to a directory storing yaml files defining available keys",
-      paramLabel = DefaultCommandValues.MANDATORY_PATH_FORMAT_HELP,
+      paramLabel = DefaultCommandValues.PATH_FORMAT_HELP,
       arity = "1")
   private Path keyStorePath = Path.of("./");
 
@@ -109,14 +109,14 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
   @Option(
       names = {"--http-listen-host"},
       description = "Host for HTTP to listen on (default: ${DEFAULT-VALUE})",
-      paramLabel = MANDATORY_HOST_FORMAT_HELP,
+      paramLabel = HOST_FORMAT_HELP,
       arity = "1")
   private String httpListenHost = InetAddress.getLoopbackAddress().getHostAddress();
 
   @Option(
       names = {"--http-listen-port"},
       description = "Port for HTTP to listen on (default: ${DEFAULT-VALUE})",
-      paramLabel = MANDATORY_PORT_FORMAT_HELP,
+      paramLabel = PORT_FORMAT_HELP,
       arity = "1")
   private final Integer httpListenPort = 9000;
 
@@ -143,14 +143,14 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
   @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"}) // PicoCLI requires non-final Strings.
   @Option(
       names = {"--metrics-host"},
-      paramLabel = MANDATORY_HOST_FORMAT_HELP,
+      paramLabel = HOST_FORMAT_HELP,
       description = "Host for the metrics exporter to listen on (default: ${DEFAULT-VALUE})",
       arity = "1")
   private String metricsHost = InetAddress.getLoopbackAddress().getHostAddress();
 
   @Option(
       names = {"--metrics-port"},
-      paramLabel = MANDATORY_PORT_FORMAT_HELP,
+      paramLabel = PORT_FORMAT_HELP,
       description = "Port for the metrics exporter to listen on (default: ${DEFAULT-VALUE})",
       arity = "1")
   private final Integer metricsPort = 9001;

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
@@ -23,7 +23,7 @@ import tech.pegasys.web3signer.commandline.config.PicoCliTlsServerOptions;
 import tech.pegasys.web3signer.commandline.config.PicoCliTlsServerOptionsValidator;
 import tech.pegasys.web3signer.commandline.convertor.MetricCategoryConverter;
 import tech.pegasys.web3signer.common.Web3SignerMetricCategory;
-import tech.pegasys.web3signer.core.config.Config;
+import tech.pegasys.web3signer.core.config.BaseConfig;
 import tech.pegasys.web3signer.core.config.TlsOptions;
 
 import java.io.File;
@@ -62,7 +62,7 @@ import picocli.CommandLine.Spec;
     footerHeading = "%n",
     subcommands = {HelpCommand.class},
     footer = "Web3Signer is licensed under the Apache License 2.0")
-public class Web3SignerBaseCommand implements Config, Runnable {
+public class Web3SignerBaseCommand implements BaseConfig, Runnable {
 
   @Spec private CommandLine.Model.CommandSpec spec; // injected by picocli
   public static final String KEY_STORE_CONFIG_FILE_SIZE_OPTION_NAME =

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/annotations/RequiredOption.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/annotations/RequiredOption.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.web3signer.core.annotations;
+package tech.pegasys.web3signer.commandline.annotations;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/PicoCliClientAuthConstraints.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/PicoCliClientAuthConstraints.java
@@ -12,8 +12,8 @@
  */
 package tech.pegasys.web3signer.commandline.config;
 
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_BOOL_FORMAT_HELP;
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.BOOL_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.FILE_FORMAT_HELP;
 
 import tech.pegasys.web3signer.core.config.ClientAuthConstraints;
 
@@ -27,7 +27,7 @@ public class PicoCliClientAuthConstraints implements ClientAuthConstraints {
   @Option(
       names = "--tls-known-clients-file",
       description = "Path to a file containing the fingerprints of authorized clients.",
-      paramLabel = MANDATORY_FILE_FORMAT_HELP,
+      paramLabel = FILE_FORMAT_HELP,
       arity = "1")
   private File tlsKnownClientsFile = null;
 
@@ -35,7 +35,7 @@ public class PicoCliClientAuthConstraints implements ClientAuthConstraints {
       names = "--tls-allow-ca-clients",
       description =
           "If set to true, allows clients authorized by the CA to connect to Web3Signer. (Default: false)",
-      paramLabel = MANDATORY_BOOL_FORMAT_HELP,
+      paramLabel = BOOL_FORMAT_HELP,
       arity = "1")
   private Boolean tlsAllowCaClients = false;
 

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/PicoCliTlsServerOptions.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/PicoCliTlsServerOptions.java
@@ -12,8 +12,8 @@
  */
 package tech.pegasys.web3signer.commandline.config;
 
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_BOOL_FORMAT_HELP;
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.BOOL_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.FILE_FORMAT_HELP;
 
 import tech.pegasys.web3signer.core.config.ClientAuthConstraints;
 import tech.pegasys.web3signer.core.config.TlsOptions;
@@ -31,14 +31,14 @@ public class PicoCliTlsServerOptions implements TlsOptions {
       description =
           "Path to a PKCS#12 formatted keystore; used to enable TLS on inbound connections.",
       arity = "1",
-      paramLabel = MANDATORY_FILE_FORMAT_HELP)
+      paramLabel = FILE_FORMAT_HELP)
   private File keyStoreFile = null;
 
   @Option(
       names = "--tls-keystore-password-file",
       description = "Path to a file containing the password used to decrypt the keystore.",
       arity = "1",
-      paramLabel = MANDATORY_FILE_FORMAT_HELP)
+      paramLabel = FILE_FORMAT_HELP)
   private File keyStorePasswordFile = null;
 
   @Option(
@@ -46,7 +46,7 @@ public class PicoCliTlsServerOptions implements TlsOptions {
       description =
           "If set to true, any client may connect, regardless of presented certificate. This cannot "
               + "be set to true if either a known clients file is specified or CA clients have been enabled. (Default: false)",
-      paramLabel = MANDATORY_BOOL_FORMAT_HELP,
+      paramLabel = BOOL_FORMAT_HELP,
       arity = "1")
   Boolean tlsAllowAnyClient = false; // package level access for validator
 

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/PicoKeystoresParameters.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/PicoKeystoresParameters.java
@@ -25,7 +25,7 @@ public class PicoKeystoresParameters implements KeystoresParameters {
       names = {"--keystores-path"},
       description =
           "The path to a directory storing Eth2 keystores. Keystore files must use a .json file extension.",
-      paramLabel = DefaultCommandValues.MANDATORY_PATH_FORMAT_HELP)
+      paramLabel = DefaultCommandValues.PATH_FORMAT_HELP)
   private Path keystoresPath;
 
   @Option(
@@ -34,7 +34,7 @@ public class PicoKeystoresParameters implements KeystoresParameters {
           "The path to a directory with the corresponding password files for the keystores."
               + " Filename must match the corresponding keystore filename but with a .txt extension."
               + " This cannot be set if --keystores-password-file is also specified.",
-      paramLabel = DefaultCommandValues.MANDATORY_PATH_FORMAT_HELP)
+      paramLabel = DefaultCommandValues.PATH_FORMAT_HELP)
   private Path keystoresPasswordsPath;
 
   @Option(
@@ -42,7 +42,7 @@ public class PicoKeystoresParameters implements KeystoresParameters {
       description =
           "The path to a file that contains the password that all keystores use."
               + " This cannot be set if --keystores-passwords-path is also specified.",
-      paramLabel = DefaultCommandValues.MANDATORY_PATH_FORMAT_HELP)
+      paramLabel = DefaultCommandValues.PATH_FORMAT_HELP)
   private Path keystoresPasswordFile;
 
   @Override

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/client/PicoCliClientTlsOptions.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/client/PicoCliClientTlsOptions.java
@@ -12,8 +12,8 @@
  */
 package tech.pegasys.web3signer.commandline.config.client;
 
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_BOOL_FORMAT_HELP;
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.BOOL_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.FILE_FORMAT_HELP;
 
 import tech.pegasys.web3signer.core.config.KeyStoreOptions;
 import tech.pegasys.web3signer.core.config.client.ClientTlsOptions;
@@ -29,7 +29,7 @@ public class PicoCliClientTlsOptions implements ClientTlsOptions {
   @Option(
       names = "--downstream-http-tls-enabled",
       description = "Flag to enable TLS connection to web3 provider. Defaults to disabled.",
-      paramLabel = MANDATORY_BOOL_FORMAT_HELP,
+      paramLabel = BOOL_FORMAT_HELP,
       arity = "0..1")
   private boolean tlsEnabled = false;
 
@@ -39,7 +39,7 @@ public class PicoCliClientTlsOptions implements ClientTlsOptions {
       names = "--downstream-http-tls-known-servers-file",
       description =
           "Path to a file containing the hostname, port and certificate fingerprints of web3 providers to trust. Must be specified if CA auth is disabled.",
-      paramLabel = MANDATORY_FILE_FORMAT_HELP,
+      paramLabel = FILE_FORMAT_HELP,
       arity = "1")
   private Path knownServersFile;
 

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/client/PicoCliClientTlsOptions.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/client/PicoCliClientTlsOptions.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.commandline.config.client;
+
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_BOOL_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
+
+import tech.pegasys.web3signer.core.config.KeyStoreOptions;
+import tech.pegasys.web3signer.core.config.client.ClientTlsOptions;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+public class PicoCliClientTlsOptions implements ClientTlsOptions {
+  @SuppressWarnings("UnusedVariable")
+  @Option(
+      names = "--downstream-http-tls-enabled",
+      description = "Flag to enable TLS connection to web3 provider. Defaults to disabled.",
+      paramLabel = MANDATORY_BOOL_FORMAT_HELP,
+      arity = "0..1")
+  private boolean tlsEnabled = false;
+
+  @Mixin private PicoCliKeyStoreOptions keyStoreOptions;
+
+  @Option(
+      names = "--downstream-http-tls-known-servers-file",
+      description =
+          "Path to a file containing the hostname, port and certificate fingerprints of web3 providers to trust. Must be specified if CA auth is disabled.",
+      paramLabel = MANDATORY_FILE_FORMAT_HELP,
+      arity = "1")
+  private Path knownServersFile;
+
+  @Option(
+      names = "--downstream-http-tls-ca-auth-enabled",
+      description =
+          "If set, will use the system's CA to validate received server certificates. Defaults to enabled.",
+      arity = "1")
+  private boolean caAuthEnabled = true;
+
+  @Override
+  public Optional<KeyStoreOptions> getKeyStoreOptions() {
+    if (keyStoreOptions.getKeyStoreFile() == null && keyStoreOptions.getPasswordFile() == null) {
+      return Optional.empty();
+    }
+    return Optional.of(keyStoreOptions);
+  }
+
+  @Override
+  public boolean isCaAuthEnabled() {
+    return caAuthEnabled;
+  }
+
+  @Override
+  public Optional<Path> getKnownServersFile() {
+    return Optional.ofNullable(knownServersFile);
+  }
+
+  public boolean isTlsEnabled() {
+    return tlsEnabled;
+  }
+}

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/client/PicoCliKeyStoreOptions.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/client/PicoCliKeyStoreOptions.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.commandline.config.client;
+
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
+
+import tech.pegasys.web3signer.core.config.KeyStoreOptions;
+
+import java.nio.file.Path;
+
+import picocli.CommandLine.Option;
+
+class PicoCliKeyStoreOptions implements KeyStoreOptions {
+
+  @Option(
+      names = "--downstream-http-tls-keystore-file",
+      description =
+          "Path to a PKCS#12 formatted keystore containing the key and certificate "
+              + "to present to a TLS-enabled web3 provider that requires client authentication.",
+      arity = "1",
+      paramLabel = MANDATORY_FILE_FORMAT_HELP)
+  private Path keyStoreFile;
+
+  @Option(
+      names = "--downstream-http-tls-keystore-password-file",
+      description = "Path to a file containing the password used to decrypt the keystore.",
+      arity = "1",
+      paramLabel = MANDATORY_FILE_FORMAT_HELP)
+  private Path passwordFile;
+
+  @Override
+  public Path getKeyStoreFile() {
+    return keyStoreFile;
+  }
+
+  @Override
+  public Path getPasswordFile() {
+    return passwordFile;
+  }
+}

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/client/PicoCliKeyStoreOptions.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/client/PicoCliKeyStoreOptions.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.web3signer.commandline.config.client;
 
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.FILE_FORMAT_HELP;
 
 import tech.pegasys.web3signer.core.config.KeyStoreOptions;
 
@@ -28,14 +28,14 @@ class PicoCliKeyStoreOptions implements KeyStoreOptions {
           "Path to a PKCS#12 formatted keystore containing the key and certificate "
               + "to present to a TLS-enabled web3 provider that requires client authentication.",
       arity = "1",
-      paramLabel = MANDATORY_FILE_FORMAT_HELP)
+      paramLabel = FILE_FORMAT_HELP)
   private Path keyStoreFile;
 
   @Option(
       names = "--downstream-http-tls-keystore-password-file",
       description = "Path to a file containing the password used to decrypt the keystore.",
       arity = "1",
-      paramLabel = MANDATORY_FILE_FORMAT_HELP)
+      paramLabel = FILE_FORMAT_HELP)
   private Path passwordFile;
 
   @Override

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth1SubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth1SubCommand.java
@@ -12,13 +12,13 @@
  */
 package tech.pegasys.web3signer.commandline.subcommands;
 
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_HOST_FORMAT_HELP;
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP;
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_PATH_FORMAT_HELP;
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_PORT_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.BOOL_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.HOST_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.LONG_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.PATH_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.PORT_FORMAT_HELP;
 import static tech.pegasys.web3signer.commandline.util.RequiredOptionsUtil.checkIfRequiredOptionsAreInitialized;
 
-import tech.pegasys.web3signer.commandline.annotations.RequiredOption;
 import tech.pegasys.web3signer.commandline.config.client.PicoCliClientTlsOptions;
 import tech.pegasys.web3signer.core.Eth1Runner;
 import tech.pegasys.web3signer.core.Runner;
@@ -47,28 +47,38 @@ public class Eth1SubCommand extends ModeSubCommand implements Eth1Config {
 
   @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
   @CommandLine.Option(
+      names = "--downstream-http-proxy-enabled",
+      description =
+          "Enable http downstream proxying of requests to the web3provider (default: ${DEFAULT-VALUE})",
+      paramLabel = BOOL_FORMAT_HELP,
+      arity = "1")
+  private Boolean downstreamHttpProxyEnabled = false;
+
+  @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
+  @CommandLine.Option(
       names = "--downstream-http-host",
-      description = "The endpoint to which received requests are forwarded (default: 127.0.0.1)",
-      paramLabel = MANDATORY_HOST_FORMAT_HELP,
+      description =
+          "The endpoint to which received requests are forwarded (default: ${DEFAULT-VALUE})",
+      paramLabel = HOST_FORMAT_HELP,
       arity = "1")
   private String downstreamHttpHost = "127.0.0.1";
 
   @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
-  @RequiredOption
   @CommandLine.Option(
       names = "--downstream-http-port",
-      description = "The endpoint to which received requests are forwarded",
-      paramLabel = MANDATORY_PORT_FORMAT_HELP,
+      description =
+          "The endpoint to which received requests are forwarded (default: ${DEFAULT-VALUE})",
+      paramLabel = PORT_FORMAT_HELP,
       arity = "1")
-  private Integer downstreamHttpPort;
+  private Integer downstreamHttpPort = 8545;
 
   private String downstreamHttpPath = "/";
 
   @CommandLine.Option(
       names = {"--downstream-http-path"},
-      description = "The path to which received requests are forwarded (default: /)",
+      description = "The path to which received requests are forwarded (default: ${DEFAULT-VALUE})",
       defaultValue = "/",
-      paramLabel = MANDATORY_PATH_FORMAT_HELP,
+      paramLabel = PATH_FORMAT_HELP,
       arity = "1")
   public void setDownstreamHttpPath(final String path) {
     try {
@@ -87,8 +97,9 @@ public class Eth1SubCommand extends ModeSubCommand implements Eth1Config {
   @SuppressWarnings("FieldMayBeFinal")
   @CommandLine.Option(
       names = {"--downstream-http-request-timeout"},
-      description = "Timeout in milliseconds to wait for downstream request (default: 5000)",
-      paramLabel = MANDATORY_LONG_FORMAT_HELP,
+      description =
+          "Timeout in milliseconds to wait for downstream request (default: ${DEFAULT-VALUE})",
+      paramLabel = LONG_FORMAT_HELP,
       arity = "1")
   private long downstreamHttpRequestTimeout = Duration.ofSeconds(5).toMillis();
 
@@ -96,13 +107,13 @@ public class Eth1SubCommand extends ModeSubCommand implements Eth1Config {
   @CommandLine.Option(
       names = {"--downstream-http-proxy-host"},
       description = "Hostname for proxy connect, no proxy if null (default: null)",
-      paramLabel = MANDATORY_HOST_FORMAT_HELP,
+      paramLabel = HOST_FORMAT_HELP,
       arity = "1")
   private String httpProxyHost = null;
 
   @CommandLine.Option(
       names = {"--downstream-http-proxy-port"},
-      paramLabel = MANDATORY_PORT_FORMAT_HELP,
+      paramLabel = PORT_FORMAT_HELP,
       description = "Port for proxy connect (default: 80)",
       arity = "1")
   private final Integer httpProxyPort = 80;
@@ -111,7 +122,8 @@ public class Eth1SubCommand extends ModeSubCommand implements Eth1Config {
   @CommandLine.Option(
       names = {"--downstream-http-proxy-username"},
       paramLabel = "<username>",
-      description = "Username for proxy connect, no authentication if null (default: null)",
+      description =
+          "Username for proxy connect, no authentication if null (default: ${DEFAULT-VALUE})",
       arity = "1")
   private String httpProxyUsername = null;
 
@@ -119,7 +131,8 @@ public class Eth1SubCommand extends ModeSubCommand implements Eth1Config {
   @CommandLine.Option(
       names = {"--downstream-http-proxy-password"},
       paramLabel = "<password>",
-      description = "Password for proxy connect, no authentication if null (default: null)",
+      description =
+          "Password for proxy connect, no authentication if null (default: ${DEFAULT-VALUE})",
       arity = "1")
   private String httpProxyPassword = null;
 
@@ -138,6 +151,11 @@ public class Eth1SubCommand extends ModeSubCommand implements Eth1Config {
   @Override
   protected void validateArgs() {
     checkIfRequiredOptionsAreInitialized(this);
+  }
+
+  @Override
+  public Boolean getDownstreamHttpProxyEnabled() {
+    return downstreamHttpProxyEnabled;
   }
 
   @Override

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth1SubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth1SubCommand.java
@@ -12,9 +12,25 @@
  */
 package tech.pegasys.web3signer.commandline.subcommands;
 
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_HOST_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_PATH_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_PORT_FORMAT_HELP;
+import static tech.pegasys.web3signer.core.util.RequiredOptionsUtil.checkIfRequiredOptionsAreInitialized;
+
+import tech.pegasys.web3signer.commandline.config.client.PicoCliClientTlsOptions;
 import tech.pegasys.web3signer.core.Eth1Runner;
 import tech.pegasys.web3signer.core.Runner;
+import tech.pegasys.web3signer.core.annotations.RequiredOption;
+import tech.pegasys.web3signer.core.config.Eth1Config;
+import tech.pegasys.web3signer.core.config.client.ClientTlsOptions;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.Optional;
+
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;
 
@@ -23,13 +39,95 @@ import picocli.CommandLine.HelpCommand;
     description = "Handle Ethereum-1 SECP256k1 signing operations and public key reporting",
     subcommands = {HelpCommand.class},
     mixinStandardHelpOptions = true)
-public class Eth1SubCommand extends ModeSubCommand {
+public class Eth1SubCommand extends ModeSubCommand implements Eth1Config {
 
   public static final String COMMAND_NAME = "eth1";
 
+  @CommandLine.Spec private CommandLine.Model.CommandSpec spec; // injected by picocli
+
+  @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
+  @CommandLine.Option(
+      names = "--downstream-http-host",
+      description = "The endpoint to which received requests are forwarded (default: 127.0.0.1)",
+      paramLabel = MANDATORY_HOST_FORMAT_HELP,
+      arity = "1")
+  private String downstreamHttpHost = "127.0.0.1";
+
+  @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
+  @RequiredOption
+  @CommandLine.Option(
+      names = "--downstream-http-port",
+      description = "The endpoint to which received requests are forwarded",
+      paramLabel = MANDATORY_PORT_FORMAT_HELP,
+      arity = "1")
+  private Integer downstreamHttpPort;
+
+  private String downstreamHttpPath = "/";
+
+  @CommandLine.Option(
+      names = {"--downstream-http-path"},
+      description = "The path to which received requests are forwarded (default: /)",
+      defaultValue = "/",
+      paramLabel = MANDATORY_PATH_FORMAT_HELP,
+      arity = "1")
+  public void setDownstreamHttpPath(final String path) {
+    try {
+      final URI uri = new URI(path);
+      if (!uri.getPath().equals(path)) {
+        throw new CommandLine.ParameterException(
+            spec.commandLine(), "Illegal characters detected in --downstream-http-path");
+      }
+    } catch (final URISyntaxException e) {
+      throw new CommandLine.ParameterException(
+          spec.commandLine(), "Illegal characters detected in --downstream-http-path");
+    }
+    this.downstreamHttpPath = path;
+  }
+
+  @SuppressWarnings("FieldMayBeFinal")
+  @CommandLine.Option(
+      names = {"--downstream-http-request-timeout"},
+      description = "Timeout in milliseconds to wait for downstream request (default: 5000)",
+      paramLabel = MANDATORY_LONG_FORMAT_HELP,
+      arity = "1")
+  private long downstreamHttpRequestTimeout = Duration.ofSeconds(5).toMillis();
+
+  @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
+  @CommandLine.Option(
+      names = {"--downstream-http-proxy-host"},
+      description = "Hostname for proxy connect, no proxy if null (default: null)",
+      paramLabel = MANDATORY_HOST_FORMAT_HELP,
+      arity = "1")
+  private String httpProxyHost = null;
+
+  @CommandLine.Option(
+      names = {"--downstream-http-proxy-port"},
+      paramLabel = MANDATORY_PORT_FORMAT_HELP,
+      description = "Port for proxy connect (default: 80)",
+      arity = "1")
+  private final Integer httpProxyPort = 80;
+
+  @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
+  @CommandLine.Option(
+      names = {"--downstream-http-proxy-username"},
+      paramLabel = "<username>",
+      description = "Username for proxy connect, no authentication if null (default: null)",
+      arity = "1")
+  private String httpProxyUsername = null;
+
+  @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
+  @CommandLine.Option(
+      names = {"--downstream-http-proxy-password"},
+      paramLabel = "<password>",
+      description = "Password for proxy connect, no authentication if null (default: null)",
+      arity = "1")
+  private String httpProxyPassword = null;
+
+  @CommandLine.Mixin private PicoCliClientTlsOptions clientTlsOptions;
+
   @Override
   public Runner createRunner() {
-    return new Eth1Runner(config);
+    return new Eth1Runner(config, this);
   }
 
   @Override
@@ -39,6 +137,51 @@ public class Eth1SubCommand extends ModeSubCommand {
 
   @Override
   protected void validateArgs() {
-    // no special validation required
+    checkIfRequiredOptionsAreInitialized(this);
+  }
+
+  @Override
+  public String getDownstreamHttpHost() {
+    return downstreamHttpHost;
+  }
+
+  @Override
+  public Integer getDownstreamHttpPort() {
+    return downstreamHttpPort;
+  }
+
+  @Override
+  public String getDownstreamHttpPath() {
+    return downstreamHttpPath;
+  }
+
+  @Override
+  public Duration getDownstreamHttpRequestTimeout() {
+    return Duration.ofMillis(downstreamHttpRequestTimeout);
+  }
+
+  @Override
+  public String getHttpProxyHost() {
+    return httpProxyHost;
+  }
+
+  @Override
+  public Integer getHttpProxyPort() {
+    return httpProxyPort;
+  }
+
+  @Override
+  public String getHttpProxyUsername() {
+    return httpProxyUsername;
+  }
+
+  @Override
+  public String getHttpProxyPassword() {
+    return httpProxyPassword;
+  }
+
+  @Override
+  public Optional<ClientTlsOptions> getClientTlsOptions() {
+    return clientTlsOptions.isTlsEnabled() ? Optional.of(clientTlsOptions) : Optional.empty();
   }
 }

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth1SubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth1SubCommand.java
@@ -16,12 +16,12 @@ import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY
 import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP;
 import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_PATH_FORMAT_HELP;
 import static tech.pegasys.web3signer.commandline.DefaultCommandValues.MANDATORY_PORT_FORMAT_HELP;
-import static tech.pegasys.web3signer.core.util.RequiredOptionsUtil.checkIfRequiredOptionsAreInitialized;
+import static tech.pegasys.web3signer.commandline.util.RequiredOptionsUtil.checkIfRequiredOptionsAreInitialized;
 
+import tech.pegasys.web3signer.commandline.annotations.RequiredOption;
 import tech.pegasys.web3signer.commandline.config.client.PicoCliClientTlsOptions;
 import tech.pegasys.web3signer.core.Eth1Runner;
 import tech.pegasys.web3signer.core.Runner;
-import tech.pegasys.web3signer.core.annotations.RequiredOption;
 import tech.pegasys.web3signer.core.config.Eth1Config;
 import tech.pegasys.web3signer.core.config.client.ClientTlsOptions;
 

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/util/RequiredOptionsUtil.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/util/RequiredOptionsUtil.java
@@ -12,8 +12,8 @@
  */
 package tech.pegasys.web3signer.commandline.util;
 
+import tech.pegasys.web3signer.commandline.annotations.RequiredOption;
 import tech.pegasys.web3signer.core.InitializationException;
-import tech.pegasys.web3signer.core.annotations.RequiredOption;
 import tech.pegasys.web3signer.core.config.InvalidCommandLineOptionsException;
 
 import java.lang.reflect.Field;

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/util/RequiredOptionsUtil.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/util/RequiredOptionsUtil.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.web3signer.core.util;
+package tech.pegasys.web3signer.commandline.util;
 
 import tech.pegasys.web3signer.core.InitializationException;
 import tech.pegasys.web3signer.core.annotations.RequiredOption;

--- a/commandline/src/test/java/tech/pegasys/web3signer/commandline/CommandlineParserTest.java
+++ b/commandline/src/test/java/tech/pegasys/web3signer/commandline/CommandlineParserTest.java
@@ -27,7 +27,7 @@ import static tech.pegasys.web3signer.commandline.PicoCliAwsSecretsManagerParame
 import tech.pegasys.web3signer.commandline.subcommands.Eth2SubCommand;
 import tech.pegasys.web3signer.core.Context;
 import tech.pegasys.web3signer.core.Runner;
-import tech.pegasys.web3signer.core.config.Config;
+import tech.pegasys.web3signer.core.config.BaseConfig;
 import tech.pegasys.web3signer.signing.ArtifactSignerProvider;
 import tech.pegasys.web3signer.signing.config.AwsAuthenticationMode;
 
@@ -533,8 +533,8 @@ class CommandlineParserTest {
 
   public static class NoOpRunner extends Runner {
 
-    protected NoOpRunner(final Config config) {
-      super(config);
+    protected NoOpRunner(final BaseConfig baseConfig) {
+      super(baseConfig);
     }
 
     @Override

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -19,7 +19,7 @@ import static tech.pegasys.web3signer.signing.KeyType.SECP256K1;
 
 import tech.pegasys.signers.hashicorp.HashicorpConnectionFactory;
 import tech.pegasys.signers.secp256k1.azure.AzureKeyVaultSignerFactory;
-import tech.pegasys.web3signer.core.config.Config;
+import tech.pegasys.web3signer.core.config.BaseConfig;
 import tech.pegasys.web3signer.core.service.DownstreamPathCalculator;
 import tech.pegasys.web3signer.core.service.PassThroughHandler;
 import tech.pegasys.web3signer.core.service.VertxRequestTransmitter;
@@ -52,8 +52,8 @@ import io.vertx.ext.web.openapi.RouterBuilder;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 public class Eth1Runner extends Runner {
-  public Eth1Runner(final Config config) {
-    super(config);
+  public Eth1Runner(final BaseConfig baseConfig) {
+    super(baseConfig);
   }
 
   @Override
@@ -127,7 +127,7 @@ public class Eth1Runner extends Runner {
             final Secp256k1ArtifactSignerFactory ethSecpArtifactSignerFactory =
                 new Secp256k1ArtifactSignerFactory(
                     hashicorpConnectionFactory,
-                    config.getKeyConfigPath(),
+                    baseConfig.getKeyConfigPath(),
                     azureFactory,
                     interlockKeyProvider,
                     yubiHsmOpaqueDataProvider,
@@ -136,11 +136,11 @@ public class Eth1Runner extends Runner {
 
             return new SignerLoader()
                 .load(
-                    config.getKeyConfigPath(),
+                    baseConfig.getKeyConfigPath(),
                     "yaml",
                     new YamlSignerParser(
                         List.of(ethSecpArtifactSignerFactory),
-                        YamlMapperFactory.createYamlMapper(config.getKeyStoreConfigFileMaxSize())))
+                        YamlMapperFactory.createYamlMapper(baseConfig.getKeyStoreConfigFileMaxSize())))
                 .getValues();
           }
         });

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -46,6 +46,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.impl.BlockingHandlerDecorator;
 import io.vertx.ext.web.openapi.RouterBuilder;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -105,9 +106,11 @@ public class Eth1Runner extends Runner {
                 downstreamPathCalculator,
                 responseBodyHandler);
 
-    routerBuilder.rootHandler(new PassThroughHandler(transmitterFactory));
+    final Router router = context.getRouterBuilder().createRouter();
+    final PassThroughHandler passThroughHandler = new PassThroughHandler(transmitterFactory);
+    router.route().handler(BodyHandler.create()).handler(passThroughHandler);
 
-    return context.getRouterBuilder().createRouter();
+    return router;
   }
 
   @Override

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -140,7 +140,8 @@ public class Eth1Runner extends Runner {
                     "yaml",
                     new YamlSignerParser(
                         List.of(ethSecpArtifactSignerFactory),
-                        YamlMapperFactory.createYamlMapper(baseConfig.getKeyStoreConfigFileMaxSize())))
+                        YamlMapperFactory.createYamlMapper(
+                            baseConfig.getKeyStoreConfigFileMaxSize())))
                 .getValues();
           }
         });

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -32,7 +32,7 @@ import tech.pegasys.signers.hashicorp.HashicorpConnectionFactory;
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSSecretKey;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.web3signer.core.config.Config;
+import tech.pegasys.web3signer.core.config.BaseConfig;
 import tech.pegasys.web3signer.core.metrics.SlashingProtectionMetrics;
 import tech.pegasys.web3signer.core.service.http.SigningObjectMapperFactory;
 import tech.pegasys.web3signer.core.service.http.handlers.LogErrorHandler;
@@ -105,14 +105,14 @@ public class Eth2Runner extends Runner {
   private final boolean isKeyManagerApiEnabled;
 
   public Eth2Runner(
-      final Config config,
+      final BaseConfig baseConfig,
       final SlashingProtectionParameters slashingProtectionParameters,
       final AzureKeyVaultParameters azureKeyVaultParameters,
       final KeystoresParameters keystoresParameters,
       final AwsSecretsManagerParameters awsSecretsManagerParameters,
       final Spec eth2Spec,
       final boolean isKeyManagerApiEnabled) {
-    super(config);
+    super(baseConfig);
     this.slashingProtectionContext = createSlashingProtection(slashingProtectionParameters);
     this.azureKeyVaultParameters = azureKeyVaultParameters;
     this.slashingProtectionParameters = slashingProtectionParameters;
@@ -210,7 +210,7 @@ public class Eth2Runner extends Runner {
               new BlockingHandlerDecorator(
                   new ImportKeystoresHandler(
                       objectMapper,
-                      config.getKeyConfigPath(),
+                      baseConfig.getKeyConfigPath(),
                       slashingProtectionContext.map(
                           SlashingProtectionContext::getSlashingProtection),
                       blsSignerProvider,
@@ -239,8 +239,8 @@ public class Eth2Runner extends Runner {
         new FileValidatorManager(
             artifactSignerProvider,
             new KeystoreFileManager(
-                config.getKeyConfigPath(),
-                YamlMapperFactory.createYamlMapper(config.getKeyStoreConfigFileMaxSize())),
+                baseConfig.getKeyConfigPath(),
+                YamlMapperFactory.createYamlMapper(baseConfig.getKeyStoreConfigFileMaxSize())),
             objectMapper);
     if (slashingProtectionContext.isPresent()) {
       final SlashingProtectionContext slashingProtectionContext =
@@ -271,7 +271,7 @@ public class Eth2Runner extends Runner {
                       awsSecretsManagerParameters.getCacheMaximumSize())) {
             final AbstractArtifactSignerFactory artifactSignerFactory =
                 new BlsArtifactSignerFactory(
-                    config.getKeyConfigPath(),
+                    baseConfig.getKeyConfigPath(),
                     metricsSystem,
                     hashicorpConnectionFactory,
                     interlockKeyProvider,
@@ -283,12 +283,12 @@ public class Eth2Runner extends Runner {
             final MappedResults<ArtifactSigner> results =
                 new SignerLoader()
                     .load(
-                        config.getKeyConfigPath(),
+                        baseConfig.getKeyConfigPath(),
                         "yaml",
                         new YamlSignerParser(
                             List.of(artifactSignerFactory),
                             YamlMapperFactory.createYamlMapper(
-                                config.getKeyStoreConfigFileMaxSize())));
+                                baseConfig.getKeyStoreConfigFileMaxSize())));
             registerSignerLoadingHealthCheck(KEYS_CHECK_CONFIG_FILE_LOADING, results);
             signers.addAll(results.getValues());
           }

--- a/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
@@ -22,7 +22,7 @@ import static tech.pegasys.web3signer.core.service.http.handlers.ContentTypes.JS
 import tech.pegasys.signers.aws.AwsSecretsManagerProvider;
 import tech.pegasys.signers.hashicorp.HashicorpConnectionFactory;
 import tech.pegasys.signers.secp256k1.azure.AzureKeyVaultSignerFactory;
-import tech.pegasys.web3signer.core.config.Config;
+import tech.pegasys.web3signer.core.config.BaseConfig;
 import tech.pegasys.web3signer.core.service.jsonrpc.FcJsonRpc;
 import tech.pegasys.web3signer.core.service.jsonrpc.FcJsonRpcMetrics;
 import tech.pegasys.web3signer.core.service.jsonrpc.FilecoinJsonRpcModule;
@@ -55,8 +55,8 @@ public class FilecoinRunner extends Runner {
   private static final String FC_JSON_RPC_PATH = "/rpc/v0";
   private final FilecoinNetwork network;
 
-  public FilecoinRunner(final Config config, final FilecoinNetwork network) {
-    super(config);
+  public FilecoinRunner(final BaseConfig baseConfig, final FilecoinNetwork network) {
+    super(baseConfig);
     this.network = network;
   }
 
@@ -128,7 +128,7 @@ public class FilecoinRunner extends Runner {
 
             final AbstractArtifactSignerFactory blsArtifactSignerFactory =
                 new BlsArtifactSignerFactory(
-                    config.getKeyConfigPath(),
+                    baseConfig.getKeyConfigPath(),
                     metricsSystem,
                     hashicorpConnectionFactory,
                     interlockKeyProvider,
@@ -139,7 +139,7 @@ public class FilecoinRunner extends Runner {
             final AbstractArtifactSignerFactory secpArtifactSignerFactory =
                 new Secp256k1ArtifactSignerFactory(
                     hashicorpConnectionFactory,
-                    config.getKeyConfigPath(),
+                    baseConfig.getKeyConfigPath(),
                     azureFactory,
                     interlockKeyProvider,
                     yubiHsmOpaqueDataProvider,
@@ -148,11 +148,11 @@ public class FilecoinRunner extends Runner {
 
             return new SignerLoader()
                 .load(
-                    config.getKeyConfigPath(),
+                    baseConfig.getKeyConfigPath(),
                     "yaml",
                     new YamlSignerParser(
                         List.of(blsArtifactSignerFactory, secpArtifactSignerFactory),
-                        YamlMapperFactory.createYamlMapper(config.getKeyStoreConfigFileMaxSize())))
+                        YamlMapperFactory.createYamlMapper(baseConfig.getKeyStoreConfigFileMaxSize())))
                 .getValues();
           }
         });

--- a/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
@@ -152,7 +152,8 @@ public class FilecoinRunner extends Runner {
                     "yaml",
                     new YamlSignerParser(
                         List.of(blsArtifactSignerFactory, secpArtifactSignerFactory),
-                        YamlMapperFactory.createYamlMapper(baseConfig.getKeyStoreConfigFileMaxSize())))
+                        YamlMapperFactory.createYamlMapper(
+                            baseConfig.getKeyStoreConfigFileMaxSize())))
                 .getValues();
           }
         });

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -417,7 +417,9 @@ public abstract class Runner implements Runnable {
       return ".*";
     } else {
       final StringJoiner stringJoiner = new StringJoiner("|");
-      baseConfig.getCorsAllowedOrigins().stream().filter(s -> !s.isEmpty()).forEach(stringJoiner::add);
+      baseConfig.getCorsAllowedOrigins().stream()
+          .filter(s -> !s.isEmpty())
+          .forEach(stringJoiner::add);
       return stringJoiner.toString();
     }
   }

--- a/core/src/main/java/tech/pegasys/web3signer/core/WebClientOptionsFactory.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/WebClientOptionsFactory.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core;
+
+import static org.apache.tuweni.net.tls.VertxTrustOptions.allowlistServers;
+
+import tech.pegasys.web3signer.core.config.Eth1Config;
+import tech.pegasys.web3signer.core.config.KeyStoreOptions;
+import tech.pegasys.web3signer.core.config.client.ClientTlsOptions;
+import tech.pegasys.web3signer.core.util.FileUtil;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import io.vertx.core.net.PfxOptions;
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.ext.web.client.WebClientOptions;
+
+class WebClientOptionsFactory {
+
+  public WebClientOptions createWebClientOptions(final Eth1Config eth1Config) {
+    final WebClientOptions clientOptions =
+        new WebClientOptions()
+            .setDefaultPort(eth1Config.getDownstreamHttpPort())
+            .setDefaultHost(eth1Config.getDownstreamHttpHost())
+            .setTryUseCompression(true)
+            .setProxyOptions(getProxyOptions(eth1Config).orElse(null));
+
+    applyTlsOptions(clientOptions, eth1Config);
+    return clientOptions;
+  }
+
+  private static Optional<ProxyOptions> getProxyOptions(final Eth1Config config) {
+    final String proxyHost = config.getHttpProxyHost();
+    if (proxyHost == null) {
+      return Optional.empty();
+    }
+    final int proxyPort = config.getHttpProxyPort();
+    final ProxyOptions proxyOptions = new ProxyOptions().setHost(proxyHost).setPort(proxyPort);
+    final String proxyUsername = config.getHttpProxyUsername();
+    final String proxyPassword = config.getHttpProxyPassword();
+    if (proxyUsername != null && proxyPassword != null) {
+      proxyOptions.setUsername(proxyUsername).setPassword(proxyPassword);
+    }
+    return Optional.of(proxyOptions);
+  }
+
+  private void applyTlsOptions(final WebClientOptions webClientOptions, final Eth1Config config) {
+    final Optional<ClientTlsOptions> optionalClientTlsOptions = config.getClientTlsOptions();
+    if (optionalClientTlsOptions.isEmpty()) {
+      return;
+    }
+
+    webClientOptions.setSsl(true);
+
+    final ClientTlsOptions clientTlsOptions = optionalClientTlsOptions.get();
+
+    applyTrustOptions(
+        webClientOptions,
+        clientTlsOptions.getKnownServersFile(),
+        clientTlsOptions.isCaAuthEnabled());
+    applyKeyStoreOptions(webClientOptions, clientTlsOptions.getKeyStoreOptions());
+  }
+
+  private void applyTrustOptions(
+      final WebClientOptions webClientOptions,
+      final Optional<Path> knownServerFile,
+      final boolean caAuthEnabled) {
+
+    if (knownServerFile.isPresent()) {
+      try {
+        webClientOptions.setTrustOptions(allowlistServers(knownServerFile.get(), caAuthEnabled));
+      } catch (RuntimeException e) {
+        throw new InitializationException("Failed to load known server file.", e);
+      }
+    }
+
+    if (knownServerFile.isEmpty() && !caAuthEnabled) {
+      throw new InitializationException(
+          "Must specify a known-server file if CA-signed option is disabled");
+    }
+    // otherwise knownServerFile is empty and caAuthEnabled is true which is the default situation
+  }
+
+  private void applyKeyStoreOptions(
+      final WebClientOptions webClientOptions,
+      final Optional<KeyStoreOptions> optionalKeyStoreOptions) {
+
+    if (optionalKeyStoreOptions.isEmpty()) {
+      return;
+    }
+
+    try {
+      webClientOptions.setPfxKeyCertOptions(convertFrom(optionalKeyStoreOptions.get()));
+    } catch (final IOException e) {
+      throw new InitializationException("Failed to load client certificate keystore.", e);
+    }
+  }
+
+  private PfxOptions convertFrom(final KeyStoreOptions keyStoreOptions) throws IOException {
+    final String password = FileUtil.readFirstLineFromFile(keyStoreOptions.getPasswordFile());
+    return new PfxOptions()
+        .setPassword(password)
+        .setPath(keyStoreOptions.getKeyStoreFile().toString());
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/annotations/RequiredOption.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/annotations/RequiredOption.java
@@ -10,17 +10,13 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.web3signer.commandline;
+package tech.pegasys.web3signer.core.annotations;
 
-public interface DefaultCommandValues {
-  String CONFIG_FILE_OPTION_NAME = "--config-file";
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-  // TODO JF these are used for optional values as well?
-  String MANDATORY_FILE_FORMAT_HELP = "<FILE>";
-  String MANDATORY_PATH_FORMAT_HELP = "<PATH>";
-  String MANDATORY_HOST_FORMAT_HELP = "<HOST>";
-  String MANDATORY_PORT_FORMAT_HELP = "<PORT>";
-  String MANDATORY_BOOL_FORMAT_HELP = "<BOOL>";
-
-  String MANDATORY_LONG_FORMAT_HELP = "<LONG>";
-}
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface RequiredOption {}

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/BaseConfig.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/BaseConfig.java
@@ -21,7 +21,7 @@ import java.util.Set;
 import org.apache.logging.log4j.Level;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 
-public interface Config {
+public interface BaseConfig {
 
   Level getLogLevel();
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/Eth1Config.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/Eth1Config.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.config;
+
+import tech.pegasys.web3signer.core.config.client.ClientTlsOptions;
+
+import java.time.Duration;
+import java.util.Optional;
+
+public interface Eth1Config {
+
+  String getDownstreamHttpHost();
+
+  Integer getDownstreamHttpPort();
+
+  String getDownstreamHttpPath();
+
+  Duration getDownstreamHttpRequestTimeout();
+
+  String getHttpProxyHost();
+
+  Integer getHttpProxyPort();
+
+  String getHttpProxyUsername();
+
+  String getHttpProxyPassword();
+
+  Optional<ClientTlsOptions> getClientTlsOptions();
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/Eth1Config.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/Eth1Config.java
@@ -19,6 +19,8 @@ import java.util.Optional;
 
 public interface Eth1Config {
 
+  Boolean getDownstreamHttpProxyEnabled();
+
   String getDownstreamHttpHost();
 
   Integer getDownstreamHttpPort();

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/InvalidCommandLineOptionsException.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/InvalidCommandLineOptionsException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.config;
+
+public class InvalidCommandLineOptionsException extends RuntimeException {
+
+  public InvalidCommandLineOptionsException() {}
+
+  public InvalidCommandLineOptionsException(final String message) {
+    super(message);
+  }
+
+  public InvalidCommandLineOptionsException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public InvalidCommandLineOptionsException(final Throwable cause) {
+    super(cause);
+  }
+
+  public InvalidCommandLineOptionsException(
+      final String message,
+      final Throwable cause,
+      final boolean enableSuppression,
+      final boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/KeyStoreOptions.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/KeyStoreOptions.java
@@ -10,17 +10,13 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.web3signer.commandline;
+package tech.pegasys.web3signer.core.config;
 
-public interface DefaultCommandValues {
-  String CONFIG_FILE_OPTION_NAME = "--config-file";
+import java.nio.file.Path;
 
-  // TODO JF these are used for optional values as well?
-  String MANDATORY_FILE_FORMAT_HELP = "<FILE>";
-  String MANDATORY_PATH_FORMAT_HELP = "<PATH>";
-  String MANDATORY_HOST_FORMAT_HELP = "<HOST>";
-  String MANDATORY_PORT_FORMAT_HELP = "<PORT>";
-  String MANDATORY_BOOL_FORMAT_HELP = "<BOOL>";
+public interface KeyStoreOptions {
 
-  String MANDATORY_LONG_FORMAT_HELP = "<LONG>";
+  Path getKeyStoreFile();
+
+  Path getPasswordFile();
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/client/ClientTlsOptions.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/client/ClientTlsOptions.java
@@ -10,17 +10,17 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.web3signer.commandline;
+package tech.pegasys.web3signer.core.config.client;
 
-public interface DefaultCommandValues {
-  String CONFIG_FILE_OPTION_NAME = "--config-file";
+import tech.pegasys.web3signer.core.config.KeyStoreOptions;
 
-  // TODO JF these are used for optional values as well?
-  String MANDATORY_FILE_FORMAT_HELP = "<FILE>";
-  String MANDATORY_PATH_FORMAT_HELP = "<PATH>";
-  String MANDATORY_HOST_FORMAT_HELP = "<HOST>";
-  String MANDATORY_PORT_FORMAT_HELP = "<PORT>";
-  String MANDATORY_BOOL_FORMAT_HELP = "<BOOL>";
+import java.nio.file.Path;
+import java.util.Optional;
 
-  String MANDATORY_LONG_FORMAT_HELP = "<LONG>";
+public interface ClientTlsOptions {
+  Optional<KeyStoreOptions> getKeyStoreOptions();
+
+  Optional<Path> getKnownServersFile();
+
+  boolean isCaAuthEnabled();
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/DownstreamPathCalculator.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/DownstreamPathCalculator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service;
+
+public class DownstreamPathCalculator {
+
+  private final String httpDownstreamPathPrefix;
+
+  public DownstreamPathCalculator(final String httpDownstreamPathPrefix) {
+    this.httpDownstreamPathPrefix = httpDownstreamPathPrefix;
+  }
+
+  public String calculateDownstreamPath(final String receivedRequestUri) {
+    // This function is required to join httpDownStreamPathPrefix with receivedRequestURI
+    // remove any duplicate "/"
+    // Not have an ending "/" if the path
+    // assumes httpdownstreamPathPrefix does not include =,?,&
+    // has a leading "/" as required by vertx
+    String result = "/" + httpDownstreamPathPrefix + "/" + receivedRequestUri;
+    result = result.replaceAll("/+", "/");
+    return result.length() == 1 ? result : result.replaceAll("/$", "");
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/DownstreamResponseHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/DownstreamResponseHandler.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service;
+
+import java.util.Map.Entry;
+
+public interface DownstreamResponseHandler {
+
+  void handleResponse(
+      final Iterable<Entry<String, String>> headers, final int statusCode, final String body);
+
+  void handleFailure(final Throwable t);
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/ForwardedMessageResponder.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/ForwardedMessageResponder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_GATEWAY;
+import static io.netty.handler.codec.http.HttpResponseStatus.GATEWAY_TIMEOUT;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+
+import java.net.ConnectException;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeoutException;
+import javax.net.ssl.SSLHandshakeException;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.vertx.ext.web.RoutingContext;
+
+public class ForwardedMessageResponder implements DownstreamResponseHandler {
+
+  private final RoutingContext context;
+
+  public ForwardedMessageResponder(final RoutingContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public void handleResponse(
+      final Iterable<Entry<String, String>> headers, final int statusCode, final String body) {
+    context.response().setStatusCode(statusCode);
+    headers.forEach(
+        entry -> {
+          if (!entry.getKey().equals(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString())) {
+            context.response().headers().add(entry.getKey(), entry.getValue());
+          }
+        });
+    context.response().setChunked(false);
+    context.response().end(body);
+  }
+
+  @Override
+  public void handleFailure(final Throwable thrown) {
+    if (thrown instanceof TimeoutException || thrown instanceof ConnectException) {
+      context.fail(GATEWAY_TIMEOUT.code(), thrown);
+    } else if (thrown instanceof SSLHandshakeException) {
+      context.fail(BAD_GATEWAY.code(), thrown);
+    } else {
+      context.fail(INTERNAL_SERVER_ERROR.code(), thrown);
+    }
+  }
+
+  protected RoutingContext context() {
+    return context;
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/HeaderHelpers.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/HeaderHelpers.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service;
+
+import java.util.List;
+
+import com.google.common.net.HttpHeaders;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+
+public class HeaderHelpers {
+
+  public static MultiMap createHeaders(final MultiMap headers) {
+    final MultiMap headersToReturn = new HeadersMultiMap();
+    headers.forEach(entry -> headersToReturn.add(entry.getKey(), entry.getValue()));
+
+    headersToReturn.remove(HttpHeaders.CONTENT_LENGTH);
+    headersToReturn.remove(HttpHeaders.ORIGIN);
+    renameHeader(headersToReturn, HttpHeaders.HOST, HttpHeaders.X_FORWARDED_HOST);
+
+    return headersToReturn;
+  }
+
+  private static void renameHeader(
+      final MultiMap headers, final String oldHeader, final String newHeader) {
+    final List<String> oldHeaderValue = headers.getAll(oldHeader);
+    headers.remove(oldHeader);
+    if (oldHeaderValue != null) {
+      headers.add(newHeader, oldHeaderValue);
+    }
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/PassThroughHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/PassThroughHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service;
+
+import tech.pegasys.web3signer.core.service.jsonrpc.JsonRpcRequest;
+import tech.pegasys.web3signer.core.service.jsonrpc.JsonRpcRequestHandler;
+
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PassThroughHandler implements JsonRpcRequestHandler, Handler<RoutingContext> {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final VertxRequestTransmitterFactory transmitterFactory;
+
+  public PassThroughHandler(final VertxRequestTransmitterFactory vertxTransmitterFactory) {
+    this.transmitterFactory = vertxTransmitterFactory;
+  }
+
+  @Override
+  public void handle(final RoutingContext context, final JsonRpcRequest request) {
+    handle(context);
+  }
+
+  @Override
+  public void handle(final RoutingContext context) {
+    logRequest(context.request(), context.getBodyAsString());
+    final VertxRequestTransmitter transmitter =
+        transmitterFactory.create(new ForwardedMessageResponder(context));
+
+    final HttpServerRequest request = context.request();
+    final MultiMap headersToSend = HeaderHelpers.createHeaders(request.headers());
+    transmitter.sendRequest(
+        request.method(), headersToSend, request.path(), context.getBodyAsString());
+  }
+
+  private void logRequest(final HttpServerRequest httpRequest, final String body) {
+    LOG.debug(
+        "Proxying method: {}, uri: {}, body: {}",
+        httpRequest::method,
+        httpRequest::absoluteURI,
+        () -> body);
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/RequestTransmitter.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/RequestTransmitter.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service;
+
+import java.util.Map.Entry;
+
+import io.vertx.core.http.HttpMethod;
+
+public interface RequestTransmitter {
+
+  void sendRequest(
+      HttpMethod method, Iterable<Entry<String, String>> headers, String path, String body);
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/VertxRequestTransmitter.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/VertxRequestTransmitter.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class VertxRequestTransmitter implements RequestTransmitter {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Vertx vertx;
+  private final Duration httpRequestTimeout;
+  private final DownstreamResponseHandler bodyHandler;
+  private final HttpClient downStreamConnection;
+  private final DownstreamPathCalculator downstreamPathCalculator;
+  private final AtomicBoolean responseHandled = new AtomicBoolean(false);
+
+  public VertxRequestTransmitter(
+      final Vertx vertx,
+      final HttpClient downStreamConnection,
+      final Duration httpRequestTimeout,
+      final DownstreamPathCalculator downstreamPathCalculator,
+      final DownstreamResponseHandler bodyHandler) {
+    this.vertx = vertx;
+    this.httpRequestTimeout = httpRequestTimeout;
+    this.bodyHandler = bodyHandler;
+    this.downStreamConnection = downStreamConnection;
+    this.downstreamPathCalculator = downstreamPathCalculator;
+  }
+
+  @Override
+  public void sendRequest(
+      final HttpMethod method,
+      final Iterable<Entry<String, String>> headers,
+      final String path,
+      final String body) {
+    LOG.debug(
+        "Sending headers {} and request {} to {} ",
+        () ->
+            StreamSupport.stream(headers.spliterator(), false)
+                .map(Objects::toString)
+                .collect(Collectors.joining(", ")),
+        () -> body,
+        () -> path);
+
+    final String fullPath = downstreamPathCalculator.calculateDownstreamPath(path);
+    downStreamConnection
+        .request(method, fullPath)
+        .onSuccess(
+            request -> {
+              request.response().onSuccess(this::handleResponse).onFailure(this::handleException);
+              request.setTimeout(httpRequestTimeout.toMillis());
+              request.exceptionHandler(this::handleException);
+              headers.forEach(entry -> request.headers().add(entry.getKey(), entry.getValue()));
+              request.setChunked(false);
+              request.end(body);
+            })
+        .onFailure(this::handleException);
+  }
+
+  private void handleException(final Throwable thrown) {
+    LOG.error("Transmission failed", thrown);
+    if (!responseHandled.getAndSet(true)) {
+      vertx.executeBlocking(
+          future -> bodyHandler.handleFailure(thrown),
+          false,
+          res -> {
+            if (res.failed()) {
+              LOG.error("Reporting failure, failed", res.cause());
+            }
+          });
+    }
+  }
+
+  private void handleResponse(final HttpClientResponse response) {
+    responseHandled.set(true);
+    logResponse(response);
+    response.bodyHandler(
+        body ->
+            vertx.executeBlocking(
+                future ->
+                    bodyHandler.handleResponse(
+                        response.headers(),
+                        response.statusCode(),
+                        body.toString(StandardCharsets.UTF_8)),
+                false,
+                res -> {
+                  if (res.failed()) {
+                    final Throwable t = res.cause();
+                    LOG.error("An unhandled error occurred while processing a response", t);
+                    bodyHandler.handleFailure(t);
+                  }
+                }));
+  }
+
+  private void logResponse(final HttpClientResponse response) {
+    LOG.debug("Response status: {}", response.statusCode());
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/VertxRequestTransmitterFactory.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/VertxRequestTransmitterFactory.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service;
+
+@FunctionalInterface
+public interface VertxRequestTransmitterFactory {
+
+  VertxRequestTransmitter create(DownstreamResponseHandler downstreamResponseHandler);
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/jsonrpc/JsonRpcRequest.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/jsonrpc/JsonRpcRequest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service.jsonrpc;
+
+import tech.pegasys.web3signer.core.service.jsonrpc.exceptions.InvalidJsonRpcRequestException;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+@JsonPropertyOrder({"jsonrpc", "method", "params", "id"})
+public class JsonRpcRequest {
+
+  private final String method;
+  private final String version;
+  private JsonRpcRequestId id;
+  private Object params;
+
+  @JsonCreator
+  public JsonRpcRequest(
+      @JsonProperty("jsonrpc") final String version, @JsonProperty("method") final String method) {
+    this.version = version;
+    this.method = method;
+    if (method == null) {
+      throw new InvalidJsonRpcRequestException("Field 'method' is required");
+    }
+  }
+
+  @JsonGetter("id")
+  public JsonRpcRequestId getId() {
+    return id;
+  }
+
+  @JsonGetter("method")
+  public String getMethod() {
+    return method;
+  }
+
+  @JsonGetter("jsonrpc")
+  public String getVersion() {
+    return version;
+  }
+
+  @JsonInclude(Include.NON_NULL)
+  @JsonGetter("params")
+  public Object getParams() {
+    return params;
+  }
+
+  @JsonSetter("id")
+  public void setId(final JsonRpcRequestId id) {
+    this.id = id;
+  }
+
+  @JsonSetter("params")
+  public void setParams(final Object params) {
+    this.params = params;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final JsonRpcRequest that = (JsonRpcRequest) o;
+    return Objects.equals(method, that.method)
+        && Objects.equals(version, that.version)
+        && Objects.equals(id, that.id)
+        && Objects.equals(params, that.params);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(method, version, id, params);
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/jsonrpc/JsonRpcRequestHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/jsonrpc/JsonRpcRequestHandler.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service.jsonrpc;
+
+import io.vertx.ext.web.RoutingContext;
+
+public interface JsonRpcRequestHandler {
+
+  void handle(RoutingContext context, JsonRpcRequest rpcRequest);
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/jsonrpc/JsonRpcRequestId.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/jsonrpc/JsonRpcRequestId.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service.jsonrpc;
+
+import tech.pegasys.web3signer.core.service.jsonrpc.exceptions.InvalidJsonRpcRequestException;
+
+import java.math.BigInteger;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class JsonRpcRequestId {
+
+  private static final Class<?>[] VALID_ID_TYPES =
+      new Class<?>[] {
+        String.class, Integer.class, Long.class, Float.class, Double.class, BigInteger.class
+      };
+
+  private final Object id;
+
+  @JsonCreator
+  public JsonRpcRequestId(final Object id) {
+    if (isRequestTypeInvalid(id)) {
+      throw new InvalidJsonRpcRequestException("Invalid id");
+    }
+    this.id = id;
+  }
+
+  @JsonValue
+  public Object getValue() {
+    return id;
+  }
+
+  private boolean isRequestTypeInvalid(final Object id) {
+    return isNotNull(id) && isTypeInvalid(id);
+  }
+
+  /**
+   * The JSON spec says "The use of Null as a value for the id member in a Request object is
+   * discouraged" Both geth and parity accept null values, so we decided to support them as well.
+   */
+  private boolean isNotNull(final Object id) {
+    return id != null;
+  }
+
+  private boolean isTypeInvalid(final Object id) {
+    for (final Class<?> validType : VALID_ID_TYPES) {
+      if (validType.isInstance(id)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final JsonRpcRequestId that = (JsonRpcRequestId) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+
+  @Override
+  public String toString() {
+    return "JsonRpcRequestId{" + "id=" + id + '}';
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/jsonrpc/exceptions/InvalidJsonRpcRequestException.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/jsonrpc/exceptions/InvalidJsonRpcRequestException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service.jsonrpc.exceptions;
+
+public class InvalidJsonRpcRequestException extends IllegalArgumentException {
+
+  public InvalidJsonRpcRequestException(final String message) {
+    super(message);
+  }
+
+  public InvalidJsonRpcRequestException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/util/RequiredOptionsUtil.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/util/RequiredOptionsUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.util;
+
+import tech.pegasys.web3signer.core.InitializationException;
+import tech.pegasys.web3signer.core.annotations.RequiredOption;
+import tech.pegasys.web3signer.core.config.InvalidCommandLineOptionsException;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import picocli.CommandLine;
+
+public class RequiredOptionsUtil {
+  public static void checkIfRequiredOptionsAreInitialized(final Object... objects) {
+    final Set<String> missingOptions = new LinkedHashSet<>();
+
+    for (Object object : objects) {
+      for (Field field : getAllFields(object.getClass())) {
+        field.setAccessible(true);
+        if (field.isAnnotationPresent(RequiredOption.class)
+            && field.isAnnotationPresent(CommandLine.Option.class)) {
+          final Object value;
+          try {
+            value = field.get(object);
+          } catch (final IllegalAccessException e) {
+            throw new InitializationException("Error parsing options: " + e.getMessage(), e);
+          }
+          if (value == null) {
+            final CommandLine.Option optionAnnotation =
+                field.getDeclaredAnnotation(CommandLine.Option.class);
+            final String[] names = optionAnnotation.names();
+            missingOptions.add(longestName(names));
+          }
+        }
+      }
+    }
+
+    if (!missingOptions.isEmpty()) {
+      throw new InvalidCommandLineOptionsException(
+          "Missing required option(s): " + String.join(",", missingOptions));
+    }
+  }
+
+  static List<Field> getAllFields(final Class<?> clazz) {
+    final List<Field> allFields = new ArrayList<>();
+    Class<?> currentClass = clazz;
+    while (currentClass != null) {
+      allFields.addAll(Arrays.asList(currentClass.getDeclaredFields()));
+      currentClass = currentClass.getSuperclass();
+    }
+    return allFields;
+  }
+
+  static String longestName(final String[] names) {
+    final String[] namesCopy = Arrays.copyOf(names, names.length);
+    Arrays.sort(namesCopy, Comparator.comparingInt(String::length).reversed());
+    return namesCopy[0];
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
This is the first part of adding an RPC proxy to Web3Signer for the execution client RPCs. It adds the base functionality of http proxy in eth1 mode disabled by default behind a feature toggle. It does not include integration and acceptance tests. This will be added in a subsequent PR.

The RPC proxy will proxy any unmatched RPC requests to a downstream execution client. By having the proxy it means that all RPC requests can go through web3signer with web3signer providing additional RPCs for eth_sendtransaction and eth_accounts (not part of this PR).

It is disabled by default behind a feature flag --downstream-http-proxy-enabled.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
