### PR TITLE
Azure key cleanup

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AzureKeyVaultAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AzureKeyVaultAcceptanceTest.java
@@ -71,7 +71,6 @@ public class AzureKeyVaultAcceptanceTest extends AcceptanceTestBase {
         .contentType(ContentType.JSON)
         .body("", hasItems(EXPECTED_KEY, EXPECTED_TAGGED_KEY));
 
-    // Since our Azure vault contains some invalid keys, the healthcheck would return 503.
     final Response healthcheckResponse = signer.healthcheck();
     healthcheckResponse
         .then()

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AzureKeyVaultAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AzureKeyVaultAcceptanceTest.java
@@ -68,14 +68,14 @@ public class AzureKeyVaultAcceptanceTest extends AcceptanceTestBase {
     final Response healthcheckResponse = signer.healthcheck();
     healthcheckResponse
         .then()
-        .statusCode(503)
+        .statusCode(200)
         .contentType(ContentType.JSON)
-        .body("status", equalTo("DOWN"));
+        .body("status", equalTo("UP"));
 
-    // keys loaded would still be >= 1 though
+    // keys loaded are ACCTEST-MULTILINE-KEY (200), TEST-KEY (1), TEST-KEY-2 (1)
     final String jsonBody = healthcheckResponse.body().asString();
     int keysLoaded = getAzureBulkLoadingData(jsonBody, "keys-loaded");
-    assertThat(keysLoaded).isGreaterThanOrEqualTo(1);
+    assertThat(keysLoaded).isEqualTo(201);
   }
 
   @ParameterizedTest(name = "{index} - Using config file: {0}")

--- a/keystorage/src/test/java/tech/pegasys/web3signer/keystorage/azure/AzureKeyVaultTest.java
+++ b/keystorage/src/test/java/tech/pegasys/web3signer/keystorage/azure/AzureKeyVaultTest.java
@@ -87,10 +87,6 @@ public class AzureKeyVaultTest {
     final MappedResults<SimpleEntry<String, String>> result =
         azureKeyVault.mapSecrets(SimpleEntry::new, Collections.emptyMap());
     final Collection<SimpleEntry<String, String>> entries = result.getValues();
-    final Optional<SimpleEntry<String, String>> myBlsEntry =
-        entries.stream().filter(e -> e.getKey().equals("MyBls")).findAny();
-    Assertions.assertThat(myBlsEntry).isPresent();
-    Assertions.assertThat(myBlsEntry.get().getValue()).isEqualTo("BlsKey");
 
     final Optional<SimpleEntry<String, String>> testKeyEntry =
         entries.stream().filter(e -> e.getKey().equals("TEST-KEY")).findAny();
@@ -180,8 +176,8 @@ public class AzureKeyVaultTest {
     Assertions.assertThat(testKeyEntry).isEmpty();
 
     final Optional<SimpleEntry<String, String>> myBlsEntry =
-        entries.stream().filter(e -> e.getKey().equals("MyBls")).findAny();
+        entries.stream().filter(e -> e.getKey().equals("TEST-KEY-2")).findAny();
     Assertions.assertThat(myBlsEntry).isPresent();
-    Assertions.assertThat(myBlsEntry.get().getValue()).isEqualTo("BlsKey");
+    Assertions.assertThat(myBlsEntry.get().getValue()).isEqualTo(EXPECTED_KEY);
   }
 }

--- a/keystorage/src/test/java/tech/pegasys/web3signer/keystorage/azure/AzureKeyVaultTest.java
+++ b/keystorage/src/test/java/tech/pegasys/web3signer/keystorage/azure/AzureKeyVaultTest.java
@@ -36,6 +36,8 @@ public class AzureKeyVaultTest {
   private static final String SECRET_NAME = "TEST-KEY";
   private static final String EXPECTED_KEY =
       "3ee2224386c82ffea477e2adf28a2929f5c349165a4196158c7f3a2ecca40f35";
+  private static final String EXPECTED_KEY2 =
+      "0x5aba5b89c1d8b731dba1ba29128a4070df0dbfd7e0a67edb40ae7f860cd3ca1c";
 
   @BeforeAll
   public static void setup() {
@@ -109,7 +111,7 @@ public class AzureKeyVaultTest {
             .filter(entry -> "TEST-KEY-2".equals(entry.getKey()))
             .findFirst();
     Assertions.assertThat(secretEntry).isPresent();
-    Assertions.assertThat(secretEntry.get().getValue()).isEqualTo(EXPECTED_KEY);
+    Assertions.assertThat(secretEntry.get().getValue()).isEqualTo(EXPECTED_KEY2);
 
     // we should not encounter any error count
     Assertions.assertThat(result.getErrorCount()).isZero();
@@ -178,6 +180,6 @@ public class AzureKeyVaultTest {
     final Optional<SimpleEntry<String, String>> myBlsEntry =
         entries.stream().filter(e -> e.getKey().equals("TEST-KEY-2")).findAny();
     Assertions.assertThat(myBlsEntry).isPresent();
-    Assertions.assertThat(myBlsEntry.get().getValue()).isEqualTo(EXPECTED_KEY);
+    Assertions.assertThat(myBlsEntry.get().getValue()).isEqualTo(EXPECTED_KEY2);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Cleanup how Azure keys are used in our tests
* Removed need for invalid MyBls key to allow acceptance test to bulk load successfully
* Made the secrets unique for the two test keys so can check the correct number of keys are loaded

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
