### PR TITLE
Optimize pruning connection creation

### DIFF
--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningIntegrationTest.java
@@ -49,7 +49,7 @@ public class PruningIntegrationTest extends IntegrationTestBase {
     final SlashingProtectionContext slashingProtectionContext =
         SlashingProtectionContextFactory.create(
             new TestSlashingProtectionParameters(
-                databaseUrl, USERNAME, PASSWORD, amountToKeep, slotsPerEpoch));
+                databaseUrl, USERNAME, PASSWORD, amountToKeep, slotsPerEpoch, true));
     final int size = 10;
     insertValidatorAndCreateSlashingData(
         slashingProtectionContext.getRegisteredValidators(), size, size, 1);
@@ -82,7 +82,7 @@ public class PruningIntegrationTest extends IntegrationTestBase {
   void dataUnchangedForNonRegisteredValidators() {
     final SlashingProtectionContext slashingProtectionContext =
         SlashingProtectionContextFactory.create(
-            new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 1, 1));
+            new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 1, 1, true));
     jdbi.withHandle(h -> validators.registerValidators(h, List.of(Bytes.of(1))));
     createSlashingData(2, 2, 1);
     insertValidatorAndCreateSlashingData(
@@ -101,7 +101,7 @@ public class PruningIntegrationTest extends IntegrationTestBase {
   void watermarkIsNotMovedLower() {
     final SlashingProtectionContext slashingProtectionContext =
         SlashingProtectionContextFactory.create(
-            new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 5, 1));
+            new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 5, 1, true));
     insertValidatorAndCreateSlashingData(
         slashingProtectionContext.getRegisteredValidators(), 10, 10, 1);
     jdbi.useTransaction(
@@ -121,7 +121,7 @@ public class PruningIntegrationTest extends IntegrationTestBase {
   void noPruningOccursWhenThereIsNoWatermark() {
     final SlashingProtectionContext slashingProtectionContext =
         SlashingProtectionContextFactory.create(
-            new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 1, 1));
+            new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 1, 1, true));
     slashingProtectionContext.getRegisteredValidators().registerValidators(List.of(Bytes.of(1)));
     for (int i = 0; i < 5; i++) {
       insertBlockAt(UInt64.valueOf(i), 1);
@@ -139,7 +139,7 @@ public class PruningIntegrationTest extends IntegrationTestBase {
   void prunesForDataWithGaps() {
     final SlashingProtectionContext slashingProtectionContext =
         SlashingProtectionContextFactory.create(
-            new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 5, 1));
+            new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 5, 1, true));
     slashingProtectionContext.getRegisteredValidators().registerValidators(List.of(Bytes.of(1)));
 
     for (int i = 0; i < 2; i++) {
@@ -169,7 +169,7 @@ public class PruningIntegrationTest extends IntegrationTestBase {
   void prunesForDataWithGapsAndDoesNotDeleteAllData() {
     final SlashingProtectionContext slashingProtectionContext =
         SlashingProtectionContextFactory.create(
-            new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 5, 1));
+            new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 5, 1, true));
     slashingProtectionContext.getRegisteredValidators().registerValidators(List.of(Bytes.of(1)));
 
     for (int i = 0; i < 2; i++) {

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningRunnerIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningRunnerIntegrationTest.java
@@ -50,7 +50,7 @@ public class PruningRunnerIntegrationTest extends IntegrationTestBase {
   @BeforeEach
   void setupSlashingProtection() {
     slashingProtectionParameters =
-        new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 5, 1);
+        new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 5, 1, true);
     scheduledExecutorService =
         new ScheduledThreadPoolExecutor(
             1, new ThreadFactoryBuilder().setNameFormat("slashing-db-pruner" + "-%d").build());
@@ -126,7 +126,7 @@ public class PruningRunnerIntegrationTest extends IntegrationTestBase {
   @Test
   void prunesValidatorsForScheduledRunAreRunPeriodically() {
     final SlashingProtectionParameters slashingProtectionParameters =
-        new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 5, 1, 1);
+        new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 5, 1, 1, true);
     final TestSlashingProtection testSlashingProtection =
         new TestSlashingProtection(
             pruningSlashingProtectionContext.getSlashingProtection(),
@@ -155,7 +155,7 @@ public class PruningRunnerIntegrationTest extends IntegrationTestBase {
   @Test
   void prunesValidatorsForScheduledRunHandlesErrors() {
     final SlashingProtectionParameters slashingProtectionParameters =
-        new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 5, 1, 1);
+        new TestSlashingProtectionParameters(databaseUrl, USERNAME, PASSWORD, 5, 1, 1, true);
     final TestSlashingProtection testSlashingProtection =
         new TestSlashingProtection(pruningSlashingProtectionContext.getSlashingProtection());
     final DbPrunerRunner dbPrunerRunner =

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbPruner.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbPruner.java
@@ -32,13 +32,13 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 
 public class DbPruner {
-  private final Jdbi jdbi;
+  private final Optional<Jdbi> jdbi;
   private final SignedBlocksDao signedBlocksDao;
   private final SignedAttestationsDao signedAttestationsDao;
   private final LowWatermarkDao lowWatermarkDao;
 
   public DbPruner(
-      final Jdbi jdbi,
+      final Optional<Jdbi> jdbi,
       final SignedBlocksDao signedBlocksDao,
       final SignedAttestationsDao signedAttestationsDao,
       final LowWatermarkDao lowWatermarkDao) {
@@ -60,6 +60,10 @@ public class DbPruner {
   }
 
   private void pruneBlocks(final int validatorId, final long slotsToKeep) {
+
+    final Jdbi jdbi =
+        this.jdbi.orElseThrow(() -> new NullPointerException("Pruner has no connection created"));
+
     final boolean hasWatermark =
         jdbi.inTransaction(
             READ_UNCOMMITTED,
@@ -92,6 +96,9 @@ public class DbPruner {
   }
 
   private void pruneAttestations(final int validatorId, final long epochsToKeep) {
+    final Jdbi jdbi =
+        this.jdbi.orElseThrow(() -> new NullPointerException("Pruner has no connection created"));
+
     final boolean hasWatermark =
         jdbi.inTransaction(
             READ_UNCOMMITTED,

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbPruner.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbPruner.java
@@ -62,7 +62,7 @@ public class DbPruner {
   private void pruneBlocks(final int validatorId, final long slotsToKeep) {
 
     final Jdbi jdbi =
-        this.jdbi.orElseThrow(() -> new NullPointerException("Pruner has no connection created"));
+        this.jdbi.orElseThrow(() -> new IllegalStateException("Pruner has no connection created"));
 
     final boolean hasWatermark =
         jdbi.inTransaction(
@@ -97,7 +97,7 @@ public class DbPruner {
 
   private void pruneAttestations(final int validatorId, final long epochsToKeep) {
     final Jdbi jdbi =
-        this.jdbi.orElseThrow(() -> new NullPointerException("Pruner has no connection created"));
+        this.jdbi.orElseThrow(() -> new IllegalStateException("Pruner has no connection created"));
 
     final boolean hasWatermark =
         jdbi.inTransaction(

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtection.java
@@ -62,7 +62,7 @@ public class DbSlashingProtection implements SlashingProtection {
 
   public DbSlashingProtection(
       final Jdbi jdbi,
-      final Jdbi pruningJdbi,
+      final Optional<Jdbi> pruningJdbi,
       final ValidatorsDao validatorsDao,
       final SignedBlocksDao signedBlocksDao,
       final SignedAttestationsDao signedAttestationsDao,

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContext.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContext.java
@@ -12,18 +12,20 @@
  */
 package tech.pegasys.web3signer.slashingprotection;
 
+import java.util.Optional;
+
 import org.jdbi.v3.core.Jdbi;
 
 public class SlashingProtectionContext {
 
   private final Jdbi slashingProtectionJdbi;
-  private final Jdbi pruningJdbi;
+  private final Optional<Jdbi> pruningJdbi;
   private final RegisteredValidators registeredValidators;
   private final SlashingProtection slashingProtection;
 
   public SlashingProtectionContext(
       final Jdbi slashingProtectionJdbi,
-      final Jdbi pruningJdbi,
+      final Optional<Jdbi> pruningJdbi,
       final RegisteredValidators registeredValidators,
       final SlashingProtection slashingProtection) {
     this.slashingProtectionJdbi = slashingProtectionJdbi;
@@ -36,7 +38,7 @@ public class SlashingProtectionContext {
     return slashingProtectionJdbi;
   }
 
-  public Jdbi getPruningJdbi() {
+  public Optional<Jdbi> getPruningJdbi() {
     return pruningJdbi;
   }
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactory.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactory.java
@@ -21,6 +21,8 @@ import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlocksDao;
 import tech.pegasys.web3signer.slashingprotection.dao.ValidatorsDao;
 
+import java.util.Optional;
+
 import org.jdbi.v3.core.Jdbi;
 
 public class SlashingProtectionContextFactory {
@@ -37,15 +39,16 @@ public class SlashingProtectionContextFactory {
     verifyVersion(jdbi);
 
     // create separate Jdbi instance for pruning operations
-    final Jdbi pruningJdbi =
+    final Optional<Jdbi> pruningJdbi =
         slashingProtectionParameters.isPruningEnabled()
-            ? DbConnection.createPruningConnection(
-                slashingProtectionParameters.getDbUrl(),
-                slashingProtectionParameters.getDbUsername(),
-                slashingProtectionParameters.getDbPassword(),
-                slashingProtectionParameters.getPruningDbPoolConfigurationFile(),
-                slashingProtectionParameters.isDbConnectionPoolEnabled())
-            : null;
+            ? Optional.of(
+                DbConnection.createPruningConnection(
+                    slashingProtectionParameters.getDbUrl(),
+                    slashingProtectionParameters.getDbUsername(),
+                    slashingProtectionParameters.getDbPassword(),
+                    slashingProtectionParameters.getPruningDbPoolConfigurationFile(),
+                    slashingProtectionParameters.isDbConnectionPoolEnabled()))
+            : Optional.empty();
 
     final ValidatorsDao validatorsDao = new ValidatorsDao();
     final RegisteredValidators registeredValidators = new RegisteredValidators(jdbi, validatorsDao);

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactory.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactory.java
@@ -38,12 +38,14 @@ public class SlashingProtectionContextFactory {
 
     // create separate Jdbi instance for pruning operations
     final Jdbi pruningJdbi =
-        DbConnection.createPruningConnection(
-            slashingProtectionParameters.getDbUrl(),
-            slashingProtectionParameters.getDbUsername(),
-            slashingProtectionParameters.getDbPassword(),
-            slashingProtectionParameters.getPruningDbPoolConfigurationFile(),
-            slashingProtectionParameters.isDbConnectionPoolEnabled());
+        slashingProtectionParameters.isPruningEnabled()
+            ? DbConnection.createPruningConnection(
+                slashingProtectionParameters.getDbUrl(),
+                slashingProtectionParameters.getDbUsername(),
+                slashingProtectionParameters.getDbPassword(),
+                slashingProtectionParameters.getPruningDbPoolConfigurationFile(),
+                slashingProtectionParameters.isDbConnectionPoolEnabled())
+            : null;
 
     final ValidatorsDao validatorsDao = new ValidatorsDao();
     final RegisteredValidators registeredValidators = new RegisteredValidators(jdbi, validatorsDao);

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
@@ -74,13 +74,13 @@ public class DbSlashingProtectionTest {
 
   private DbSlashingProtection dbSlashingProtection;
   private Jdbi slashingJdbi;
-  private Jdbi pruningJdbi;
+  private Optional<Jdbi> pruningJdbi;
 
   @BeforeEach
   public void setup(final Jdbi jdbi) {
     DbConnection.configureJdbi(jdbi);
     slashingJdbi = spy(jdbi);
-    pruningJdbi = spy(jdbi);
+    pruningJdbi = Optional.of(spy(jdbi));
     dbSlashingProtection =
         new DbSlashingProtection(
             slashingJdbi,
@@ -161,7 +161,7 @@ public class DbSlashingProtectionTest {
     final DbSlashingProtection dbSlashingProtection =
         new DbSlashingProtection(
             jdbi,
-            jdbi,
+            Optional.of(jdbi),
             validatorsDao,
             signedBlocksDao,
             signedAttestationsDao,
@@ -332,7 +332,7 @@ public class DbSlashingProtectionTest {
     final DbSlashingProtection dbSlashingProtection =
         new DbSlashingProtection(
             jdbi,
-            jdbi,
+            Optional.of(jdbi),
             validatorsDao,
             signedBlocksDao,
             signedAttestationsDao,
@@ -582,7 +582,7 @@ public class DbSlashingProtectionTest {
   @Test
   public void pruningUseSeparateDatasource() {
     dbSlashingProtection.prune();
-    verify(pruningJdbi, atLeast(2))
+    verify(pruningJdbi.get(), atLeast(2))
         .inTransaction(eq(TransactionIsolationLevel.READ_UNCOMMITTED), any());
     verifyNoInteractions(slashingJdbi);
   }

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactoryTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactoryTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.slashingprotection;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import db.DatabaseUtil;
+import dsl.TestSlashingProtectionParameters;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.Test;
+
+class SlashingProtectionContextFactoryTest {
+
+  private static final String USERNAME = "postgres";
+  private static final String PASSWORD = "postgres";
+
+  @Test
+  public void dontCreatPruningConnectionWhenPrunningIsDisabled() {
+    final DatabaseUtil.TestDatabaseInfo testDatabaseInfo = DatabaseUtil.create();
+
+    SlashingProtectionContext factory =
+        SlashingProtectionContextFactory.create(
+            new TestSlashingProtectionParameters(
+                testDatabaseInfo.databaseUrl(), USERNAME, PASSWORD, false));
+    assertThat(factory.getPruningJdbi()).isEqualTo(null);
+  }
+
+  @Test
+  public void creatPruningConnectionWhenPrunningIsEnabled() {
+    final DatabaseUtil.TestDatabaseInfo testDatabaseInfo = DatabaseUtil.create();
+
+    SlashingProtectionContext factory =
+        SlashingProtectionContextFactory.create(
+            new TestSlashingProtectionParameters(
+                testDatabaseInfo.databaseUrl(), USERNAME, PASSWORD, true));
+    assertThat(factory.getPruningJdbi()).isInstanceOf(Jdbi.class);
+  }
+}

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactoryTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactoryTest.java
@@ -14,6 +14,8 @@ package tech.pegasys.web3signer.slashingprotection;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import java.util.Optional;
+
 import db.DatabaseUtil;
 import dsl.TestSlashingProtectionParameters;
 import org.jdbi.v3.core.Jdbi;
@@ -32,7 +34,7 @@ class SlashingProtectionContextFactoryTest {
         SlashingProtectionContextFactory.create(
             new TestSlashingProtectionParameters(
                 testDatabaseInfo.databaseUrl(), USERNAME, PASSWORD, false));
-    assertThat(factory.getPruningJdbi()).isEqualTo(null);
+    assertThat(factory.getPruningJdbi()).isEqualTo(Optional.empty());
   }
 
   @Test
@@ -43,6 +45,6 @@ class SlashingProtectionContextFactoryTest {
         SlashingProtectionContextFactory.create(
             new TestSlashingProtectionParameters(
                 testDatabaseInfo.databaseUrl(), USERNAME, PASSWORD, true));
-    assertThat(factory.getPruningJdbi()).isInstanceOf(Jdbi.class);
+    assertThat(factory.getPruningJdbi().get()).isInstanceOf(Jdbi.class);
   }
 }

--- a/slashing-protection/src/testFixtures/java/dsl/TestSlashingProtectionParameters.java
+++ b/slashing-protection/src/testFixtures/java/dsl/TestSlashingProtectionParameters.java
@@ -39,16 +39,15 @@ public class TestSlashingProtectionParameters implements SlashingProtectionParam
 
   public TestSlashingProtectionParameters(
       final String dbUrl, final String dbUser, final String dbPassword) {
-    this(dbUrl, dbUser, dbPassword, 0, 0);
+    this(dbUrl, dbUser, dbPassword, 0, 0, true);
   }
 
   public TestSlashingProtectionParameters(
       final String dbUrl,
       final String dbUser,
       final String dbPassword,
-      final int pruningEpochsToKeep,
-      final int pruningSlotsPerEpoch) {
-    this(dbUrl, dbUser, dbPassword, pruningEpochsToKeep, pruningSlotsPerEpoch, Long.MAX_VALUE);
+      final boolean pruningEnabled) {
+    this(dbUrl, dbUser, dbPassword, 0, 0, pruningEnabled);
   }
 
   public TestSlashingProtectionParameters(
@@ -57,7 +56,25 @@ public class TestSlashingProtectionParameters implements SlashingProtectionParam
       final String dbPassword,
       final int pruningEpochsToKeep,
       final int pruningSlotsPerEpoch,
-      final long pruningInterval) {
+      final boolean pruningEnabled) {
+    this(
+        dbUrl,
+        dbUser,
+        dbPassword,
+        pruningEpochsToKeep,
+        pruningSlotsPerEpoch,
+        Long.MAX_VALUE,
+        pruningEnabled);
+  }
+
+  public TestSlashingProtectionParameters(
+      final String dbUrl,
+      final String dbUser,
+      final String dbPassword,
+      final int pruningEpochsToKeep,
+      final int pruningSlotsPerEpoch,
+      final long pruningInterval,
+      final boolean pruningEnabled) {
     this(
         dbUrl,
         dbUser,
@@ -69,7 +86,8 @@ public class TestSlashingProtectionParameters implements SlashingProtectionParam
         pruningInterval,
         3000,
         3000,
-        true);
+        true,
+        pruningEnabled);
   }
 
   public TestSlashingProtectionParameters(
@@ -83,13 +101,14 @@ public class TestSlashingProtectionParameters implements SlashingProtectionParam
       final long pruningInterval,
       final int dbHealthCheckTimeoutMilliseconds,
       final int dbHealthCheckIntervalMilliseconds,
-      final boolean dbConnectionPoolEnabled) {
+      final boolean dbConnectionPoolEnabled,
+      final boolean pruningEnabled) {
     this.dbUrl = dbUrl;
     this.dbUser = dbUser;
     this.dbPassword = dbPassword;
     this.dbPoolConfigurationFile = dbPoolConfigurationFile;
     this.pruningDbPoolConfigurationFile = pruningDbPoolConfigurationFile;
-    this.pruningEnabled = true;
+    this.pruningEnabled = pruningEnabled;
     this.pruningAtBootEnabled = true;
     this.pruningEpochsToKeep = pruningEpochsToKeep;
     this.pruningSlotsPerEpoch = pruningSlotsPerEpoch;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
This PR simply adds a check to avoid creating a connection to the DB for pruning when pruning is disabled. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #672 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [ ] I thought about testing these changes in a realistic/non-local environment.
