### PR TITLE
Hashicorp connection, override http protocol version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+
+## Next release
+### Features Added
+- Hashicorp connection properties can now override http protocol to HTTP/1.1 from the default of HTTP/2. [#817](https://github.com/ConsenSys/web3signer/pull/817)
+
+### Bugs fixed
+
+---
 ## 23.6.0
 
 As part of our ongoing commitment to deliver the best remote signing solutions, we are announcing a change in our product offerings.

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/MetadataFileHelpers.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/utils/MetadataFileHelpers.java
@@ -107,7 +107,9 @@ public class MetadataFileHelpers {
   }
 
   public void createHashicorpYamlFileAt(
-      final Path metadataFilePath, final HashicorpSigningParams node) {
+      final Path metadataFilePath,
+      final HashicorpSigningParams node,
+      Optional<String> httpProtocolVersion) {
     try {
       final Map<String, String> signingMetadata = new HashMap<>();
 
@@ -130,6 +132,8 @@ public class MetadataFileHelpers {
       signingMetadata.put("keyName", node.getSecretName());
       signingMetadata.put("token", node.getVaultToken());
       signingMetadata.put("keyType", node.getKeyType().toString());
+
+      httpProtocolVersion.ifPresent(version -> signingMetadata.put("httpProtocolVersion", version));
 
       createYamlFile(metadataFilePath, signingMetadata);
     } catch (final Exception e) {

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/keystorage/HashicorpVaultAccessAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/keystorage/HashicorpVaultAccessAcceptanceTest.java
@@ -64,11 +64,11 @@ public class HashicorpVaultAccessAcceptanceTest {
         Collections.singletonMap(SECRET_KEY, SECRET_VALUE), KEY_SUBPATH);
 
     final ConnectionParameters connectionParameters =
-        new ConnectionParameters(
-            hashicorpNode.getHost(),
-            Optional.of(hashicorpNode.getPort()),
-            Optional.empty(),
-            Optional.of(30_000L));
+        ConnectionParameters.newBuilder()
+            .withServerHost(hashicorpNode.getHost())
+            .withServerPort(hashicorpNode.getPort())
+            .withTimeoutMs(30_000L)
+            .build();
     final KeyDefinition key =
         new KeyDefinition(
             hashicorpNode.getHttpApiPathForSecret(KEY_SUBPATH),
@@ -97,11 +97,12 @@ public class HashicorpVaultAccessAcceptanceTest {
     final TlsOptions tlsOptions =
         new TlsOptions(Optional.of(TrustStoreType.WHITELIST), fingerprintFile, null);
     final ConnectionParameters connectionParameters =
-        new ConnectionParameters(
-            hashicorpNode.getHost(),
-            Optional.of(hashicorpNode.getPort()),
-            Optional.of(tlsOptions),
-            Optional.of(30_000L));
+        ConnectionParameters.newBuilder()
+            .withServerHost(hashicorpNode.getHost())
+            .withServerPort(hashicorpNode.getPort())
+            .withTlsOptions(tlsOptions)
+            .withTimeoutMs(30_000L)
+            .build();
     final KeyDefinition key =
         new KeyDefinition(
             hashicorpNode.getHttpApiPathForSecret(KEY_SUBPATH),
@@ -128,11 +129,12 @@ public class HashicorpVaultAccessAcceptanceTest {
     final TlsOptions tlsOptions =
         new TlsOptions(Optional.of(TrustStoreType.PKCS12), trustStorePath, TRUST_STORE_PASSWORD);
     final ConnectionParameters connectionParameters =
-        new ConnectionParameters(
-            hashicorpNode.getHost(),
-            Optional.of(hashicorpNode.getPort()),
-            Optional.of(tlsOptions),
-            Optional.of(30_000L));
+        ConnectionParameters.newBuilder()
+            .withServerHost(hashicorpNode.getHost())
+            .withServerPort(hashicorpNode.getPort())
+            .withTlsOptions(tlsOptions)
+            .withTimeoutMs(30_000L)
+            .build();
     final KeyDefinition key =
         new KeyDefinition(
             hashicorpNode.getHttpApiPathForSecret(KEY_SUBPATH),
@@ -159,11 +161,12 @@ public class HashicorpVaultAccessAcceptanceTest {
     final TlsOptions tlsOptions =
         new TlsOptions(Optional.of(TrustStoreType.JKS), trustStorePath, TRUST_STORE_PASSWORD);
     final ConnectionParameters connectionParameters =
-        new ConnectionParameters(
-            hashicorpNode.getHost(),
-            Optional.of(hashicorpNode.getPort()),
-            Optional.of(tlsOptions),
-            Optional.of(30_000L));
+        ConnectionParameters.newBuilder()
+            .withServerHost(hashicorpNode.getHost())
+            .withServerPort(hashicorpNode.getPort())
+            .withTlsOptions(tlsOptions)
+            .withTimeoutMs(30_000L)
+            .build();
     final KeyDefinition key =
         new KeyDefinition(
             hashicorpNode.getHttpApiPathForSecret(KEY_SUBPATH),
@@ -189,11 +192,12 @@ public class HashicorpVaultAccessAcceptanceTest {
     final TlsOptions tlsOptions =
         new TlsOptions(Optional.of(TrustStoreType.PEM), trustStorePath, null);
     final ConnectionParameters connectionParameters =
-        new ConnectionParameters(
-            hashicorpNode.getHost(),
-            Optional.of(hashicorpNode.getPort()),
-            Optional.of(tlsOptions),
-            Optional.of(30_000L));
+        ConnectionParameters.newBuilder()
+            .withServerHost(hashicorpNode.getHost())
+            .withServerPort(hashicorpNode.getPort())
+            .withTlsOptions(tlsOptions)
+            .withTimeoutMs(30_000L)
+            .build();
     final KeyDefinition key =
         new KeyDefinition(
             hashicorpNode.getHttpApiPathForSecret(KEY_SUBPATH),

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/SecpSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/SecpSigningAcceptanceTest.java
@@ -29,6 +29,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.security.SignatureException;
 import java.security.interfaces.ECPublicKey;
+import java.util.Optional;
 
 import com.google.common.io.Resources;
 import io.restassured.response.Response;
@@ -81,7 +82,9 @@ public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
           new HashicorpSigningParams(hashicorpNode, secretPath, secretName, KeyType.SECP256K1);
 
       METADATA_FILE_HELPERS.createHashicorpYamlFileAt(
-          testDirectory.resolve(PUBLIC_KEY_HEX_STRING + ".yaml"), hashicorpSigningParams);
+          testDirectory.resolve(PUBLIC_KEY_HEX_STRING + ".yaml"),
+          hashicorpSigningParams,
+          Optional.empty());
 
       signAndVerifySignature();
     } finally {

--- a/keystorage/src/integrationTest/java/tech/pegasys/web3signer/keystore/hashicorp/HashicorpIntegrationTest.java
+++ b/keystorage/src/integrationTest/java/tech/pegasys/web3signer/keystore/hashicorp/HashicorpIntegrationTest.java
@@ -43,7 +43,6 @@ class HashicorpIntegrationTest {
   private static final String ROOT_TOKEN = "token";
   private static final String EXPECTED_KEY_STRING =
       "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63";
-  private static final long TIMEOUT_MILLISECONDS = 10_000;
 
   private final HashicorpConnectionFactory factory = new HashicorpConnectionFactory();
 
@@ -58,11 +57,10 @@ class HashicorpIntegrationTest {
                 .withBody("{\"data\":{\"data\":{\"value\":\"" + EXPECTED_KEY_STRING + "\"}}}"));
 
     final ConnectionParameters connectionParameters =
-        new ConnectionParameters(
-            DEFAULT_HOST,
-            Optional.of(clientAndServer.getLocalPort()),
-            Optional.empty(),
-            Optional.of(TIMEOUT_MILLISECONDS));
+        ConnectionParameters.newBuilder()
+            .withServerHost(DEFAULT_HOST)
+            .withServerPort(clientAndServer.getLocalPort())
+            .build();
     final KeyDefinition key = new KeyDefinition(KEY_PATH, Optional.empty(), ROOT_TOKEN);
 
     final HashicorpConnection connection = factory.create(connectionParameters);
@@ -92,11 +90,11 @@ class HashicorpIntegrationTest {
             Path.of(keyStoreFactory.keyStoreFileName),
             KeyStoreFactory.KEY_STORE_PASSWORD);
     final ConnectionParameters connectionParameters =
-        new ConnectionParameters(
-            DEFAULT_HOST,
-            Optional.of(clientAndServer.getLocalPort()),
-            Optional.of(tlsOptions),
-            Optional.of(TIMEOUT_MILLISECONDS));
+        ConnectionParameters.newBuilder()
+            .withServerHost(DEFAULT_HOST)
+            .withServerPort(clientAndServer.getLocalPort())
+            .withTlsOptions(tlsOptions)
+            .build();
     final KeyDefinition key = new KeyDefinition(KEY_PATH, Optional.empty(), ROOT_TOKEN);
 
     final HashicorpConnection connection = factory.create(connectionParameters);
@@ -113,11 +111,11 @@ class HashicorpIntegrationTest {
         .respond(response().withDelay(TimeUnit.SECONDS, 5));
 
     final ConnectionParameters connectionParameters =
-        new ConnectionParameters(
-            DEFAULT_HOST,
-            Optional.of(clientAndServer.getLocalPort()),
-            Optional.empty(),
-            Optional.of(1L));
+        ConnectionParameters.newBuilder()
+            .withServerHost(DEFAULT_HOST)
+            .withServerPort(clientAndServer.getLocalPort())
+            .withTimeoutMs(1L)
+            .build();
     final KeyDefinition key = new KeyDefinition(KEY_PATH, Optional.empty(), ROOT_TOKEN);
 
     final HashicorpConnection connection = factory.create(connectionParameters);
@@ -132,11 +130,10 @@ class HashicorpIntegrationTest {
     clientAndServer.when(request().withPath(".*")).respond(response().withStatusCode(500));
 
     final ConnectionParameters connectionParameters =
-        new ConnectionParameters(
-            DEFAULT_HOST,
-            Optional.of(clientAndServer.getLocalPort()),
-            Optional.empty(),
-            Optional.of(TIMEOUT_MILLISECONDS));
+        ConnectionParameters.newBuilder()
+            .withServerHost(DEFAULT_HOST)
+            .withServerPort(clientAndServer.getLocalPort())
+            .build();
     final KeyDefinition key = new KeyDefinition(KEY_PATH, Optional.empty(), ROOT_TOKEN);
 
     final HashicorpConnection connection = factory.create(connectionParameters);

--- a/keystorage/src/main/java/tech/pegasys/web3signer/keystorage/hashicorp/HashicorpConnectionFactory.java
+++ b/keystorage/src/main/java/tech/pegasys/web3signer/keystorage/hashicorp/HashicorpConnectionFactory.java
@@ -52,6 +52,8 @@ public class HashicorpConnectionFactory implements AutoCloseable {
         _key -> {
           final HttpClient.Builder httpClientBuilder =
               HttpClient.newBuilder()
+                  .followRedirects(HttpClient.Redirect.NORMAL)
+                  .version(connectionParameters.getHttpProtocolVersion())
                   .connectTimeout(Duration.ofMillis(connectionParameters.getTimeoutMilliseconds()));
           try {
             if (connectionParameters.getTlsOptions().isPresent()) {

--- a/keystorage/src/test/java/tech/pegasys/web3signer/keystorage/hashicorp/HashicorpConnectionFactoryTest.java
+++ b/keystorage/src/test/java/tech/pegasys/web3signer/keystorage/hashicorp/HashicorpConnectionFactoryTest.java
@@ -46,8 +46,11 @@ public class HashicorpConnectionFactoryTest {
     final TlsOptions tlsOptions =
         new TlsOptions(Optional.of(TrustStoreType.WHITELIST), invalidWhitelist.toPath(), null);
     final ConnectionParameters params =
-        new ConnectionParameters(
-            CONFIGURED_HOST, Optional.empty(), Optional.of(tlsOptions), Optional.of(10L));
+        ConnectionParameters.newBuilder()
+            .withServerHost(CONFIGURED_HOST)
+            .withTlsOptions(tlsOptions)
+            .withTimeoutMs(10L)
+            .build();
 
     assertThatThrownBy(() -> connectionFactory.create(params))
         .isInstanceOf(HashicorpException.class);
@@ -60,8 +63,11 @@ public class HashicorpConnectionFactoryTest {
     final TlsOptions tlsOptions =
         new TlsOptions(Optional.of(TrustStoreType.WHITELIST), invalidFile, null);
     final ConnectionParameters params =
-        new ConnectionParameters(
-            CONFIGURED_HOST, Optional.empty(), Optional.of(tlsOptions), Optional.of(10L));
+        ConnectionParameters.newBuilder()
+            .withServerHost(CONFIGURED_HOST)
+            .withTlsOptions(tlsOptions)
+            .withTimeoutMs(10L)
+            .build();
 
     assertThatThrownBy(() -> connectionFactory.create(params))
         .isInstanceOf(HashicorpException.class)
@@ -75,10 +81,12 @@ public class HashicorpConnectionFactoryTest {
 
     final TlsOptions tlsOptions =
         spy(new TlsOptions(Optional.of(TrustStoreType.PKCS12), keystorePath, "password"));
-
     final ConnectionParameters params =
-        new ConnectionParameters(
-            CONFIGURED_HOST, Optional.empty(), Optional.of(tlsOptions), Optional.of(10L));
+        ConnectionParameters.newBuilder()
+            .withServerHost(CONFIGURED_HOST)
+            .withTlsOptions(tlsOptions)
+            .withTimeoutMs(10L)
+            .build();
 
     connectionFactory.create(params);
 
@@ -90,10 +98,12 @@ public class HashicorpConnectionFactoryTest {
   @Test
   void defaultPortIsUsedByConnectionParametersIfNonConfigured() {
     final ConnectionParameters params =
-        new ConnectionParameters(
-            CONFIGURED_HOST, Optional.empty(), Optional.empty(), Optional.of(10L));
+        ConnectionParameters.newBuilder()
+            .withServerHost(CONFIGURED_HOST)
+            .withTimeoutMs(10L)
+            .build();
 
-    assertThat(params.getServerPort()).isEqualTo(8200);
+    assertThat(params.getVaultURI().getPort()).isEqualTo(8200);
   }
 
   @ParameterizedTest
@@ -103,8 +113,11 @@ public class HashicorpConnectionFactoryTest {
         new TlsOptions(Optional.of(TrustStoreType.fromString(trustType).get()), null, null);
 
     final ConnectionParameters params =
-        new ConnectionParameters(
-            CONFIGURED_HOST, Optional.empty(), Optional.of(tlsOptions), Optional.of(10L));
+        ConnectionParameters.newBuilder()
+            .withServerHost(CONFIGURED_HOST)
+            .withTlsOptions(tlsOptions)
+            .withTimeoutMs(10L)
+            .build();
 
     assertThatThrownBy(() -> connectionFactory.create(params))
         .isInstanceOf(HashicorpException.class);
@@ -120,8 +133,11 @@ public class HashicorpConnectionFactoryTest {
             Optional.of(TrustStoreType.fromString(trustType).get()), tempFile.toPath(), null);
 
     final ConnectionParameters params =
-        new ConnectionParameters(
-            CONFIGURED_HOST, Optional.empty(), Optional.of(tlsOptions), Optional.of(10L));
+        ConnectionParameters.newBuilder()
+            .withServerHost(CONFIGURED_HOST)
+            .withTlsOptions(tlsOptions)
+            .withTimeoutMs(10L)
+            .build();
 
     assertThatThrownBy(() -> connectionFactory.create(params))
         .isInstanceOf(HashicorpException.class);

--- a/keystorage/src/test/java/tech/pegasys/web3signer/keystorage/hashicorp/HashicorpConnectionTest.java
+++ b/keystorage/src/test/java/tech/pegasys/web3signer/keystorage/hashicorp/HashicorpConnectionTest.java
@@ -41,8 +41,11 @@ public class HashicorpConnectionTest {
         new TlsOptions(Optional.of(TrustStoreType.JKS), tempFile.toPath(), "anyPassword");
 
     final ConnectionParameters params =
-        new ConnectionParameters(
-            CONFIGURED_HOST, Optional.empty(), Optional.of(tlsOptions), Optional.of(10L));
+        ConnectionParameters.newBuilder()
+            .withServerHost(CONFIGURED_HOST)
+            .withTlsOptions(tlsOptions)
+            .withTimeoutMs(10L)
+            .build();
 
     assertThatThrownBy(() -> connectionFactory.create(params))
         .isInstanceOf(HashicorpException.class)
@@ -62,8 +65,11 @@ public class HashicorpConnectionTest {
         new TlsOptions(Optional.of(TrustStoreType.PKCS12), keystorePath, "wrongPassword");
 
     final ConnectionParameters params =
-        new ConnectionParameters(
-            CONFIGURED_HOST, Optional.empty(), Optional.of(tlsOptions), Optional.of(10L));
+        ConnectionParameters.newBuilder()
+            .withServerHost(CONFIGURED_HOST)
+            .withTlsOptions(tlsOptions)
+            .withTimeoutMs(10L)
+            .build();
 
     assertThatThrownBy(() -> connectionFactory.create(params))
         .isInstanceOf(HashicorpException.class)

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AbstractArtifactSignerFactory.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AbstractArtifactSignerFactory.java
@@ -69,13 +69,16 @@ public abstract class AbstractArtifactSignerFactory implements ArtifactSignerFac
     final Optional<TlsOptions> tlsOptions = buildTlsOptions(metadata);
 
     try {
+      final ConnectionParameters connectionParameters =
+          ConnectionParameters.newBuilder()
+              .withServerHost(metadata.getServerHost())
+              .withServerPort(metadata.getServerPort())
+              .withTlsOptions(tlsOptions.orElse(null))
+              .withTimeoutMs(metadata.getTimeout())
+              .withHttpProtocolVersion(metadata.getHttpProtocolVersion())
+              .build();
       final HashicorpConnection connection =
-          hashicorpConnectionFactory.create(
-              new ConnectionParameters(
-                  metadata.getServerHost(),
-                  Optional.ofNullable(metadata.getServerPort()),
-                  tlsOptions,
-                  Optional.ofNullable(metadata.getTimeout())));
+          hashicorpConnectionFactory.create(connectionParameters);
 
       final String secret =
           connection.fetchKey(

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/HashicorpSigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/HashicorpSigningMetadata.java
@@ -15,6 +15,7 @@ package tech.pegasys.web3signer.signing.config.metadata;
 import tech.pegasys.web3signer.signing.ArtifactSigner;
 import tech.pegasys.web3signer.signing.KeyType;
 
+import java.net.http.HttpClient;
 import java.nio.file.Path;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -34,6 +35,7 @@ public class HashicorpSigningMetadata extends SigningMetadata {
 
   private Boolean tlsEnabled = false;
   private Path tlsKnownServerFile = null;
+  private HttpClient.Version httpProtocolVersion;
 
   @JsonCreator
   public HashicorpSigningMetadata(
@@ -72,6 +74,11 @@ public class HashicorpSigningMetadata extends SigningMetadata {
     this.tlsKnownServerFile = value;
   }
 
+  @JsonSetter("httpProtocolVersion")
+  public void setHttpProtocolVersion(final HttpClient.Version httpProtocolVersion) {
+    this.httpProtocolVersion = httpProtocolVersion;
+  }
+
   public String getServerHost() {
     return serverHost;
   }
@@ -102,6 +109,10 @@ public class HashicorpSigningMetadata extends SigningMetadata {
 
   public Path getTlsKnownServerFile() {
     return tlsKnownServerFile;
+  }
+
+  public HttpClient.Version getHttpProtocolVersion() {
+    return httpProtocolVersion;
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->
## PR Description
Hashicorp connection, override http protocol version. Hashicorp Signing Metadata file can now optionally take `httpProtocolVersion` with possible values of `HTTP_1_1` and `HTTP_2`. It defaults to `HTTP_2`. This should help in situations where vault is behind load balancer/vault agent and unable to handle Http 2 connections over h2c.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #811 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
