### PR TITLE
Replace usage of deprecated isEqualToComparingFieldByField in tests

### DIFF
--- a/signing/src/test/java/tech/pegasys/web3signer/signing/secp256k1/filebased/CredentialSignerTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/secp256k1/filebased/CredentialSignerTest.java
@@ -36,6 +36,7 @@ class CredentialSignerTest {
     assertThat(hashingSigner.getPublicKey().getEncoded())
         .isEqualTo(nonHashingSigner.getPublicKey().getEncoded());
     assertThat(hashingSigner.sign(data))
-        .isEqualToComparingFieldByField(nonHashingSigner.sign(Hash.sha3(data)));
+        .usingRecursiveComparison()
+        .isEqualTo(nonHashingSigner.sign(Hash.sha3(data)));
   }
 }

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningIntegrationTest.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/PruningIntegrationTest.java
@@ -70,7 +70,8 @@ public class PruningIntegrationTest extends IntegrationTestBase {
     assertThat(blocks).usingFieldByFieldElementComparator().isEqualTo(expectedBlocks);
 
     assertThat(getWatermark(1))
-        .isEqualToComparingFieldByField(
+        .usingRecursiveComparison()
+        .isEqualTo(
             new SigningWatermark(
                 1,
                 UInt64.valueOf(expectedLowestPopulatedSlot),

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/WatermarkImportingIntegrationTestBase.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/WatermarkImportingIntegrationTestBase.java
@@ -48,8 +48,8 @@ public class WatermarkImportingIntegrationTestBase extends IntegrationTestBase {
     final InputStream input = createInputDataWith(List.of(5, 4), emptyList());
     slashingProtectionContext.getSlashingProtection().importData(input);
     assertThat(getWatermark(VALIDATOR_ID))
-        .isEqualToComparingFieldByField(
-            new SigningWatermark(VALIDATOR_ID, UInt64.valueOf(4), null, null));
+        .usingRecursiveComparison()
+        .isEqualTo(new SigningWatermark(VALIDATOR_ID, UInt64.valueOf(4), null, null));
   }
 
   @Test
@@ -105,8 +105,8 @@ public class WatermarkImportingIntegrationTestBase extends IntegrationTestBase {
             emptyList(), List.of(new ImmutablePair<>(3, 4), new ImmutablePair<>(2, 5)));
     slashingProtectionContext.getSlashingProtection().importData(input);
     assertThat(getWatermark(VALIDATOR_ID))
-        .isEqualToComparingFieldByField(
-            new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(2), UInt64.valueOf(4)));
+        .usingRecursiveComparison()
+        .isEqualTo(new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(2), UInt64.valueOf(4)));
   }
 
   @Test
@@ -122,8 +122,8 @@ public class WatermarkImportingIntegrationTestBase extends IntegrationTestBase {
                 h, VALIDATOR_ID, UInt64.valueOf(3), UInt64.valueOf(4)));
 
     assertThat(getWatermark(VALIDATOR_ID))
-        .isEqualToComparingFieldByField(
-            new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(3), UInt64.valueOf(4)));
+        .usingRecursiveComparison()
+        .isEqualTo(new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(3), UInt64.valueOf(4)));
 
     final InputStream input =
         createInputDataWith(
@@ -131,8 +131,8 @@ public class WatermarkImportingIntegrationTestBase extends IntegrationTestBase {
     slashingProtectionContext.getSlashingProtection().importData(input);
 
     assertThat(getWatermark(VALIDATOR_ID))
-        .isEqualToComparingFieldByField(
-            new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(8), UInt64.valueOf(10)));
+        .usingRecursiveComparison()
+        .isEqualTo(new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(8), UInt64.valueOf(10)));
   }
 
   @Test
@@ -150,8 +150,8 @@ public class WatermarkImportingIntegrationTestBase extends IntegrationTestBase {
     final InputStream input = createInputDataWith(emptyList(), List.of(new ImmutablePair<>(1, 2)));
     slashingProtectionContext.getSlashingProtection().importData(input);
     assertThat(getWatermark(VALIDATOR_ID))
-        .isEqualToComparingFieldByField(
-            new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(3), UInt64.valueOf(4)));
+        .usingRecursiveComparison()
+        .isEqualTo(new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(3), UInt64.valueOf(4)));
   }
 
   @Test
