### PR TITLE
Suppress okthttp brotli CVE

### DIFF
--- a/gradle/owasp-suppression.xml
+++ b/gradle/owasp-suppression.xml
@@ -8,4 +8,11 @@
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
         <vulnerabilityName>CVE-2023-35116</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Suppress CVE-2023-3782 as Web3Signer doesn't use brotli and the NVD is incorrectly applying against all okhttp packages instead of just brotli one. See discussion in https://github.com/square/okhttp/issues/7738
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.squareup\.okhttp3/.*$</packageUrl>
+        <cve>CVE-2023-3782</cve>
+    </suppress>
 </suppressions>

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -176,7 +176,7 @@ dependencyManagement {
       com.squareup.okhttp3:logging-interceptor:4.9.0 // CVE-2021-0341
       \--- org.web3j:core:4.9.2
      */
-    dependency 'com.squareup.okhttp3:logging-interceptor:4.10.0'
+    dependency 'com.squareup.okhttp3:logging-interceptor:4.11.0'
 
     dependencySet(group: 'com.squareup.okhttp3', version: '4.11.0') {
       entry 'okhttp'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Suppress CVE-2023-3782 for okhttp brotli issue. Web3Signer does not use the brotli support in okhttp. But CVE incorrectly specifies all packages of okhttp. There is no fix for this CVE currently.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
