### PR TITLE
Optimize pruning connection creation

### DIFF
--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -377,7 +377,7 @@ public class Eth2Runner extends Runner {
     final DbPrunerRunner dbPrunerRunner =
         new DbPrunerRunner(
             slashingProtectionParameters,
-            slashingProtectionContext.get().getSlashingProtection(),
+            slashingProtectionContext.get().getPruner(),
             Executors.newScheduledThreadPool(1));
     if (slashingProtectionParameters.isPruningAtBootEnabled()) {
       dbPrunerRunner.execute();

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningIntegrationTest.java
@@ -56,7 +56,7 @@ public class PruningIntegrationTest extends IntegrationTestBase {
     final List<SignedAttestation> allAttestations = fetchAttestations(1);
     final List<SignedBlock> allBlocks = fetchBlocks(1);
 
-    slashingProtectionContext.getSlashingProtection().prune();
+    slashingProtectionContext.getPruner().prune();
 
     final List<SignedAttestation> expectedAttestations =
         allAttestations.subList(expectedLowestPopulatedEpoch, size);
@@ -88,7 +88,7 @@ public class PruningIntegrationTest extends IntegrationTestBase {
     insertValidatorAndCreateSlashingData(
         slashingProtectionContext.getRegisteredValidators(), 2, 2, 2);
 
-    slashingProtectionContext.getSlashingProtection().prune();
+    slashingProtectionContext.getPruner().prune();
 
     final List<SignedAttestation> attestationsForValidator1 = fetchAttestations(1);
     assertThat(attestationsForValidator1).hasSize(2);
@@ -109,7 +109,7 @@ public class PruningIntegrationTest extends IntegrationTestBase {
           lowWatermarkDao.updateSlotWatermarkFor(h, 1, UInt64.valueOf(8));
           lowWatermarkDao.updateEpochWatermarksFor(h, 1, UInt64.valueOf(8), UInt64.valueOf(8));
         });
-    slashingProtectionContext.getSlashingProtection().prune();
+    slashingProtectionContext.getPruner().prune();
 
     // we are only able to prune 2 entries because the watermark is at 8
     assertThat(fetchAttestations(1)).hasSize(2);
@@ -130,7 +130,7 @@ public class PruningIntegrationTest extends IntegrationTestBase {
       insertAttestationAt(UInt64.valueOf(i), UInt64.valueOf(i), 1);
     }
 
-    slashingProtectionContext.getSlashingProtection().prune();
+    slashingProtectionContext.getPruner().prune();
     assertThat(fetchAttestations(1)).hasSize(5);
     assertThat(fetchBlocks(1)).hasSize(5);
   }
@@ -156,7 +156,7 @@ public class PruningIntegrationTest extends IntegrationTestBase {
           lowWatermarkDao.updateEpochWatermarksFor(h, 1, UInt64.ZERO, UInt64.ZERO);
         });
 
-    slashingProtectionContext.getSlashingProtection().prune();
+    slashingProtectionContext.getPruner().prune();
 
     assertThat(fetchAttestations(1)).hasSize(2);
     assertThat(fetchBlocks(1)).hasSize(2);
@@ -184,7 +184,7 @@ public class PruningIntegrationTest extends IntegrationTestBase {
           lowWatermarkDao.updateEpochWatermarksFor(h, 1, UInt64.ZERO, UInt64.ZERO);
         });
 