@@ -169,8 +169,8 @@ public class WatermarkImportingIntegrationTestBase extends IntegrationTestBase {
 
     slashingProtectionContext.getSlashingProtection().importData(input);
     assertThat(getWatermark(VALIDATOR_ID))
-        .isEqualToComparingFieldByField(
-            new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(3), UInt64.valueOf(12)));
+        .usingRecursiveComparison()
+        .isEqualTo(new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(3), UInt64.valueOf(12)));
   }
 
   @Test
@@ -188,8 +188,8 @@ public class WatermarkImportingIntegrationTestBase extends IntegrationTestBase {
 
     slashingProtectionContext.getSlashingProtection().importData(input);
     assertThat(getWatermark(VALIDATOR_ID))
-        .isEqualToComparingFieldByField(
-            new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(4), UInt64.valueOf(6)));
+        .usingRecursiveComparison()
+        .isEqualTo(new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(4), UInt64.valueOf(6)));
   }
 
   @Test
@@ -208,7 +208,8 @@ public class WatermarkImportingIntegrationTestBase extends IntegrationTestBase {
     final InputStream input = createInputDataWith(emptyList(), emptyList());
     slashingProtectionContext.getSlashingProtection().importData(input);
     assertThat(getWatermark(VALIDATOR_ID))
-        .isEqualToComparingFieldByField(
+        .usingRecursiveComparison()
+        .isEqualTo(
             new SigningWatermark(
                 VALIDATOR_ID, UInt64.valueOf(6), UInt64.valueOf(3), UInt64.valueOf(4)));
   }

--- a/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/WatermarkUpdatesIntegrationTestBase.java
+++ b/slashing-protection/src/integration-test/java/tech/pegasys/web3signer/slashingprotection/WatermarkUpdatesIntegrationTestBase.java
@@ -48,7 +48,8 @@ public class WatermarkUpdatesIntegrationTestBase extends IntegrationTestBase {
 
     assertThat(findAllBlocks()).hasSize(1);
     assertThat(getWatermark(VALIDATOR_ID))
-        .isEqualToComparingFieldByField(new SigningWatermark(VALIDATOR_ID, blockSlot, null, null));
+        .usingRecursiveComparison()
+        .isEqualTo(new SigningWatermark(VALIDATOR_ID, blockSlot, null, null));
   }
 
   @Test
@@ -60,24 +61,24 @@ public class WatermarkUpdatesIntegrationTestBase extends IntegrationTestBase {
         .maySignBlock(PUBLIC_KEY, Bytes.of(100), UInt64.valueOf(3), GVR);
     assertThat(findAllBlocks()).hasSize(1);
     assertThat(getWatermark(VALIDATOR_ID))
-        .isEqualToComparingFieldByField(
-            new SigningWatermark(VALIDATOR_ID, UInt64.valueOf(3), null, null));
+        .usingRecursiveComparison()
+        .isEqualTo(new SigningWatermark(VALIDATOR_ID, UInt64.valueOf(3), null, null));
 
     slashingProtectionContext
         .getSlashingProtection()
         .maySignBlock(PUBLIC_KEY, Bytes.of(100), UInt64.valueOf(4), GVR);
     assertThat(findAllBlocks()).hasSize(2);
     assertThat(getWatermark(VALIDATOR_ID))
-        .isEqualToComparingFieldByField(
-            new SigningWatermark(VALIDATOR_ID, UInt64.valueOf(3), null, null));
+        .usingRecursiveComparison()
+        .isEqualTo(new SigningWatermark(VALIDATOR_ID, UInt64.valueOf(3), null, null));
 
     slashingProtectionContext
         .getSlashingProtection()
         .maySignBlock(PUBLIC_KEY, Bytes.of(100), UInt64.valueOf(5), GVR);
     assertThat(findAllBlocks()).hasSize(3);
     assertThat(getWatermark(VALIDATOR_ID))
-        .isEqualToComparingFieldByField(
-            new SigningWatermark(VALIDATOR_ID, UInt64.valueOf(3), null, null));
+        .usingRecursiveComparison()
+        .isEqualTo(new SigningWatermark(VALIDATOR_ID, UInt64.valueOf(3), null, null));
   }
 
   @Test
@@ -88,8 +89,8 @@ public class WatermarkUpdatesIntegrationTestBase extends IntegrationTestBase {
         .getSlashingProtection()
         .maySignAttestation(PUBLIC_KEY, Bytes.of(100), UInt64.valueOf(3), UInt64.valueOf(4), GVR);
     assertThat(getWatermark(VALIDATOR_ID))
-        .isEqualToComparingFieldByField(
-            new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(3), UInt64.valueOf(4)));
+        .usingRecursiveComparison()
+        .isEqualTo(new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(3), UInt64.valueOf(4)));
   }
 
   @Test
