### PR TITLE
Only proxy RPC requests

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfiguration.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfiguration.java
@@ -69,7 +69,6 @@ public class SignerConfiguration {
   private final Optional<String> network;
   private final boolean keyManagerApiEnabled;
   private Optional<WatermarkRepairParameters> watermarkRepairParameters;
-  private boolean downstreamHttpProxyEnabled;
   private int downstreamHttpPort;
   private Optional<ClientTlsOptions> downstreamTlsOptions;
   private final Duration startupTimeout;
@@ -113,7 +112,6 @@ public class SignerConfiguration {
       final Optional<String> network,
       final boolean keyManagerApiEnabled,
       final Optional<WatermarkRepairParameters> watermarkRepairParameters,
-      final boolean downstreamHttpProxyEnabled,
       final int downstreamHttpPort,
       final Optional<ClientTlsOptions> downstreamTlsOptions) {
     this.hostname = hostname;
@@ -154,7 +152,6 @@ public class SignerConfiguration {
     this.network = network;
     this.keyManagerApiEnabled = keyManagerApiEnabled;
     this.watermarkRepairParameters = watermarkRepairParameters;
-    this.downstreamHttpProxyEnabled = downstreamHttpProxyEnabled;
     this.downstreamHttpPort = downstreamHttpPort;
     this.downstreamTlsOptions = downstreamTlsOptions;
   }
@@ -317,10 +314,6 @@ public class SignerConfiguration {
 
   public Optional<WatermarkRepairParameters> getWatermarkRepairParameters() {
     return watermarkRepairParameters;
-  }
-
-  public boolean isDownstreamHttpProxyEnabled() {
-    return downstreamHttpProxyEnabled;
   }
 
   public int getDownstreamHttpPort() {

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfigurationBuilder.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfigurationBuilder.java
@@ -72,7 +72,6 @@ public class SignerConfigurationBuilder {
   private boolean keyManagerApiEnabled = false;
   private KeystoresParameters keystoresParameters;
   private WatermarkRepairParameters watermarkRepairParameters;
-  private boolean downstreamHttpProxyEnabled;
   private int downstreamHttpPort;
   private ClientTlsOptions downstreamTlsOptions;
 
@@ -279,12 +278,6 @@ public class SignerConfigurationBuilder {
     return this;
   }
 
-  public SignerConfigurationBuilder withDownstreamHttpProxyEnabled(
-      final boolean downstreamHttpProxyEnabled) {
-    this.downstreamHttpProxyEnabled = downstreamHttpProxyEnabled;
-    return this;
-  }
-
   public SignerConfigurationBuilder withDownstreamHttpPort(final int downstreamHttpPort) {
     this.downstreamHttpPort = downstreamHttpPort;
     return this;
@@ -339,7 +332,6 @@ public class SignerConfigurationBuilder {
         Optional.ofNullable(network),
         keyManagerApiEnabled,
         Optional.ofNullable(watermarkRepairParameters),
-        downstreamHttpProxyEnabled,
         downstreamHttpPort,
         Optional.ofNullable(downstreamTlsOptions));
   }

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
@@ -175,11 +175,6 @@ public class CmdLineParamsConfigFileImpl implements CmdLineParamsBuilder {
     } else if (signerConfig.getMode().equals("eth1")) {
       yamlConfig.append(
           String.format(
-              YAML_BOOLEAN_FMT,
-              "eth1.downstream-http-proxy-enabled",
-              signerConfig.isDownstreamHttpProxyEnabled()));
-      yamlConfig.append(
-          String.format(
               YAML_NUMERIC_FMT, "eth1.downstream-http-port", signerConfig.getDownstreamHttpPort()));
       yamlConfig.append(createDownstreamTlsArgs());
     }

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
@@ -138,8 +138,6 @@ public class CmdLineParamsDefaultImpl implements CmdLineParamsBuilder {
           .getAwsSecretsManagerParameters()
           .ifPresent(awsParams -> params.addAll(awsBulkLoadingOptions(awsParams)));
     } else if (signerConfig.getMode().equals("eth1")) {
-      params.add("--downstream-http-proxy-enabled");
-      params.add(Boolean.toString(signerConfig.isDownstreamHttpProxyEnabled()));
       params.add("--downstream-http-port");
       params.add(Integer.toString(signerConfig.getDownstreamHttpPort()));
       params.addAll(createDownstreamTlsArgs());

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/eth1rpc/EthRpcDownstreamTlsAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/eth1rpc/EthRpcDownstreamTlsAcceptanceTest.java
@@ -66,8 +66,7 @@ class EthRpcDownstreamTlsAcceptanceTest extends Eth1RpcAcceptanceTestBase {
         Files.writeString(workDir.resolve("clientKeystorePassword"), presentedCert.getPassword());
 
     final Path fingerPrintFilePath = workDir.resolve("known_servers");
-    final SignerConfigurationBuilder builder =
-        new SignerConfigurationBuilder().withMode("eth1").withDownstreamHttpProxyEnabled(true);
+    final SignerConfigurationBuilder builder = new SignerConfigurationBuilder().withMode("eth1");
     final Optional<Integer> downstreamWeb3ServerPort =
         Optional.of(Integers.valueOf(downstreamWeb3Port));
 

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/eth1rpc/PassThroughAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/eth1rpc/PassThroughAcceptanceTest.java
@@ -35,7 +35,6 @@ public class PassThroughAcceptanceTest extends Eth1RpcAcceptanceTestBase {
         new SignerConfigurationBuilder()
             .withKeyStoreDirectory(testDirectory)
             .withMode("eth1")
-            .withDownstreamHttpProxyEnabled(true)
             .withDownstreamHttpPort(besu.ports().getHttpRpc())
             .build();
     startSigner(web3SignerConfiguration);

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth1SubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth1SubCommand.java
@@ -12,7 +12,6 @@
  */
 package tech.pegasys.web3signer.commandline.subcommands;
 
-import static tech.pegasys.web3signer.commandline.DefaultCommandValues.BOOL_FORMAT_HELP;
 import static tech.pegasys.web3signer.commandline.DefaultCommandValues.HOST_FORMAT_HELP;
 import static tech.pegasys.web3signer.commandline.DefaultCommandValues.LONG_FORMAT_HELP;
 import static tech.pegasys.web3signer.commandline.DefaultCommandValues.PATH_FORMAT_HELP;
@@ -44,15 +43,6 @@ public class Eth1SubCommand extends ModeSubCommand implements Eth1Config {
   public static final String COMMAND_NAME = "eth1";
 
   @CommandLine.Spec private CommandLine.Model.CommandSpec spec; // injected by picocli
-
-  @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
-  @CommandLine.Option(
-      names = "--downstream-http-proxy-enabled",
-      description =
-          "Enable http downstream proxying of requests to the web3provider (default: ${DEFAULT-VALUE})",
-      paramLabel = BOOL_FORMAT_HELP,
-      arity = "1")
-  private Boolean downstreamHttpProxyEnabled = false;
 
   @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
   @CommandLine.Option(
@@ -151,11 +141,6 @@ public class Eth1SubCommand extends ModeSubCommand implements Eth1Config {
   @Override
   protected void validateArgs() {
     checkIfRequiredOptionsAreInitialized(this);
-  }
-
-  @Override
-  public Boolean getDownstreamHttpProxyEnabled() {
-    return downstreamHttpProxyEnabled;
   }
 
   @Override

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -67,6 +67,7 @@ dependencies {
   integrationTestImplementation 'org.apache.logging.log4j:log4j-core'
   integrationTestImplementation 'org.assertj:assertj-core'
   integrationTestImplementation 'org.junit.jupiter:junit-jupiter-api'
+  integrationTestImplementation 'org.junit.jupiter:junit-jupiter-params'
   integrationTestImplementation 'org.mockito:mockito-junit-jupiter'
   integrationTestImplementation sourceSets.testFixtures.output
   integrationTestImplementation 'io.rest-assured:rest-assured'

--- a/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/IntegrationTestBase.java
+++ b/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/IntegrationTestBase.java
@@ -25,6 +25,7 @@ import static org.web3j.utils.Async.defaultExecutorService;
 import tech.pegasys.web3signer.core.Eth1Runner;
 import tech.pegasys.web3signer.core.config.BaseConfig;
 import tech.pegasys.web3signer.core.config.Eth1Config;
+import tech.pegasys.web3signer.core.jsonrpcproxy.model.HttpMethod;
 import tech.pegasys.web3signer.core.jsonrpcproxy.model.request.EthNodeRequest;
 import tech.pegasys.web3signer.core.jsonrpcproxy.model.request.EthRequestFactory;
 import tech.pegasys.web3signer.core.jsonrpcproxy.model.request.Web3SignerRequest;
@@ -251,6 +252,21 @@ public class IntegrationTestBase {
             .body(request.getBody())
             .headers(RestAssuredConverter.headers(request.getHeaders()))
             .delete(path);
+    verifyResponseMatchesExpected(response, expectResponse);
+  }
+
+  void sendRequestAndVerifyResponse(
+      final HttpMethod httpMethod,
+      final Web3SignerRequest request,
+      final Web3SignerResponse expectResponse,
+      final String path) {
+    final Response response =
+        given()
+            .when()
+            .body(request.getBody())
+            .headers(RestAssuredConverter.headers(request.getHeaders()))
+            .request(httpMethod.name(), path);
+
     verifyResponseMatchesExpected(response, expectResponse);
   }
 

--- a/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/model/HttpMethod.java
+++ b/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/model/HttpMethod.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.jsonrpcproxy.model;
+
+public enum HttpMethod {
+  POST,
+  GET,
+  PUT,
+  DELETE
+}

--- a/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/support/TestEth1Config.java
+++ b/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/support/TestEth1Config.java
@@ -36,11 +36,6 @@ public class TestEth1Config implements Eth1Config {
   }
 
   @Override
-  public Boolean getDownstreamHttpProxyEnabled() {
-    return true;
-  }
-
-  @Override
   public String getDownstreamHttpHost() {
     return downstreamHttpHost;
   }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -103,40 +103,38 @@ public class Eth1Runner extends Runner {
 
     final Router router = context.getRouterBuilder().createRouter();
 
-    if (eth1Config.getDownstreamHttpProxyEnabled()) {
-      final DownstreamPathCalculator downstreamPathCalculator =
-          new DownstreamPathCalculator(eth1Config.getDownstreamHttpPath());
+    final DownstreamPathCalculator downstreamPathCalculator =
+        new DownstreamPathCalculator(eth1Config.getDownstreamHttpPath());
 
-      final WebClientOptions webClientOptions =
-          new WebClientOptionsFactory().createWebClientOptions(eth1Config);
-      final HttpClient downStreamConnection = context.getVertx().createHttpClient(webClientOptions);
+    final WebClientOptions webClientOptions =
+        new WebClientOptionsFactory().createWebClientOptions(eth1Config);
+    final HttpClient downStreamConnection = context.getVertx().createHttpClient(webClientOptions);
 
-      final VertxRequestTransmitterFactory transmitterFactory =
-          responseBodyHandler ->
-              new VertxRequestTransmitter(
-                  context.getVertx(),
-                  downStreamConnection,
-                  eth1Config.getDownstreamHttpRequestTimeout(),
-                  downstreamPathCalculator,
-                  responseBodyHandler);
+    final VertxRequestTransmitterFactory transmitterFactory =
+        responseBodyHandler ->
+            new VertxRequestTransmitter(
+                context.getVertx(),
+                downStreamConnection,
+                eth1Config.getDownstreamHttpRequestTimeout(),
+                downstreamPathCalculator,
+                responseBodyHandler);
 
-      final JsonDecoder jsonDecoder = createJsonDecoder();
-      final PassThroughHandler passThroughHandler =
-          new PassThroughHandler(transmitterFactory, jsonDecoder);
+    final JsonDecoder jsonDecoder = createJsonDecoder();
+    final PassThroughHandler passThroughHandler =
+        new PassThroughHandler(transmitterFactory, jsonDecoder);
 
-      final RequestMapper requestMapper =
-          createRequestMapper(transmitterFactory, signerProvider, jsonDecoder);
+    final RequestMapper requestMapper =
+        createRequestMapper(transmitterFactory, signerProvider, jsonDecoder);
 
-      router
-          .route(HttpMethod.POST, "/")
-          .produces(JSON)
-          .handler(ResponseContentTypeHandler.create())
-          .handler(BodyHandler.create())
-          .failureHandler(new JsonRpcErrorHandler(new HttpResponseFactory()))
-          .blockingHandler(new JsonRpcHandler(responseFactory, requestMapper, jsonDecoder), false);
+    router
+        .route(HttpMethod.POST, "/")
+        .produces(JSON)
+        .handler(ResponseContentTypeHandler.create())
+        .handler(BodyHandler.create())
+        .failureHandler(new JsonRpcErrorHandler(new HttpResponseFactory()))
+        .blockingHandler(new JsonRpcHandler(responseFactory, requestMapper, jsonDecoder), false);
 
-      router.route().handler(BodyHandler.create()).handler(passThroughHandler);
-    }
+    router.route().handler(BodyHandler.create()).handler(passThroughHandler);
 
     return router;
   }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -64,7 +64,7 @@ import io.vertx.ext.web.openapi.RouterBuilder;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 public class Eth1Runner extends Runner {
-  private Eth1Config eth1Config;
+  private final Eth1Config eth1Config;
   private static final String JSON = HttpHeaderValues.APPLICATION_JSON.toString();
   private final HttpResponseFactory responseFactory = new HttpResponseFactory();
 
@@ -121,9 +121,11 @@ public class Eth1Runner extends Runner {
                   responseBodyHandler);
 
       final JsonDecoder jsonDecoder = createJsonDecoder();
-      final PassThroughHandler passThroughHandler = new PassThroughHandler(transmitterFactory);
+      final PassThroughHandler passThroughHandler =
+          new PassThroughHandler(transmitterFactory, jsonDecoder);
 
-      final RequestMapper requestMapper = createRequestMapper(transmitterFactory, signerProvider);
+      final RequestMapper requestMapper =
+          createRequestMapper(transmitterFactory, signerProvider, jsonDecoder);
 
       router
           .route(HttpMethod.POST, "/")
@@ -188,8 +190,10 @@ public class Eth1Runner extends Runner {
 
   private RequestMapper createRequestMapper(
       final VertxRequestTransmitterFactory transmitterFactory,
-      ArtifactSignerProvider signerProvider) {
-    final PassThroughHandler defaultHandler = new PassThroughHandler(transmitterFactory);
+      final ArtifactSignerProvider signerProvider,
+      final JsonDecoder jsonDecoder) {
+    final PassThroughHandler defaultHandler =
+        new PassThroughHandler(transmitterFactory, jsonDecoder);
 
     final RequestMapper requestMapper = new RequestMapper(defaultHandler);
     requestMapper.addHandler(

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/Eth1Config.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/Eth1Config.java
@@ -19,8 +19,6 @@ import java.util.Optional;
 
 public interface Eth1Config {
 
-  Boolean getDownstreamHttpProxyEnabled();
-
   String getDownstreamHttpHost();
 
   Integer getDownstreamHttpPort();

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/jsonrpc/handlers/PassThroughHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/jsonrpc/handlers/PassThroughHandler.java
@@ -52,7 +52,7 @@ public class PassThroughHandler implements JsonRpcRequestHandler, Handler<Routin
       return;
     }
 
-    logRequest(context.request(), context.getBodyAsString());
+    logRequest(context.request(), context.body().asString());
     final VertxRequestTransmitter transmitter =
         transmitterFactory.create(new ForwardedMessageResponder(context));
 
@@ -66,7 +66,7 @@ public class PassThroughHandler implements JsonRpcRequestHandler, Handler<Routin
     final HttpMethod method = context.request().method();
     try {
       final JsonRpcRequest request =
-          jsonDecoder.decodeValue(context.getBody(), JsonRpcRequest.class);
+          jsonDecoder.decodeValue(context.body().buffer(), JsonRpcRequest.class);
       return method.equals(HttpMethod.POST) && request.getVersion().equals("2.0");
     } catch (Exception e) {
       return false;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Ensures the Eth 1 proxy functionality only applies to RPC requests. Any unhandled rest/json requests will not be proxied to the downstream provider.

Also removed the --downstream-http-proxy-enabled flag now this restricted to RPCs.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
part of #763 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