-    slashingProtectionContext.getSlashingProtection().prune();
+    slashingProtectionContext.getPruner().prune();
 
     assertThat(fetchAttestations(1)).hasSize(1);
     assertThat(fetchBlocks(1)).hasSize(1);

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DBSlashingProtectionPruner.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DBSlashingProtectionPruner.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.slashingprotection;
+
+import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
+import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
+import tech.pegasys.web3signer.slashingprotection.dao.SignedBlocksDao;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jdbi.v3.core.Jdbi;
+
+public class DBSlashingProtectionPruner implements SlashingProtectionPruner {
+  private static final Logger LOG = LogManager.getLogger();
+  private final DbPruner dbPruner;
+
+  private final long pruningEpochsToKeep;
+  private final long pruningSlotsPerEpoch;
+  private final RegisteredValidators registeredValidators;
+
+  public DBSlashingProtectionPruner(
+      final Jdbi pruningJdbi,
+      final long pruningEpochsToKeep,
+      final long pruningSlotsPerEpoch,
+      final RegisteredValidators registeredValidators,
+      final SignedBlocksDao signedBlocksDao,
+      final SignedAttestationsDao signedAttestationsDao,
+      final LowWatermarkDao lowWatermarkDao) {
+    this.dbPruner =
+        new DbPruner(pruningJdbi, signedBlocksDao, signedAttestationsDao, lowWatermarkDao);
+    this.pruningEpochsToKeep = pruningEpochsToKeep;
+    this.pruningSlotsPerEpoch = pruningSlotsPerEpoch;
+    this.registeredValidators = registeredValidators;
+  }
+
+  @Override
+  public void prune() {
+    final Set<Integer> validatorKeys = registeredValidators.validatorIds();
+    LOG.info("Pruning slashing protection database for {} validators", validatorKeys.size());
+    final AtomicInteger pruningCount = new AtomicInteger();
+    validatorKeys.forEach(
+        v -> {
+          LOG.trace(
+              "Pruning {} of {} validator {}",
+              pruningCount::incrementAndGet,
+              validatorKeys::size,
+              () -> registeredValidators.getPublicKeyForValidatorId(v));
+          dbPruner.pruneForValidator(v, pruningEpochsToKeep, pruningSlotsPerEpoch);
+        });
+    LOG.info("Pruning slashing protection database complete");
+  }
+}

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbPrunerRunner.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbPrunerRunner.java
@@ -20,12 +20,12 @@ import org.apache.logging.log4j.Logger;
 public class DbPrunerRunner {
   private static final Logger LOG = LogManager.getLogger();
   private final SlashingProtectionParameters slashingProtectionParameters;
-  private final SlashingProtection slashingProtection;
+  private final SlashingProtectionPruner slashingProtection;
   private final ScheduledExecutorService executorService;
 
   public DbPrunerRunner(
       final SlashingProtectionParameters slashingProtectionParameters,
-      final SlashingProtection slashingProtection,
+      final SlashingProtectionPruner slashingProtection,
       final ScheduledExecutorService executorService) {
     this.slashingProtectionParameters = slashingProtectionParameters;
     this.slashingProtection = slashingProtection;

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtection.java
@@ -46,8 +46,6 @@ public interface SlashingProtection {
 
   void importDataWithFilter(InputStream output, List<String> pubkeys);
 
-  void prune();
-
   boolean isEnabledValidator(Bytes publicKey);
 
   void updateValidatorEnabledStatus(Bytes publicKey, boolean enabled);

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContext.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContext.java
@@ -12,14 +12,12 @@
  */
 package tech.pegasys.web3signer.slashingprotection;
 
-import java.util.Optional;
-
 import org.jdbi.v3.core.Jdbi;
 
 public class SlashingProtectionContext {
 
   private final Jdbi slashingProtectionJdbi;
-  private final Optional<SlashingProtectionPruner> slashingProtectionPruner;
+  private final SlashingProtectionPruner slashingProtectionPruner;
   private final RegisteredValidators registeredValidators;
   private final SlashingProtection slashingProtection;
 
@@ -27,10 +25,7 @@ public class SlashingProtectionContext {
       final Jdbi slashingProtectionJdbi,
       final RegisteredValidators registeredValidators,
       final SlashingProtection slashingProtection) {
-    this.slashingProtectionJdbi = slashingProtectionJdbi;
-    this.slashingProtectionPruner = Optional.empty();
-    this.registeredValidators = registeredValidators;
-    this.slashingProtection = slashingProtection;
+    this(slashingProtectionJdbi, null, registeredValidators, slashingProtection);
   }
 
   public SlashingProtectionContext(
@@ -39,7 +34,7 @@ public class SlashingProtectionContext {
       final RegisteredValidators registeredValidators,
       final SlashingProtection slashingProtection) {
     this.slashingProtectionJdbi = slashingProtectionJdbi;
-    this.slashingProtectionPruner = Optional.of(slashingProtectionPruner);
+    this.slashingProtectionPruner = slashingProtectionPruner;
     this.registeredValidators = registeredValidators;
     this.slashingProtection = slashingProtection;
   }
@@ -49,7 +44,7 @@ public class SlashingProtectionContext {
   }
 
   public SlashingProtectionPruner getPruner() {
-    return slashingProtectionPruner.get();
+    return slashingProtectionPruner;
   }
 
   public RegisteredValidators getRegisteredValidators() {

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContext.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContext.java
@@ -12,22 +12,34 @@
  */
 package tech.pegasys.web3signer.slashingprotection;
 
+import java.util.Optional;
+
 import org.jdbi.v3.core.Jdbi;
 
 public class SlashingProtectionContext {
 
   private final Jdbi slashingProtectionJdbi;
-  private final Jdbi pruningJdbi;
+  private final Optional<SlashingProtectionPruner> slashingProtectionPruner;
   private final RegisteredValidators registeredValidators;
   private final SlashingProtection slashingProtection;
 
   public SlashingProtectionContext(
       final Jdbi slashingProtectionJdbi,
-      final Jdbi pruningJdbi,
       final RegisteredValidators registeredValidators,
       final SlashingProtection slashingProtection) {
     this.slashingProtectionJdbi = slashingProtectionJdbi;
-    this.pruningJdbi = pruningJdbi;
+    this.slashingProtectionPruner = Optional.empty();
+    this.registeredValidators = registeredValidators;
+    this.slashingProtection = slashingProtection;
+  }
+
+  public SlashingProtectionContext(
+      final Jdbi slashingProtectionJdbi,
+      final SlashingProtectionPruner slashingProtectionPruner,
+      final RegisteredValidators registeredValidators,
+      final SlashingProtection slashingProtection) {
+    this.slashingProtectionJdbi = slashingProtectionJdbi;
+    this.slashingProtectionPruner = Optional.of(slashingProtectionPruner);
     this.registeredValidators = registeredValidators;
     this.slashingProtection = slashingProtection;
   }
@@ -36,8 +48,8 @@ public class SlashingProtectionContext {
     return slashingProtectionJdbi;
   }
 
-  public Jdbi getPruningJdbi() {
-    return pruningJdbi;
+  public SlashingProtectionPruner getPruner() {
+    return slashingProtectionPruner.get();
   }
 
   public RegisteredValidators getRegisteredValidators() {

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactory.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactory.java
@@ -27,6 +27,7 @@ public class SlashingProtectionContextFactory {
 
   public static SlashingProtectionContext create(
       final SlashingProtectionParameters slashingProtectionParameters) {
+
     final Jdbi jdbi =
         DbConnection.createConnection(
             slashingProtectionParameters.getDbUrl(),
@@ -37,30 +38,44 @@ public class SlashingProtectionContextFactory {
     verifyVersion(jdbi);
 
     // create separate Jdbi instance for pruning operations
-    final Jdbi pruningJdbi =
-        DbConnection.createPruningConnection(
-            slashingProtectionParameters.getDbUrl(),
-            slashingProtectionParameters.getDbUsername(),
-            slashingProtectionParameters.getDbPassword(),
-            slashingProtectionParameters.getPruningDbPoolConfigurationFile(),
-            slashingProtectionParameters.isDbConnectionPoolEnabled());
 
     final ValidatorsDao validatorsDao = new ValidatorsDao();
+    final SignedBlocksDao signedBlocksDao = new SignedBlocksDao();
+    final SignedAttestationsDao signedAttestationsDao = new SignedAttestationsDao();
+    final MetadataDao metadataDao = new MetadataDao();
+    final LowWatermarkDao lowWatermarkDao = new LowWatermarkDao();
     final RegisteredValidators registeredValidators = new RegisteredValidators(jdbi, validatorsDao);
     final DbSlashingProtection dbSlashingProtection =
         new DbSlashingProtection(
             jdbi,
-            pruningJdbi,
             validatorsDao,
-            new SignedBlocksDao(),
-            new SignedAttestationsDao(),
-            new MetadataDao(),
-            new LowWatermarkDao(),
-            slashingProtectionParameters.getPruningEpochsToKeep(),
-            slashingProtectionParameters.getPruningSlotsPerEpoch(),
+            signedBlocksDao,
+            signedAttestationsDao,
+            metadataDao,
+            lowWatermarkDao,
             registeredValidators);
-    return new SlashingProtectionContext(
-        jdbi, pruningJdbi, registeredValidators, dbSlashingProtection);
+    if (slashingProtectionParameters.isPruningEnabled()) {
+      final Jdbi pruningJdbi =
+          DbConnection.createPruningConnection(
+              slashingProtectionParameters.getDbUrl(),
+              slashingProtectionParameters.getDbUsername(),
+              slashingProtectionParameters.getDbPassword(),
+              slashingProtectionParameters.getPruningDbPoolConfigurationFile(),
+              slashingProtectionParameters.isDbConnectionPoolEnabled());
+      final SlashingProtectionPruner slashingProtectionPruner =
+          new DBSlashingProtectionPruner(
+              pruningJdbi,
+              slashingProtectionParameters.getPruningEpochsToKeep(),
+              slashingProtectionParameters.getPruningSlotsPerEpoch(),
+              registeredValidators,
+              signedBlocksDao,
+              signedAttestationsDao,
+              lowWatermarkDao);
+      return new SlashingProtectionContext(
+          jdbi, slashingProtectionPruner, registeredValidators, dbSlashingProtection);
+    }
+
+    return new SlashingProtectionContext(jdbi, registeredValidators, dbSlashingProtection);
   }
 
   private static void verifyVersion(final Jdbi jdbi) {

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactory.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionContextFactory.java
@@ -37,8 +37,6 @@ public class SlashingProtectionContextFactory {
             slashingProtectionParameters.isDbConnectionPoolEnabled());
     verifyVersion(jdbi);
 
-    // create separate Jdbi instance for pruning operations
-
     final ValidatorsDao validatorsDao = new ValidatorsDao();
     final SignedBlocksDao signedBlocksDao = new SignedBlocksDao();
     final SignedAttestationsDao signedAttestationsDao = new SignedAttestationsDao();

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionPruner.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/SlashingProtectionPruner.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.slashingprotection;
+
+public interface SlashingProtectionPruner {
+
+  void prune();
+}

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionPrunerTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionPrunerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.slashingprotection;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
+import tech.pegasys.web3signer.slashingprotection.dao.MetadataDao;
+import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
+import tech.pegasys.web3signer.slashingprotection.dao.SignedBlocksDao;
+import tech.pegasys.web3signer.slashingprotection.dao.ValidatorsDao;
+
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.common.collect.HashBiMap;
+import db.DatabaseSetupExtension;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(DatabaseSetupExtension.class)
+public class DbSlashingProtectionPrunerTest {
+
+  private static final int VALIDATOR_ID = 1;
+
+  private static final Bytes PUBLIC_KEY1 = Bytes.of(42);
+
+  private static final Bytes32 GVR = Bytes32.leftPad(Bytes.of(100));
+
+  @Mock private ValidatorsDao validatorsDao;
+  @Mock private SignedBlocksDao signedBlocksDao;
+  @Mock private SignedAttestationsDao signedAttestationsDao;
+  @Mock private MetadataDao metadataDao;
+  @Mock private LowWatermarkDao lowWatermarkDao;
+
+  private DBSlashingProtectionPruner dbSlashingProtectionPruner;
+  private Jdbi pruningJdbi;
+  private Jdbi slashingJdbi;
+
+  @BeforeEach
+  public void setup(final Jdbi jdbi) {
+    DbConnection.configureJdbi(jdbi);
+    slashingJdbi = spy(jdbi);
+    pruningJdbi = spy(jdbi);
+    dbSlashingProtectionPruner =
+        new DBSlashingProtectionPruner(
+            pruningJdbi,
+            1,
+            1,
+            new RegisteredValidators(
+                slashingJdbi, validatorsDao, HashBiMap.create(Map.of(PUBLIC_KEY1, VALIDATOR_ID))),
+            signedBlocksDao,
+            signedAttestationsDao,
+            lowWatermarkDao);
+    lenient().when(metadataDao.findGenesisValidatorsRoot(any())).thenReturn(Optional.of(GVR));
+    lenient().when(validatorsDao.isEnabled(any(), eq(VALIDATOR_ID))).thenReturn(true);
+  }
+
+  @Test
+  public void pruningUseSeparateDatasource() {
+    dbSlashingProtectionPruner.prune();
+    verify(pruningJdbi, atLeast(2))
+        .inTransaction(eq(TransactionIsolationLevel.READ_UNCOMMITTED), any());
+    verifyNoInteractions(slashingJdbi);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
This PR optimizes the creation of the pruning db connection by only creating a connection when pruning is enabled.
I also refactored the code to separate the pruning feature from the SlashingProtection class since it is a independent feature.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes https://github.com/ConsenSys/web3signer/issues/672

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