@@ -103,7 +104,7 @@ public class WatermarkUpdatesIntegrationTestBase extends IntegrationTestBase {
         .getSlashingProtection()
         .maySignAttestation(PUBLIC_KEY, Bytes.of(100), UInt64.valueOf(4), UInt64.valueOf(5), GVR);
     assertThat(getWatermark(VALIDATOR_ID))
-        .isEqualToComparingFieldByField(
-            new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(3), UInt64.valueOf(4)));
+        .usingRecursiveComparison()
+        .isEqualTo(new SigningWatermark(VALIDATOR_ID, null, UInt64.valueOf(3), UInt64.valueOf(4)));
   }
 }

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedAttestationsDaoTest.java
@@ -43,7 +43,9 @@ public class SignedAttestationsDaoTest {
             handle, 1, UInt64.valueOf(4), Bytes.of(3));
     assertThat(existingAttestation).isNotEmpty();
     assertThat(existingAttestation).hasSize(1);
-    assertThat(existingAttestation.get(0)).isEqualToComparingFieldByField(attestation(1, 3, 4, 2));
+    assertThat(existingAttestation.get(0))
+        .usingRecursiveComparison()
+        .isEqualTo(attestation(1, 3, 4, 2));
   }
 
   @Test
@@ -72,7 +74,7 @@ public class SignedAttestationsDaoTest {
             .mapToBean(SignedAttestation.class)
             .list();
     assertThat(attestations.size()).isEqualTo(1);
-    assertThat(attestations.get(0)).isEqualToComparingFieldByField(signedAttestation);
+    assertThat(attestations.get(0)).usingRecursiveComparison().isEqualTo(signedAttestation);
   }
 
   @Test
