### PR TITLE
Lukso support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add Azure bulk loading for secp256k1 keys in eth1 mode [#850](https://github.com/Consensys/web3signer/pull/850)
 - Added Gnosis configuration for the 🦉 CAPELLA 🦉 network fork due at epoch 648704, UTC Tue 01/08/2023, 11:34:20 [#865](https://github.com/Consensys/web3signer/pull/865)
 - Java 17 for build and runtime. [#870](https://github.com/Consensys/web3signer/pull/870)
+- Support for Lukso network in Eth2 mode. `--network lukso`
 
 ### Bugs fixed
 - Support long name aliases in environment variables and YAML configuration [#825](https://github.com/Consensys/web3signer/pull/825)

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -90,7 +90,7 @@ dependencyManagement {
 
     dependency 'org.xipki.iaik:sunpkcs11-wrapper:1.4.9'
 
-    dependencySet(group: 'tech.pegasys.teku.internal', version: '23.6.2') {
+    dependencySet(group: 'tech.pegasys.teku.internal', version: '23.8.0') {
       entry ('bls') {
         exclude group: 'org.bouncycastle', name: 'bcprov-jdk15on'
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Teku `23.8.0` (https://github.com/Consensys/teku/releases/tag/23.8.0) now supports Lukso network (https://github.com/Consensys/teku/pull/7380). This PR aims to bump Teku config version to `23.8.0` so that it is also supported in Consensys web3signer.

## Fixed Issue(s)

No related issues

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

If this PR is merged, documentation needs to be updated in order to display `lukso` among the available values for flag `--network`

## Changelog

- [x] I added the necessary changelog entry

## Testing

- [ ] I thought about testing these changes in a realistic/non-local environment.
