### PR TITLE
Support aliases in environment variables and YAML configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Hashicorp connection properties can now override http protocol to HTTP/1.1 from the default of HTTP/2. [#817](https://github.com/ConsenSys/web3signer/pull/817)
 
 ### Bugs fixed
+- Support long name aliases in environment variables and YAML configuration [#825](https://github.com/Consensys/web3signer/pull/825)
 
 ---
 ## 23.6.0

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/valueprovider/EnvironmentVariableDefaultProvider.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/valueprovider/EnvironmentVariableDefaultProvider.java
@@ -33,9 +33,15 @@ public class EnvironmentVariableDefaultProvider implements IDefaultValueProvider
       final OptionSpec optionSpec = (OptionSpec) argSpec;
       final String qualifiedPrefix =
           optionSpec.command().qualifiedName("_").replace("-", "_").toUpperCase();
-      final String key = stripPrefix(optionSpec.longestName()).replace("-", "_").toUpperCase();
-      final String qualifiedKey = qualifiedPrefix + "_" + key;
-      return environment.get(qualifiedKey);
+
+      for (final String alias : optionSpec.names()) {
+        final String key = stripPrefix(alias).replace("-", "_").toUpperCase();
+        final String qualifiedKey = qualifiedPrefix + "_" + key;
+        final String value = environment.get(qualifiedKey);
+        if (value != null) {
+          return value;
+        }
+      }
     }
 
     return null; // currently not supporting positional parameters

--- a/commandline/src/test-support/java/tech/pegasys/web3signer/CmdlineHelpers.java
+++ b/commandline/src/test-support/java/tech/pegasys/web3signer/CmdlineHelpers.java
@@ -28,7 +28,12 @@ public class CmdlineHelpers {
     return "http-listen-port: 6001\n"
         + "http-listen-host: \"localhost\"\n"
         + "key-store-path: \"./keys_yaml\"\n"
+        + "metrics-categories: \"HTTP\"\n"
         + "logging: \"INFO\"\n";
+  }
+
+  public static String validBaseYamlAliasOptions() {
+    return "metrics-category: \"HTTP\"\n" + "l: \"INFO\"\n";
   }
 
   public static Map<String, String> validBaseEnvironmentVariableOptions() {

--- a/commandline/src/test/java/tech/pegasys/web3signer/commandline/valueprovider/DemoCommand.java
+++ b/commandline/src/test/java/tech/pegasys/web3signer/commandline/valueprovider/DemoCommand.java
@@ -41,5 +41,10 @@ public class DemoCommand {
   static class SubCommand {
     @Option(names = "--codes", split = ",")
     List<String> countryCodes;
+
+    @Option(
+        names = {"--subalias", "--subaliases"},
+        description = "Subcommand Alias")
+    String subalias;
   }
 }

--- a/commandline/src/test/java/tech/pegasys/web3signer/commandline/valueprovider/DemoCommand.java
+++ b/commandline/src/test/java/tech/pegasys/web3signer/commandline/valueprovider/DemoCommand.java
@@ -32,6 +32,11 @@ public class DemoCommand {
   @Option(names = "--name", description = "Name")
   String name;
 
+  @Option(
+      names = {"--alias", "--aliases"},
+      description = "Aliases")
+  String alias;
+
   @Command(name = "country", description = "Country Codes")
   static class SubCommand {
     @Option(names = "--codes", split = ",")

--- a/commandline/src/test/java/tech/pegasys/web3signer/commandline/valueprovider/EnvironmentVariableDefaultProviderTest.java
+++ b/commandline/src/test/java/tech/pegasys/web3signer/commandline/valueprovider/EnvironmentVariableDefaultProviderTest.java
@@ -88,16 +88,22 @@ class EnvironmentVariableDefaultProviderTest {
 
     assertAliasCreated("DEMO_ALIAS", "testValue");
     assertAliasCreated("DEMO_ALIASES", "testValue2");
+    assertAliasCreated("DEMO_COUNTRY_SUBALIAS", "testValue3", "country");
+    assertAliasCreated("DEMO_COUNTRY_SUBALIASES", "testValue4", "country");
   }
 
-  private void assertAliasCreated(String envKey, String envValue) {
+  private void assertAliasCreated(String envKey, String envValue, String... subCommandName) {
     final EnvironmentVariableDefaultProvider defaultProvider =
         new EnvironmentVariableDefaultProvider(Map.of(envKey, envValue));
 
     commandLine.setDefaultValueProvider(defaultProvider);
-    commandLine.parseArgs();
+    commandLine.parseArgs(subCommandName);
 
-    assertThat(demoCommand.alias).isEqualTo(envValue);
+    if (subCommandName.length > 0) {
+      assertThat(subCommand.subalias).isEqualTo(envValue);
+    } else {
+      assertThat(demoCommand.alias).isEqualTo(envValue);
+    }
   }
 
   private Map<String, String> validEnvMap() {

--- a/commandline/src/test/java/tech/pegasys/web3signer/commandline/valueprovider/EnvironmentVariableDefaultProviderTest.java
+++ b/commandline/src/test/java/tech/pegasys/web3signer/commandline/valueprovider/EnvironmentVariableDefaultProviderTest.java
@@ -83,6 +83,23 @@ class EnvironmentVariableDefaultProviderTest {
     assertThat(subCommand.countryCodes).isNullOrEmpty();
   }
 
+  @Test
+  void environmentVariablesAreCreatedForAliases() {
+
+    assertAliasCreated("DEMO_ALIAS", "testValue");
+    assertAliasCreated("DEMO_ALIASES", "testValue2");
+  }
+
+  private void assertAliasCreated(String envKey, String envValue) {
+    final EnvironmentVariableDefaultProvider defaultProvider =
+        new EnvironmentVariableDefaultProvider(Map.of(envKey, envValue));
+
+    commandLine.setDefaultValueProvider(defaultProvider);
+    commandLine.parseArgs();
+
+    assertThat(demoCommand.alias).isEqualTo(envValue);
+  }
+
   private Map<String, String> validEnvMap() {
     return Map.of(
         "DEMO_X", "10", "DEMO_Y", "20", "DEMO_NAME", "test name", "DEMO_COUNTRY_CODES", "AU,US");

--- a/commandline/src/test/java/tech/pegasys/web3signer/commandline/valueprovider/YamlConfigFileDefaultProviderTest.java
+++ b/commandline/src/test/java/tech/pegasys/web3signer/commandline/valueprovider/YamlConfigFileDefaultProviderTest.java
@@ -21,11 +21,13 @@ import static tech.pegasys.web3signer.CmdlineHelpers.validBaseCommandOptions;
 import tech.pegasys.web3signer.CmdlineHelpers;
 import tech.pegasys.web3signer.commandline.Web3SignerBaseCommand;
 import tech.pegasys.web3signer.commandline.valueprovider.DemoCommand.SubCommand;
+import tech.pegasys.web3signer.common.Web3SignerMetricCategory;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
 
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.Test;
@@ -51,13 +53,21 @@ class YamlConfigFileDefaultProviderTest {
 
     assertThat(web3SignerBaseCommand.getHttpListenPort()).isEqualTo(6001);
     assertThat(web3SignerBaseCommand.getKeyConfigPath()).isEqualTo(Path.of("./keys_yaml"));
+    assertThat(web3SignerBaseCommand.getMetricCategories())
+        .isEqualTo(Set.of(Web3SignerMetricCategory.HTTP));
+    assertThat(web3SignerBaseCommand.getLogLevel()).isEqualTo(Level.INFO);
   }
 
   @Test
   void valuesFromConfigFileWithSubcommandArePopulated(@TempDir final Path tempDir)
       throws IOException {
     final String subcommandOptions =
-        String.join(lineSeparator(), "demo.x: 10", "demo.y: 2", "demo.name: \"test name\"");
+        String.join(
+            lineSeparator(),
+            "demo.x: 10",
+            "demo.y: 2",
+            "demo.name: \"test name\"",
+            "demo.aliases: \"test alias\"");
     final String config = CmdlineHelpers.validBaseYamlOptions() + subcommandOptions;
     final File configFile = Files.writeString(tempDir.resolve("config.yaml"), config).toFile();
 
@@ -74,6 +84,26 @@ class YamlConfigFileDefaultProviderTest {
     assertThat(subCommand.x).isEqualTo(10);
     assertThat(subCommand.y).isEqualTo(2);
     assertThat(subCommand.name).isEqualTo("test name");
+    assertThat(subCommand.alias).isEqualTo("test alias");
+  }
+
+  @Test
+  void aliasesFromConfigFileArePopulated(@TempDir final Path tempDir) throws IOException {
+    final String subcommandOptions = String.join(lineSeparator(), "demo.alias: \"test alias\"");
+    final String config = CmdlineHelpers.validBaseYamlAliasOptions() + subcommandOptions;
+    final File configFile = Files.writeString(tempDir.resolve("config.yaml"), config).toFile();
+    final Web3SignerBaseCommand web3SignerBaseCommand = new Web3SignerBaseCommand();
+    final DemoCommand subCommand = new DemoCommand();
+    final CommandLine commandLine = new CommandLine(web3SignerBaseCommand);
+    commandLine.registerConverter(Level.class, Level::valueOf);
+    commandLine.addSubcommand("demo", subCommand);
+    commandLine.setDefaultValueProvider(new YamlConfigFileDefaultProvider(commandLine, configFile));
+    commandLine.parseArgs("demo");
+
+    assertThat(web3SignerBaseCommand.getMetricCategories())
+        .isEqualTo(Set.of(Web3SignerMetricCategory.HTTP));
+    assertThat(web3SignerBaseCommand.getLogLevel()).isEqualTo(Level.INFO);
+    assertThat(subCommand.alias).isEqualTo("test alias");
   }
 
   @Test

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -119,9 +119,9 @@ dependencyManagement {
       entry 'besu'
       entry ('core') {
         exclude group: 'com.github.jnr', name: 'jnr-unixsocket'
+        exclude group: 'org.bouncycastle', name: 'bcprov-jdk15on'
       }
-      entry 'crypto'
-      entry ('utils') {
+      entry ('crypto') {
         exclude group: 'org.bouncycastle', name: 'bcprov-jdk15on'
       }
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description

Supporting PR for https://github.com/Consensys/web3signer/pull/826

Before this PR, the only aliases that were supported were the ones with the longest name. This makes sense when your aliases are always short name versions of the options, e.g. `--logging, -l`.

It doesn't make sense when you want to use aliases as a way to rename an option as for https://github.com/Consensys/web3signer/issues/586

This PR allows 'short name options' with a single leading dash to be converted into environment variables and YAML config items. 
I have opened another issue to discuss whether we should handle these differently to the long name options: https://github.com/ConsenSys/web3signer/issues/824 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
