### PR TITLE
Load SECP256K1 from AWS Secrets Manager

### DIFF
--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth1SubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth1SubCommand.java
@@ -18,6 +18,7 @@ import static tech.pegasys.web3signer.commandline.DefaultCommandValues.PATH_FORM
 import static tech.pegasys.web3signer.commandline.DefaultCommandValues.PORT_FORMAT_HELP;
 import static tech.pegasys.web3signer.commandline.util.RequiredOptionsUtil.checkIfRequiredOptionsAreInitialized;
 
+import tech.pegasys.web3signer.commandline.PicoCliAwsSecretsManagerParameters;
 import tech.pegasys.web3signer.commandline.annotations.RequiredOption;
 import tech.pegasys.web3signer.commandline.config.client.PicoCliClientTlsOptions;
 import tech.pegasys.web3signer.core.Eth1Runner;
@@ -26,6 +27,7 @@ import tech.pegasys.web3signer.core.config.Eth1Config;
 import tech.pegasys.web3signer.core.config.client.ClientTlsOptions;
 import tech.pegasys.web3signer.core.service.jsonrpc.handlers.signing.ChainIdProvider;
 import tech.pegasys.web3signer.core.service.jsonrpc.handlers.signing.ConfigurationChainId;
+import tech.pegasys.web3signer.signing.config.AwsSecretsManagerParameters;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -140,6 +142,8 @@ public class Eth1SubCommand extends ModeSubCommand implements Eth1Config {
 
   @CommandLine.Mixin private PicoCliClientTlsOptions clientTlsOptions;
 
+  @CommandLine.Mixin private PicoCliAwsSecretsManagerParameters awsSecretsManagerParameters;
+
   @Override
   public Runner createRunner() {
     return new Eth1Runner(config, this);
@@ -203,5 +207,10 @@ public class Eth1SubCommand extends ModeSubCommand implements Eth1Config {
   @Override
   public ChainIdProvider getChainId() {
     return new ConfigurationChainId(chainId);
+  }
+
+  @Override
+  public AwsSecretsManagerParameters getAwsSecretsManagerParameters() {
+    return awsSecretsManagerParameters;
   }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -58,6 +58,7 @@ dependencies {
   testImplementation 'org.bouncycastle:bcprov-jdk18on'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
+  integrationTestImplementation (testFixtures(project(":signing")))
   integrationTestImplementation 'org.apache.logging.log4j:log4j'
   integrationTestImplementation 'org.apache.logging.log4j:log4j-core'
   integrationTestImplementation 'org.assertj:assertj-core'

--- a/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/support/TestEth1Config.java
+++ b/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/support/TestEth1Config.java
@@ -16,6 +16,9 @@ import tech.pegasys.web3signer.core.config.Eth1Config;
 import tech.pegasys.web3signer.core.config.client.ClientTlsOptions;
 import tech.pegasys.web3signer.core.service.jsonrpc.handlers.signing.ChainIdProvider;
 import tech.pegasys.web3signer.core.service.jsonrpc.handlers.signing.ConfigurationChainId;
+import tech.pegasys.web3signer.signing.config.AwsAuthenticationMode;
+import tech.pegasys.web3signer.signing.config.AwsSecretsManagerParameters;
+import tech.pegasys.web3signer.signing.config.AwsSecretsManagerParametersBuilder;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -88,5 +91,15 @@ public class TestEth1Config implements Eth1Config {
   @Override
   public ChainIdProvider getChainId() {
     return chainId;
+  }
+
+  @Override
+  public AwsSecretsManagerParameters getAwsSecretsManagerParameters() {
+    /*
+    TODO: This will need to be refactored when AWS bulkloading is migrated to eth1 mode integ-test.
+     */
+    return AwsSecretsManagerParametersBuilder.anAwsSecretsManagerParameters()
+        .withAuthenticationMode(AwsAuthenticationMode.ENVIRONMENT)
+        .build();
   }
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -33,6 +33,7 @@ import tech.pegasys.web3signer.core.service.jsonrpc.handlers.RequestMapper;
 import tech.pegasys.web3signer.core.service.jsonrpc.handlers.internalresponse.EthSignResultProvider;
 import tech.pegasys.web3signer.core.service.jsonrpc.handlers.internalresponse.EthSignTransactionResultProvider;
 import tech.pegasys.web3signer.core.service.jsonrpc.handlers.internalresponse.InternalResponseHandler;
+import tech.pegasys.web3signer.keystorage.aws.AwsSecretsManagerProvider;
 import tech.pegasys.web3signer.keystorage.hashicorp.HashicorpConnectionFactory;
 import tech.pegasys.web3signer.signing.ArtifactSignerProvider;
 import tech.pegasys.web3signer.signing.EthSecpArtifactSigner;
@@ -135,11 +136,14 @@ public class Eth1Runner extends Runner {
     return new DefaultArtifactSignerProvider(
         () -> {
           final AzureKeyVaultSignerFactory azureFactory = new AzureKeyVaultSignerFactory();
-          final HashicorpConnectionFactory hashicorpConnectionFactory =
-              new HashicorpConnectionFactory();
-          try (final InterlockKeyProvider interlockKeyProvider = new InterlockKeyProvider(vertx);
+          try (final HashicorpConnectionFactory hashicorpConnectionFactory =
+                  new HashicorpConnectionFactory();
+              final InterlockKeyProvider interlockKeyProvider = new InterlockKeyProvider(vertx);
               final YubiHsmOpaqueDataProvider yubiHsmOpaqueDataProvider =
-                  new YubiHsmOpaqueDataProvider()) {
+                  new YubiHsmOpaqueDataProvider();
+              final AwsSecretsManagerProvider awsSecretsManagerProvider =
+                  new AwsSecretsManagerProvider(
+                      eth1Config.getAwsSecretsManagerParameters().getCacheMaximumSize())) {
             final Secp256k1ArtifactSignerFactory ethSecpArtifactSignerFactory =
                 new Secp256k1ArtifactSignerFactory(
                     hashicorpConnectionFactory,
@@ -147,6 +151,7 @@ public class Eth1Runner extends Runner {
                     azureFactory,
                     interlockKeyProvider,
                     yubiHsmOpaqueDataProvider,
+                    awsSecretsManagerProvider,
                     EthSecpArtifactSigner::new,
                     true);
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/FilecoinRunner.java
@@ -129,6 +129,7 @@ public class FilecoinRunner extends Runner {
                     azureFactory,
                     interlockKeyProvider,
                     yubiHsmOpaqueDataProvider,
+                    awsSecretsManagerProvider,
                     signer -> new FcSecpArtifactSigner(signer, network),
                     false);
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/Eth1Config.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/Eth1Config.java
@@ -14,6 +14,7 @@ package tech.pegasys.web3signer.core.config;
 
 import tech.pegasys.web3signer.core.config.client.ClientTlsOptions;
 import tech.pegasys.web3signer.core.service.jsonrpc.handlers.signing.ChainIdProvider;
+import tech.pegasys.web3signer.signing.config.AwsSecretsManagerParameters;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -39,4 +40,6 @@ public interface Eth1Config {
   Optional<ClientTlsOptions> getClientTlsOptions();
 
   ChainIdProvider getChainId();
+
+  AwsSecretsManagerParameters getAwsSecretsManagerParameters();
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AwsKeySigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AwsKeySigningMetadata.java
@@ -38,8 +38,9 @@ public class AwsKeySigningMetadata extends SigningMetadata implements AwsSecrets
       final String accessKeyId,
       final String secretAccessKey,
       final String secretName,
+      final KeyType keyType,
       final Optional<URI> endpointOverride) {
-    super(TYPE, KeyType.BLS);
+    super(TYPE, keyType == null ? KeyType.BLS : keyType);
     this.authenticationMode = authenticationMode;
     this.region = region;
     this.accessKeyId = accessKeyId;

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AwsKeySigningMetadataDeserializer.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AwsKeySigningMetadataDeserializer.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.web3signer.signing.config.metadata;
 
+import tech.pegasys.web3signer.signing.KeyType;
 import tech.pegasys.web3signer.signing.config.AwsAuthenticationMode;
 
 import java.io.IOException;
@@ -34,6 +35,7 @@ public class AwsKeySigningMetadataDeserializer extends StdDeserializer<AwsKeySig
   public static final String SECRET_ACCESS_KEY = "secretAccessKey";
   public static final String SECRET_NAME = "secretName";
   public static final String ENDPOINT_OVERRIDE = "endpointOverride";
+  public static final String KEY_TYPE = "keyType";
 
   @SuppressWarnings("Unused")
   public AwsKeySigningMetadataDeserializer() {
@@ -54,6 +56,7 @@ public class AwsKeySigningMetadataDeserializer extends StdDeserializer<AwsKeySig
     String secretAccessKey = null;
     String secretName = null;
     Optional<URI> endpointOverride = Optional.empty();
+    KeyType keyType = null;
 
     final JsonNode node = parser.getCodec().readTree(parser);
 
@@ -86,9 +89,13 @@ public class AwsKeySigningMetadataDeserializer extends StdDeserializer<AwsKeySig
       endpointOverride = Optional.of(URI.create(node.get(ENDPOINT_OVERRIDE).asText()));
     }
 
+    if (node.get(KEY_TYPE) != null) {
+      keyType = KeyType.valueOf(node.get(KEY_TYPE).asText(KeyType.BLS.name()));
+    }
+
     final AwsKeySigningMetadata awsKeySigningMetadata =
         new AwsKeySigningMetadata(
-            authMode, region, accessKeyId, secretAccessKey, secretName, endpointOverride);
+            authMode, region, accessKeyId, secretAccessKey, secretName, keyType, endpointOverride);
 
     validate(parser, awsKeySigningMetadata);
 

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/Secp256k1ArtifactSignerFactory.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/Secp256k1ArtifactSignerFactory.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.web3signer.signing.config.metadata;
 
+import tech.pegasys.web3signer.keystorage.aws.AwsSecretsManagerProvider;
 import tech.pegasys.web3signer.keystorage.hashicorp.HashicorpConnectionFactory;
 import tech.pegasys.web3signer.signing.ArtifactSigner;
 import tech.pegasys.web3signer.signing.KeyType;
@@ -45,13 +46,15 @@ public class Secp256k1ArtifactSignerFactory extends AbstractArtifactSignerFactor
       final AzureKeyVaultSignerFactory azureCloudSignerFactory,
       final InterlockKeyProvider interlockKeyProvider,
       final YubiHsmOpaqueDataProvider yubiHsmOpaqueDataProvider,
+      final AwsSecretsManagerProvider awsSecretsManagerProvider,
       final Function<Signer, ArtifactSigner> signerFactory,
       final boolean needToHash) {
     super(
         hashicorpConnectionFactory,
         configsDirectory,
         interlockKeyProvider,
-        yubiHsmOpaqueDataProvider);
+        yubiHsmOpaqueDataProvider,
+        awsSecretsManagerProvider);
     this.azureCloudSignerFactory = azureCloudSignerFactory;
     this.signerFactory = signerFactory;
     this.needToHash = needToHash;
@@ -117,6 +120,13 @@ public class Secp256k1ArtifactSignerFactory extends AbstractArtifactSignerFactor
   public ArtifactSigner create(final YubiHsmSigningMetadata yubiHsmSigningMetadata) {
     final Credentials credentials =
         Credentials.create(extractOpaqueDataFromYubiHsm(yubiHsmSigningMetadata).toHexString());
+    return createCredentialSigner(credentials);
+  }
+
+  @Override
+  public ArtifactSigner create(AwsKeySigningMetadata awsKeySigningMetadata) {
+    final Credentials credentials =
+        Credentials.create(extractBytesFromSecretsManager(awsKeySigningMetadata).toHexString());
     return createCredentialSigner(credentials);
   }
 

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/config/metadata/AwsKeySigningMetadataDeserializerTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/config/metadata/AwsKeySigningMetadataDeserializerTest.java
@@ -33,6 +33,12 @@ class AwsKeySigningMetadataDeserializerTest {
       "src/test/resources/aws/aws_valid_config_environment.yaml";
   private static final String AWS_VALID_CONFIG_SPECIFIED_AUTH_MODE_PATH =
       "src/test/resources/aws/aws_valid_config_specified.yaml";
+
+  private static final String AWS_VALID_CONFIG_SECP_KEYTYPE_PATH =
+      "src/test/resources/aws/aws_valid_config_specified_secp.yaml";
+
+  private static final String AWS_VALID_CONFIG_WITHOUT_KEYTYPE_PATH =
+      "src/test/resources/aws/aws_valid_config_specified_wo_keytype.yaml";
   private static final YAMLMapper YAML_MAPPER = YamlMapperFactory.createYamlMapper();
 
   @Test
@@ -79,6 +85,36 @@ class AwsKeySigningMetadataDeserializerTest {
     final AwsKeySigningMetadata deserializedMetadata =
         YAML_MAPPER.readValue(
             new File(AWS_VALID_CONFIG_SPECIFIED_AUTH_MODE_PATH), AwsKeySigningMetadata.class);
+
+    assertThat(deserializedMetadata.getAuthenticationMode())
+        .isEqualTo(AwsAuthenticationMode.SPECIFIED);
+    assertThat(deserializedMetadata.getKeyType()).isEqualTo(KeyType.BLS);
+    assertThat(deserializedMetadata.getRegion()).isEqualTo("ap-southeast-2");
+    assertThat(deserializedMetadata.getSecretName()).isEqualTo("NewSuperSecret");
+    assertThat(deserializedMetadata.getAccessKeyId()).isEqualTo("foo");
+    assertThat(deserializedMetadata.getSecretAccessKey()).isEqualTo("bar");
+  }
+
+  @Test
+  public void deserializeValidAwsConfigWithSecpKeyType() throws IOException {
+    final AwsKeySigningMetadata deserializedMetadata =
+        YAML_MAPPER.readValue(
+            new File(AWS_VALID_CONFIG_SECP_KEYTYPE_PATH), AwsKeySigningMetadata.class);
+
+    assertThat(deserializedMetadata.getAuthenticationMode())
+        .isEqualTo(AwsAuthenticationMode.SPECIFIED);
+    assertThat(deserializedMetadata.getKeyType()).isEqualTo(KeyType.SECP256K1);
+    assertThat(deserializedMetadata.getRegion()).isEqualTo("ap-southeast-2");
+    assertThat(deserializedMetadata.getSecretName()).isEqualTo("NewSuperSecret");
+    assertThat(deserializedMetadata.getAccessKeyId()).isEqualTo("foo");
+    assertThat(deserializedMetadata.getSecretAccessKey()).isEqualTo("bar");
+  }
+
+  @Test
+  public void deserializeValidAwsConfigWithoutKeyKeyTypeDefaultsToBLS() throws IOException {
+    final AwsKeySigningMetadata deserializedMetadata =
+        YAML_MAPPER.readValue(
+            new File(AWS_VALID_CONFIG_WITHOUT_KEYTYPE_PATH), AwsKeySigningMetadata.class);
 
     assertThat(deserializedMetadata.getAuthenticationMode())
         .isEqualTo(AwsAuthenticationMode.SPECIFIED);

--- a/signing/src/test/resources/aws/aws_valid_config_specified_secp.yaml
+++ b/signing/src/test/resources/aws/aws_valid_config_specified_secp.yaml
@@ -1,0 +1,7 @@
+type: "aws-secret"
+keyType: "SECP256K1"
+authenticationMode: "SPECIFIED"
+region: "ap-southeast-2"
+accessKeyId: "foo"
+secretAccessKey: "bar"
+secretName: "NewSuperSecret"

--- a/signing/src/test/resources/aws/aws_valid_config_specified_wo_keytype.yaml
+++ b/signing/src/test/resources/aws/aws_valid_config_specified_wo_keytype.yaml
@@ -1,0 +1,6 @@
+type: "aws-secret"
+authenticationMode: "SPECIFIED"
+region: "ap-southeast-2"
+accessKeyId: "foo"
+secretAccessKey: "bar"
+secretName: "NewSuperSecret"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->
## PR Description
Load SECP256K1 from AWS secrets Manager. Allow `aws-secret` type metadata file to take keyType parameter i.e. BLS and SECP256K1. Defaults to BLS if not specified.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [ ] I thought about testing these changes in a realistic/non-local environment.