@@ -89,7 +91,7 @@ public class SignedAttestationsDaoTest {
     assertThat(attestation).isNotEmpty();
     // both existing attestations surround these source and target epochs but we expect that the
     // attestation with the highest target epoch is returned
-    assertThat(attestation.get(0)).isEqualToComparingFieldByField(attestation2);
+    assertThat(attestation.get(0)).usingRecursiveComparison().isEqualTo(attestation2);
 
     // target epoch is outside of the existing attestations target epoch
     assertThat(
@@ -124,7 +126,7 @@ public class SignedAttestationsDaoTest {
     assertThat(attestations).hasSize(1);
     // both attestations are surrounded by the source and target epochs but we expect that only the
     // attestation with the highest target epoch is returned
-    assertThat(attestations.get(0)).isEqualToComparingFieldByField(attestation2);
+    assertThat(attestations.get(0)).usingRecursiveComparison().isEqualTo(attestation2);
 
     // target epoch is not outside of the existing attestations
     assertThat(
@@ -199,8 +201,12 @@ public class SignedAttestationsDaoTest {
 
     // no longer contains the first entry with sourceEpoch=2, targetEpoch=3 others should remain
     assertThat(attestations.get(1)).hasSize(2);
-    assertThat(attestations.get(1).get(0)).isEqualToComparingFieldByField(attestation(1, 3, 4, 1));
-    assertThat(attestations.get(1).get(1)).isEqualToComparingFieldByField(attestation(1, 4, 5, 1));
+    assertThat(attestations.get(1).get(0))
+        .usingRecursiveComparison()
+        .isEqualTo(attestation(1, 3, 4, 1));
+    assertThat(attestations.get(1).get(1))
+        .usingRecursiveComparison()
+        .isEqualTo(attestation(1, 4, 5, 1));
   }
 
   @Test
@@ -224,12 +230,18 @@ public class SignedAttestationsDaoTest {
 
     // no longer contains the first entry with sourceEpoch=2, targetEpoch=3 others should remain
     assertThat(attestations.get(1)).hasSize(2);
-    assertThat(attestations.get(1).get(0)).isEqualToComparingFieldByField(attestation(1, 3, 4, 1));
-    assertThat(attestations.get(1).get(1)).isEqualToComparingFieldByField(attestation(1, 4, 5, 1));
+    assertThat(attestations.get(1).get(0))
+        .usingRecursiveComparison()
+        .isEqualTo(attestation(1, 3, 4, 1));
+    assertThat(attestations.get(1).get(1))
+        .usingRecursiveComparison()
+        .isEqualTo(attestation(1, 4, 5, 1));
 
     // all existing entries should remain
     assertThat(attestations.get(2)).hasSize(1);
-    assertThat(attestations.get(2).get(0)).isEqualToComparingFieldByField(attestation(2, 2, 3, 1));
+    assertThat(attestations.get(2).get(0))
+        .usingRecursiveComparison()
+        .isEqualTo(attestation(2, 2, 3, 1));
   }
 
   @Test
@@ -242,8 +254,8 @@ public class SignedAttestationsDaoTest {
     final List<SignedAttestation> attestations =
         signedAttestationsDao.findAllAttestationsSignedBy(handle, 1).collect(Collectors.toList());
     assertThat(attestations).hasSize(2);
-    assertThat(attestations.get(0)).isEqualToComparingFieldByField(attestation(1, 2, 3, 1));
-    assertThat(attestations.get(1)).isEqualToComparingFieldByField(attestation(1, 3, 4, 1));
+    assertThat(attestations.get(0)).usingRecursiveComparison().isEqualTo(attestation(1, 2, 3, 1));
+    assertThat(attestations.get(1)).usingRecursiveComparison().isEqualTo(attestation(1, 3, 4, 1));
   }
 
   @Test
@@ -272,12 +284,14 @@ public class SignedAttestationsDaoTest {
             signedAttestationsDao
                 .findNearestAttestationWithTargetEpoch(handle, 1, UInt64.valueOf(3))
                 .get())
-        .isEqualToComparingFieldByField(attestation(1, 2, 3, 1));
+        .usingRecursiveComparison()
+        .isEqualTo(attestation(1, 2, 3, 1));
     assertThat(
             signedAttestationsDao
                 .findNearestAttestationWithTargetEpoch(handle, 1, UInt64.valueOf(5))
                 .get())
-        .isEqualToComparingFieldByField(attestation(1, 7, 8, 1));
+        .usingRecursiveComparison()
+        .isEqualTo(attestation(1, 7, 8, 1));
   }
 
   @Test

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/SignedBlocksDaoTest.java
@@ -83,11 +83,13 @@ public class SignedBlocksDaoTest {
             .mapToBean(SignedBlock.class)
             .list();
     assertThat(validators.size()).isEqualTo(3);
-    assertThat(validators.get(0)).isEqualToComparingFieldByField(block(2, 100));
+    assertThat(validators.get(0)).usingRecursiveComparison().isEqualTo(block(2, 100));
     assertThat(validators.get(1))
-        .isEqualToComparingFieldByField(new SignedBlock(2, UInt64.MAX_VALUE, Bytes.of(101)));
+        .usingRecursiveComparison()
+        .isEqualTo(new SignedBlock(2, UInt64.MAX_VALUE, Bytes.of(101)));
     assertThat(validators.get(2))
-        .isEqualToComparingFieldByField(new SignedBlock(3, UInt64.MIN_VALUE, Bytes.of(102)));
+        .usingRecursiveComparison()
+        .isEqualTo(new SignedBlock(3, UInt64.MIN_VALUE, Bytes.of(102)));
   }
 
   @Test
@@ -138,7 +140,7 @@ public class SignedBlocksDaoTest {
             .collect(Collectors.groupingBy(SignedBlock::getValidatorId));
 
     assertThat(blocks.get(1)).hasSize(1);
-    assertThat(blocks.get(1).get(0)).isEqualToComparingFieldByField(block(4, 1));
+    assertThat(blocks.get(1).get(0)).usingRecursiveComparison().isEqualTo(block(4, 1));
   }
 
   @Test
@@ -161,7 +163,7 @@ public class SignedBlocksDaoTest {
             .collect(Collectors.groupingBy(SignedBlock::getValidatorId));
 
     assertThat(blocks.get(1)).hasSize(1);
-    assertThat(blocks.get(1).get(0)).isEqualToComparingFieldByField(block(4, 1));
+    assertThat(blocks.get(1).get(0)).usingRecursiveComparison().isEqualTo(block(4, 1));
     assertThat(blocks.get(2)).hasSize(2);
   }
 
@@ -175,8 +177,8 @@ public class SignedBlocksDaoTest {
     final List<SignedBlock> blocks =
         signedBlocksDao.findAllBlockSignedBy(handle, 1).collect(Collectors.toList());
     assertThat(blocks).hasSize(2);
-    assertThat(blocks.get(0)).isEqualToComparingFieldByField(block(3, 1));
-    assertThat(blocks.get(1)).isEqualToComparingFieldByField(block(4, 1));
+    assertThat(blocks.get(0)).usingRecursiveComparison().isEqualTo(block(3, 1));
+    assertThat(blocks.get(1)).usingRecursiveComparison().isEqualTo(block(4, 1));
   }
 
   @Test
@@ -201,9 +203,11 @@ public class SignedBlocksDaoTest {
     insertBlock(handle, 1, 7, Bytes.of(1));
 
     assertThat(signedBlocksDao.findNearestBlockWithSlot(handle, 1, UInt64.valueOf(3)).get())
-        .isEqualToComparingFieldByField(block(3, 1));
+        .usingRecursiveComparison()
+        .isEqualTo(block(3, 1));
     assertThat(signedBlocksDao.findNearestBlockWithSlot(handle, 1, UInt64.valueOf(5)).get())
-        .isEqualToComparingFieldByField(block(7, 1));
+        .usingRecursiveComparison()
+        .isEqualTo(block(7, 1));
   }
 
   @Test

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/ValidatorsDaoTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/dao/ValidatorsDaoTest.java
@@ -44,9 +44,11 @@ public class ValidatorsDaoTest {
         validatorsDao.retrieveValidators(handle, List.of(Bytes.of(101), Bytes.of(102)));
     assertThat(registeredValidators).hasSize(2);
     assertThat(registeredValidators.get(0))
-        .isEqualToComparingFieldByField(new Validator(2, Bytes.of(101)));
+        .usingRecursiveComparison()
+        .isEqualTo(new Validator(2, Bytes.of(101)));
     assertThat(registeredValidators.get(1))
-        .isEqualToComparingFieldByField(new Validator(3, Bytes.of(102)));
+        .usingRecursiveComparison()
+        .isEqualTo(new Validator(3, Bytes.of(102)));
   }
 
   @Test
@@ -56,8 +58,12 @@ public class ValidatorsDaoTest {
         validatorsDao.registerValidators(handle, List.of(Bytes.of(101), Bytes.of(102)));
 
     assertThat(validators.size()).isEqualTo(2);
-    assertThat(validators.get(0)).isEqualToComparingFieldByField(new Validator(1, Bytes.of(101)));
-    assertThat(validators.get(1)).isEqualToComparingFieldByField(new Validator(2, Bytes.of(102)));
+    assertThat(validators.get(0))
+        .usingRecursiveComparison()
+        .isEqualTo(new Validator(1, Bytes.of(101)));
+    assertThat(validators.get(1))
+        .usingRecursiveComparison()
+        .isEqualTo(new Validator(2, Bytes.of(102)));
   }
 
   @Test
@@ -81,11 +87,21 @@ public class ValidatorsDaoTest {
             .mapToBean(Validator.class)
             .list();
     assertThat(validators.size()).isEqualTo(5);
-    assertThat(validators.get(0)).isEqualToComparingFieldByField(new Validator(1, Bytes.of(100)));
-    assertThat(validators.get(1)).isEqualToComparingFieldByField(new Validator(2, Bytes.of(101)));
-    assertThat(validators.get(2)).isEqualToComparingFieldByField(new Validator(3, Bytes.of(102)));
-    assertThat(validators.get(3)).isEqualToComparingFieldByField(new Validator(4, Bytes.of(103)));
-    assertThat(validators.get(4)).isEqualToComparingFieldByField(new Validator(5, Bytes.of(104)));
+    assertThat(validators.get(0))
+        .usingRecursiveComparison()
+        .isEqualTo(new Validator(1, Bytes.of(100)));
+    assertThat(validators.get(1))
+        .usingRecursiveComparison()
+        .isEqualTo(new Validator(2, Bytes.of(101)));
+    assertThat(validators.get(2))
+        .usingRecursiveComparison()
+        .isEqualTo(new Validator(3, Bytes.of(102)));
+    assertThat(validators.get(3))
+        .usingRecursiveComparison()
+        .isEqualTo(new Validator(4, Bytes.of(103)));
+    assertThat(validators.get(4))
+        .usingRecursiveComparison()
+        .isEqualTo(new Validator(5, Bytes.of(104)));
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Replace usage of deprecated isEqualToComparingFieldByField in tests

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
