### PR TITLE
Experimental flag to disable parallel processing of keystore config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 
 ### Bugs Fixed
 - Upgrade jackson and vertx to upgrade snakeyaml to 2.0 to fix CVE-2022-1471
-- Fixed handling of very large number of signing metadata files with Hashicorp connection (30000+). [#736](https://github.com/ConsenSys/web3signer/issues/736)
+- Fixed handling of very large number (30,000+) of signing metadata files with Hashicorp connection by introducing 
+experimental flag to disable parallel processing `--Xmetadata-files-parallel-processing-enabled`. 
+[#794](https://github.com/ConsenSys/web3signer/pull/794)
 - Fixed startup error with web3signer where openAPI spec cannot be loaded [#772](https://github.com/ConsenSys/web3signer/issues/772)
 
 ---

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
@@ -191,6 +191,14 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
       description = "Enable access logs (default: ${DEFAULT-VALUE})")
   private final Boolean accessLogsEnabled = false;
 
+  @Option(
+      names = "--Xmetadata-files-parallel-processing-enabled",
+      description = "Set to false to disable parallel processing of metadata config files.",
+      paramLabel = "<BOOL>",
+      arity = "1",
+      hidden = true)
+  private boolean metadataFilesParallelProcessingEnabled = true;
+
   @CommandLine.Mixin private PicoCliTlsServerOptions picoCliTlsServerOptions;
 
   @Override
@@ -280,6 +288,11 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
   @Override
   public Boolean isAccessLogsEnabled() {
     return accessLogsEnabled;
+  }
+
+  @Override
+  public boolean metadataFilesParallelProcessingEnabled() {
+    return metadataFilesParallelProcessingEnabled;
   }
 
   @Override

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
@@ -192,12 +192,12 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
   private final Boolean accessLogsEnabled = false;
 
   @Option(
-      names = "--Xmetadata-files-parallel-processing-enabled",
-      description = "Set to false to disable parallel processing of metadata config files.",
+      names = "--Xkey-store-parallel-processing-enabled",
+      description = "Set to false to disable parallel processing of key stores.",
       paramLabel = "<BOOL>",
       arity = "1",
       hidden = true)
-  private boolean metadataFilesParallelProcessingEnabled = true;
+  private boolean keystoreParallelProcessingEnabled = true;
 
   @CommandLine.Mixin private PicoCliTlsServerOptions picoCliTlsServerOptions;
 
@@ -291,8 +291,8 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
   }
 
   @Override
-  public boolean metadataFilesParallelProcessingEnabled() {
-    return metadataFilesParallelProcessingEnabled;
+  public boolean keystoreParallelProcessingEnabled() {
+    return keystoreParallelProcessingEnabled;
   }
 
   @Override

--- a/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/support/TestBaseConfig.java
+++ b/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/support/TestBaseConfig.java
@@ -125,4 +125,9 @@ public class TestBaseConfig implements BaseConfig {
   public Boolean isAccessLogsEnabled() {
     return false;
   }
+
+  @Override
+  public boolean metadataFilesParallelProcessingEnabled() {
+    return true;
+  }
 }

--- a/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/support/TestBaseConfig.java
+++ b/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/support/TestBaseConfig.java
@@ -127,7 +127,7 @@ public class TestBaseConfig implements BaseConfig {
   }
 
   @Override
-  public boolean metadataFilesParallelProcessingEnabled() {
+  public boolean keystoreParallelProcessingEnabled() {
     return true;
   }
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -148,7 +148,7 @@ public class Eth1Runner extends Runner {
                     EthSecpArtifactSigner::new,
                     true);
 
-            return new SignerLoader(baseConfig.metadataFilesParallelProcessingEnabled())
+            return new SignerLoader(baseConfig.keystoreParallelProcessingEnabled())
                 .load(
                     baseConfig.getKeyConfigPath(),
                     "yaml",

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -148,7 +148,7 @@ public class Eth1Runner extends Runner {
                     EthSecpArtifactSigner::new,
                     true);
 
-            return new SignerLoader()
+            return new SignerLoader(baseConfig.metadataFilesParallelProcessingEnabled())
                 .load(
                     baseConfig.getKeyConfigPath(),
                     "yaml",

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -259,7 +259,7 @@ public class Eth2Runner extends Runner {
                         new BlsArtifactSigner(args.getKeyPair(), args.getOrigin(), args.getPath()));
 
             final MappedResults<ArtifactSigner> results =
-                new SignerLoader()
+                new SignerLoader(baseConfig.metadataFilesParallelProcessingEnabled())
                     .load(
                         baseConfig.getKeyConfigPath(),
                         "yaml",

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -259,7 +259,7 @@ public class Eth2Runner extends Runner {
                         new BlsArtifactSigner(args.getKeyPair(), args.getOrigin(), args.getPath()));
 
             final MappedResults<ArtifactSigner> results =
-                new SignerLoader(baseConfig.metadataFilesParallelProcessingEnabled())
+                new SignerLoader(baseConfig.keystoreParallelProcessingEnabled())
                     .load(
                         baseConfig.getKeyConfigPath(),
                         "yaml",

--- a/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
@@ -132,7 +132,7 @@ public class FilecoinRunner extends Runner {
                     signer -> new FcSecpArtifactSigner(signer, network),
                     false);
 
-            return new SignerLoader()
+            return new SignerLoader(baseConfig.metadataFilesParallelProcessingEnabled())
                 .load(
                     baseConfig.getKeyConfigPath(),
                     "yaml",

--- a/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
@@ -132,7 +132,7 @@ public class FilecoinRunner extends Runner {
                     signer -> new FcSecpArtifactSigner(signer, network),
                     false);
 
-            return new SignerLoader(baseConfig.metadataFilesParallelProcessingEnabled())
+            return new SignerLoader(baseConfig.keystoreParallelProcessingEnabled())
                 .load(
                     baseConfig.getKeyConfigPath(),
                     "yaml",

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/BaseConfig.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/BaseConfig.java
@@ -59,5 +59,5 @@ public interface BaseConfig {
 
   Boolean isAccessLogsEnabled();
 
-  boolean metadataFilesParallelProcessingEnabled();
+  boolean keystoreParallelProcessingEnabled();
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/BaseConfig.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/BaseConfig.java
@@ -58,4 +58,6 @@ public interface BaseConfig {
   Boolean isSwaggerUIEnabled();
 
   Boolean isAccessLogsEnabled();
+
+  boolean metadataFilesParallelProcessingEnabled();
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Process metadata files in parallel. Use experimental flag `--Xmetadata-files-parallel-processing-enabled` to disable parallel processing of keystore config files which would solve corner case of hashicorp with 30000+ connections.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #786 
fixes #736

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
