### PR TITLE
Azure response timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Breaking Changes
 - Eth2 Signing request body: deprecating `signingRoot` in favor of `signing_root` property. `signingRoot` will be removed in a future release.
 
+### Features Added
+- Add `--azure-response-timeout` to allow request response timeout to be configurable, the field `timeout` is also accepted in the Azure metadata file. [#888](https://github.com/Consensys/web3signer/pull/888)
+
 ## 23.8.1
 
 ### Bugs fixed

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliAzureKeyVaultParameters.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/PicoCliAzureKeyVaultParameters.java
@@ -61,6 +61,12 @@ public abstract class PicoCliAzureKeyVaultParameters implements AzureKeyVaultPar
       paramLabel = "<CLIENT_SECRET>")
   private String clientSecret;
 
+  @Option(
+      names = {"--azure-response-timeout"},
+      description = "The response timeout to be used by the http client (in seconds)",
+      paramLabel = "<AZURE_RESPONSE_TIMEOUT>")
+  private long timeout = 60;
+
   @Override
   public boolean isAzureKeyVaultEnabled() {
     return azureKeyVaultEnabled;
@@ -89,5 +95,10 @@ public abstract class PicoCliAzureKeyVaultParameters implements AzureKeyVaultPar
   @Override
   public String getClientSecret() {
     return clientSecret;
+  }
+
+  @Override
+  public long getTimeout() {
+    return timeout;
   }
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -223,7 +223,8 @@ public class Eth1Runner extends Runner {
               azureKeyVaultConfig.getClientSecret(),
               azureKeyVaultConfig.getKeyVaultName(),
               azureKeyVaultConfig.getTenantId(),
-              azureKeyVaultConfig.getAuthenticationMode());
+              azureKeyVaultConfig.getAuthenticationMode(),
+              azureKeyVaultConfig.getTimeout());
       final SecpAzureBulkLoader secpAzureBulkLoader =
           new SecpAzureBulkLoader(azureKeyVault, azureSignerFactory);
       final MappedResults<ArtifactSigner> azureResult =

--- a/keystorage/src/test/java/tech/pegasys/web3signer/keystorage/azure/AzureKeyVaultTest.java
+++ b/keystorage/src/test/java/tech/pegasys/web3signer/keystorage/azure/AzureKeyVaultTest.java
@@ -45,6 +45,7 @@ public class AzureKeyVaultTest {
   private static final String EXPECTED_KEY2 =
       "0x5aba5b89c1d8b731dba1ba29128a4070df0dbfd7e0a67edb40ae7f860cd3ca1c";
   private final ExecutorService azureExecutor = Executors.newCachedThreadPool();
+  private final long AZURE_DEFAULT_TIMEOUT = 60;
 
   @BeforeAll
   public static void setup() {
@@ -58,7 +59,7 @@ public class AzureKeyVaultTest {
   void fetchExistingSecretKeyFromAzureVault() {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(
-            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor);
+            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor, AZURE_DEFAULT_TIMEOUT);
     final Optional<String> hexKey = azureKeyVault.fetchSecret(SECRET_NAME);
     Assertions.assertThat(hexKey).isNotEmpty().get().isEqualTo(EXPECTED_KEY);
   }
@@ -67,7 +68,7 @@ public class AzureKeyVaultTest {
   void connectingWithInvalidClientSecretThrowsException() {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(
-            CLIENT_ID, "invalid", TENANT_ID, VAULT_NAME, azureExecutor);
+            CLIENT_ID, "invalid", TENANT_ID, VAULT_NAME, azureExecutor, AZURE_DEFAULT_TIMEOUT);
     Assertions.assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> azureKeyVault.fetchSecret(SECRET_NAME))
         .withMessageContaining("Invalid client secret");
@@ -77,7 +78,7 @@ public class AzureKeyVaultTest {
   void connectingWithInvalidClientIdThrowsException() {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(
-            "invalid", CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor);
+            "invalid", CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor, AZURE_DEFAULT_TIMEOUT);
     Assertions.assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> azureKeyVault.fetchSecret(SECRET_NAME))
         .withMessageContaining(
@@ -88,7 +89,7 @@ public class AzureKeyVaultTest {
   void nonExistingSecretReturnEmpty() {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(
-            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor);
+            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor, AZURE_DEFAULT_TIMEOUT);
     assertThat(azureKeyVault.fetchSecret("X-" + SECRET_NAME)).isEmpty();
   }
 
@@ -96,7 +97,7 @@ public class AzureKeyVaultTest {
   void secretsCanBeMappedUsingCustomMappingFunction() {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(
-            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor);
+            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor, AZURE_DEFAULT_TIMEOUT);
 
     final MappedResults<SimpleEntry<String, String>> result =
         azureKeyVault.mapSecrets(SimpleEntry::new, Collections.emptyMap());
@@ -113,7 +114,7 @@ public class AzureKeyVaultTest {
   void keyPropertiesCanBeMappedUsingCustomMappingFunction() {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(
-            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor);
+            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor, AZURE_DEFAULT_TIMEOUT);
 
     final MappedResults<String> result =
         azureKeyVault.mapKeyProperties(KeyProperties::getName, Collections.emptyMap());
@@ -128,7 +129,7 @@ public class AzureKeyVaultTest {
   void mapSecretsUsingTags() {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(
-            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor);
+            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor, AZURE_DEFAULT_TIMEOUT);
 
     final MappedResults<SimpleEntry<String, String>> result =
         azureKeyVault.mapSecrets(SimpleEntry::new, Map.of("ENV", "TEST"));
@@ -150,7 +151,7 @@ public class AzureKeyVaultTest {
   void mapKeyPropertiesUsingTags() {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(
-            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor);
+            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor, AZURE_DEFAULT_TIMEOUT);
 
     final MappedResults<String> result =
         azureKeyVault.mapKeyProperties(KeyProperties::getName, Map.of("ENV", "TEST"));
@@ -165,7 +166,7 @@ public class AzureKeyVaultTest {
   void mapSecretsWhenTagsDoesNotExist() {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(
-            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor);
+            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor, AZURE_DEFAULT_TIMEOUT);
 
     final MappedResults<SimpleEntry<String, String>> result =
         azureKeyVault.mapSecrets(SimpleEntry::new, Map.of("INVALID_TAG", "INVALID_TEST"));
@@ -181,7 +182,7 @@ public class AzureKeyVaultTest {
   void mapKeyPropertiesWhenTagsDoesNotExist() {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(
-            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor);
+            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor, AZURE_DEFAULT_TIMEOUT);
 
     final MappedResults<String> result =
         azureKeyVault.mapKeyProperties(
@@ -198,7 +199,7 @@ public class AzureKeyVaultTest {
   void mapSecretsThrowsAwayObjectsWhichFailMapper() {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(
-            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor);
+            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor, AZURE_DEFAULT_TIMEOUT);
 
     final MappedResults<SimpleEntry<String, String>> result =
         azureKeyVault.mapSecrets(
@@ -226,7 +227,7 @@ public class AzureKeyVaultTest {
   void mapKeyPropertiesThrowsAwayObjectsWhichFailMapper() {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(
-            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor);
+            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor, AZURE_DEFAULT_TIMEOUT);
 
     final MappedResults<String> result =
         azureKeyVault.mapKeyProperties(
@@ -255,7 +256,7 @@ public class AzureKeyVaultTest {
   void mapSecretsThrowsAwayObjectsWhichMapToNull() {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(
-            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor);
+            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor, AZURE_DEFAULT_TIMEOUT);
 
     final MappedResults<SimpleEntry<String, String>> result =
         azureKeyVault.mapSecrets(
@@ -282,7 +283,7 @@ public class AzureKeyVaultTest {
   void mapKeyPropertiesThrowsAwayObjectsWhichMapToNull() {
     final AzureKeyVault azureKeyVault =
         createUsingClientSecretCredentials(
-            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor);
+            CLIENT_ID, CLIENT_SECRET, TENANT_ID, VAULT_NAME, azureExecutor, AZURE_DEFAULT_TIMEOUT);
 
     final MappedResults<String> result =
         azureKeyVault.mapKeyProperties(

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/bulkloading/SecpAzureBulkLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/bulkloading/SecpAzureBulkLoader.java
@@ -46,6 +46,7 @@ public class SecpAzureBulkLoader {
                 keyName,
                 azureKeyVaultParameters.getClientId(),
                 azureKeyVaultParameters.getClientSecret(),
-                azureKeyVaultParameters.getTenantId())));
+                azureKeyVaultParameters.getTenantId(),
+                azureKeyVaultParameters.getTimeout())));
   }
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/AzureKeyVaultFactory.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/AzureKeyVaultFactory.java
@@ -31,7 +31,8 @@ public class AzureKeyVaultFactory implements AutoCloseable {
         azureKeyVaultParameters.getClientSecret(),
         azureKeyVaultParameters.getKeyVaultName(),
         azureKeyVaultParameters.getTenantId(),
-        azureKeyVaultParameters.getAuthenticationMode());
+        azureKeyVaultParameters.getAuthenticationMode(),
+        azureKeyVaultParameters.getTimeout());
   }
 
   public AzureKeyVault createAzureKeyVault(
@@ -39,15 +40,23 @@ public class AzureKeyVaultFactory implements AutoCloseable {
       final String clientSecret,
       final String keyVaultName,
       final String tenantId,
-      final AzureAuthenticationMode mode) {
+      final AzureAuthenticationMode mode,
+      final long httpClientTimeout) {
     switch (mode) {
       case USER_ASSIGNED_MANAGED_IDENTITY:
-        return AzureKeyVault.createUsingManagedIdentity(Optional.of(clientId), keyVaultName);
+        return AzureKeyVault.createUsingManagedIdentity(
+            Optional.of(clientId), keyVaultName, httpClientTimeout);
       case SYSTEM_ASSIGNED_MANAGED_IDENTITY:
-        return AzureKeyVault.createUsingManagedIdentity(Optional.empty(), keyVaultName);
+        return AzureKeyVault.createUsingManagedIdentity(
+            Optional.empty(), keyVaultName, httpClientTimeout);
       default:
         return AzureKeyVault.createUsingClientSecretCredentials(
-            clientId, clientSecret, tenantId, keyVaultName, getOrCreateExecutor());
+            clientId,
+            clientSecret,
+            tenantId,
+            keyVaultName,
+            getOrCreateExecutor(),
+            httpClientTimeout);
     }
   }
 

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/AzureKeyVaultParameters.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/AzureKeyVaultParameters.java
@@ -29,4 +29,6 @@ public interface AzureKeyVaultParameters {
   String getClientSecret();
 
   Map<String, String> getTags();
+
+  long getTimeout();
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AzureKeySigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AzureKeySigningMetadata.java
@@ -25,6 +25,7 @@ public class AzureKeySigningMetadata extends SigningMetadata {
   private final String tenantId;
   private final String vaultName;
   private final String keyName;
+  private final long timeout;
 
   @JsonCreator
   public AzureKeySigningMetadata(
@@ -33,13 +34,15 @@ public class AzureKeySigningMetadata extends SigningMetadata {
       @JsonProperty("tenantId") final String tenantId,
       @JsonProperty("vaultName") final String vaultName,
       @JsonProperty("keyName") final String keyName,
-      @JsonProperty(value = "keyType") final KeyType keyType) {
+      @JsonProperty(value = "keyType") final KeyType keyType,
+      @JsonProperty(value = "timeout") final long timeout) {
     super(TYPE, keyType != null ? keyType : KeyType.SECP256K1);
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.tenantId = tenantId;
     this.vaultName = vaultName;
     this.keyName = keyName;
+    this.timeout = (timeout != 0) ? timeout : 60;
   }
 
   public String getClientId() {
@@ -60,6 +63,10 @@ public class AzureKeySigningMetadata extends SigningMetadata {
 
   public String getKeyName() {
     return keyName;
+  }
+
+  public long getTimeout() {
+    return timeout;
   }
 
   @Override

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AzureSecretSigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AzureSecretSigningMetadata.java
@@ -31,6 +31,7 @@ public class AzureSecretSigningMetadata extends SigningMetadata implements Azure
   private final String vaultName;
   private final String secretName;
   private final AzureAuthenticationMode authenticationMode;
+  private final long timeout;
 
   public AzureSecretSigningMetadata(
       final String clientId,
@@ -39,7 +40,8 @@ public class AzureSecretSigningMetadata extends SigningMetadata implements Azure
       final String vaultName,
       final String secretName,
       final AzureAuthenticationMode azureAuthenticationMode,
-      final KeyType keyType) {
+      final KeyType keyType,
+      final long timeout) {
     super(TYPE, keyType != null ? keyType : KeyType.BLS);
     this.clientId = clientId;
     this.clientSecret = clientSecret;
@@ -50,6 +52,7 @@ public class AzureSecretSigningMetadata extends SigningMetadata implements Azure
         azureAuthenticationMode == null
             ? AzureAuthenticationMode.CLIENT_SECRET
             : azureAuthenticationMode;
+    this.timeout = timeout;
   }
 
   @Override
@@ -96,5 +99,10 @@ public class AzureSecretSigningMetadata extends SigningMetadata implements Azure
     // tags support is not applicable for config file mode as
     // user is already providing the secret name to load the secret from.
     return Collections.emptyMap();
+  }
+
+  @Override
+  public long getTimeout() {
+    return timeout;
   }
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AzureSecretSigningMetadataDeserializer.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AzureSecretSigningMetadataDeserializer.java
@@ -36,6 +36,7 @@ public class AzureSecretSigningMetadataDeserializer
   private static final String SECRET_NAME = "secretName";
   private static final String AUTH_MODE = "authenticationMode";
   private static final String KEY_TYPE = "keyType";
+  private static final String TIMEOUT = "timeout";
 
   @SuppressWarnings("Unused")
   public AzureSecretSigningMetadataDeserializer() {
@@ -55,6 +56,8 @@ public class AzureSecretSigningMetadataDeserializer
     String tenantId = null;
     String vaultName = null;
     String secretName = null;
+    long timeout = 60;
+
     AzureAuthenticationMode authenticationMode = null;
 
     final JsonNode node = parser.getCodec().readTree(parser);
@@ -94,10 +97,20 @@ public class AzureSecretSigningMetadataDeserializer
     if (node.get(CLIENT_SECRET) != null) {
       clientSecret = node.get(CLIENT_SECRET).asText();
     }
+    if (node.get(TIMEOUT) != null) {
+      timeout = node.get(TIMEOUT).asLong();
+    }
 
     final AzureSecretSigningMetadata azureSecretSigningMetadata =
         new AzureSecretSigningMetadata(
-            clientId, clientSecret, tenantId, vaultName, secretName, authenticationMode, keyType);
+            clientId,
+            clientSecret,
+            tenantId,
+            vaultName,
+            secretName,
+            authenticationMode,
+            keyType,
+            timeout);
 
     validate(parser, azureSecretSigningMetadata);
 

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/Secp256k1ArtifactSignerFactory.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/Secp256k1ArtifactSignerFactory.java
@@ -108,7 +108,8 @@ public class Secp256k1ArtifactSignerFactory extends AbstractArtifactSignerFactor
             "",
             azureSigningMetadata.getClientId(),
             azureSigningMetadata.getClientSecret(),
-            azureSigningMetadata.getTenantId());
+            azureSigningMetadata.getTenantId(),
+            azureSigningMetadata.getTimeout());
 
     return signerFactory.apply(azureCloudSignerFactory.createSigner(config));
   }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/secp256k1/azure/AzureConfig.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/secp256k1/azure/AzureConfig.java
@@ -23,6 +23,7 @@ public class AzureConfig {
   private final String tenantId;
   // empty string means latest in azure
   private static final String KEY_LATEST_VERSION = "";
+  private final long timeout;
 
   @JsonCreator
   public AzureConfig(
@@ -31,13 +32,15 @@ public class AzureConfig {
       final String keyVersion,
       final String clientId,
       final String clientSecret,
-      final String tenantId) {
+      final String tenantId,
+      final long timeout) {
     this.keyVaultName = keyVaultName;
     this.keyName = keyName;
     this.keyVersion = keyVersion;
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.tenantId = tenantId;
+    this.timeout = timeout;
   }
 
   public AzureConfig(
@@ -45,8 +48,9 @@ public class AzureConfig {
       final String keyName,
       final String clientId,
       final String clientSecret,
-      final String tenantId) {
-    this(keyVaultName, keyName, KEY_LATEST_VERSION, clientId, clientSecret, tenantId);
+      final String tenantId,
+      final long timeout) {
+    this(keyVaultName, keyName, KEY_LATEST_VERSION, clientId, clientSecret, tenantId, timeout);
   }
 
   public String getKeyVaultName() {
@@ -71,5 +75,9 @@ public class AzureConfig {
 
   public String getTenantId() {
     return tenantId;
+  }
+
+  public long getTimeout() {
+    return timeout;
   }
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/secp256k1/azure/AzureKeyVaultSignerFactory.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/secp256k1/azure/AzureKeyVaultSignerFactory.java
@@ -58,7 +58,8 @@ public class AzureKeyVaultSignerFactory {
               config.getClientSecret(),
               config.getKeyVaultName(),
               config.getTenantId(),
-              AzureAuthenticationMode.CLIENT_SECRET);
+              AzureAuthenticationMode.CLIENT_SECRET,
+              config.getTimeout());
     } catch (final Exception e) {
       LOG.error("Failed to connect to vault", e);
       throw new SignerInitializationException(INACCESSIBLE_KEY_ERROR, e);

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/config/AzureKeyVaultFactoryTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/config/AzureKeyVaultFactoryTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 class AzureKeyVaultFactoryTest {
   final AzureKeyVaultFactory azureKeyVaultFactory = new AzureKeyVaultFactory();
+  final long DEFAULT_AZURE_TIMEOUT = 60;
 
   @AfterEach
   void shutdownExecutor() {
@@ -39,7 +40,8 @@ class AzureKeyVaultFactoryTest {
         "clientSecret",
         "keyVaultName",
         "tenantId",
-        AzureAuthenticationMode.CLIENT_SECRET);
+        AzureAuthenticationMode.CLIENT_SECRET,
+        DEFAULT_AZURE_TIMEOUT);
     assertThat(azureKeyVaultFactory.getExecutorServiceCache().get()).isNotNull();
   }
 
@@ -50,7 +52,8 @@ class AzureKeyVaultFactoryTest {
         "clientSecret",
         "keyVaultName",
         "tenantId",
-        AzureAuthenticationMode.CLIENT_SECRET);
+        AzureAuthenticationMode.CLIENT_SECRET,
+        DEFAULT_AZURE_TIMEOUT);
     final ExecutorService executorService = azureKeyVaultFactory.getExecutorServiceCache().get();
     assertThat(executorService).isNotNull();
 
@@ -59,7 +62,8 @@ class AzureKeyVaultFactoryTest {
         "clientSecret",
         "keyVaultName",
         "tenantId",
-        AzureAuthenticationMode.CLIENT_SECRET);
+        AzureAuthenticationMode.CLIENT_SECRET,
+        DEFAULT_AZURE_TIMEOUT);
     final ExecutorService executorService2 = azureKeyVaultFactory.getExecutorServiceCache().get();
     assertThat(executorService).isSameAs(executorService2);
   }
@@ -71,7 +75,8 @@ class AzureKeyVaultFactoryTest {
         "clientSecret",
         "keyVaultName",
         "tenantId",
-        AzureAuthenticationMode.USER_ASSIGNED_MANAGED_IDENTITY);
+        AzureAuthenticationMode.USER_ASSIGNED_MANAGED_IDENTITY,
+        DEFAULT_AZURE_TIMEOUT);
     assertThat(azureKeyVaultFactory.getExecutorServiceCache().get()).isNull();
   }
 
@@ -82,7 +87,8 @@ class AzureKeyVaultFactoryTest {
         "clientSecret",
         "keyVaultName",
         "tenantId",
-        AzureAuthenticationMode.SYSTEM_ASSIGNED_MANAGED_IDENTITY);
+        AzureAuthenticationMode.SYSTEM_ASSIGNED_MANAGED_IDENTITY,
+        DEFAULT_AZURE_TIMEOUT);
     assertThat(azureKeyVaultFactory.getExecutorServiceCache().get()).isNull();
   }
 
@@ -93,7 +99,8 @@ class AzureKeyVaultFactoryTest {
         "clientSecret",
         "keyVaultName",
         "tenantId",
-        AzureAuthenticationMode.CLIENT_SECRET);
+        AzureAuthenticationMode.CLIENT_SECRET,
+        DEFAULT_AZURE_TIMEOUT);
     final ExecutorService executorService = azureKeyVaultFactory.getExecutorServiceCache().get();
     assertThat(executorService).isNotNull();
 

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/secp256k1/azure/AzureKeyVaultSignerTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/secp256k1/azure/AzureKeyVaultSignerTest.java
@@ -43,6 +43,7 @@ public class AzureKeyVaultSignerTest {
 
   private static final String KEY_NAME = "TestKey2"; // uses curve name P-256K
   private static final String UNSUPPORTED_CURVE_KEY_NAME = "TestKeyP521";
+  private static final long AZURE_DEFAULT_TIMEOUT = 60;
 
   @BeforeAll
   static void preChecks() {
@@ -59,7 +60,12 @@ public class AzureKeyVaultSignerTest {
   void azureSignerCanSign() throws SignatureException {
     final AzureConfig config =
         new AzureConfig(
-            AZURE_KEY_VAULT_NAME, KEY_NAME, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID);
+            AZURE_KEY_VAULT_NAME,
+            KEY_NAME,
+            AZURE_CLIENT_ID,
+            AZURE_CLIENT_SECRET,
+            AZURE_TENANT_ID,
+            AZURE_DEFAULT_TIMEOUT);
 
     final Signer azureNonHashedDataSigner =
         new AzureKeyVaultSignerFactory(new AzureKeyVaultFactory(), new AzureHttpClientFactory())
@@ -92,7 +98,8 @@ public class AzureKeyVaultSignerTest {
             "",
             AZURE_CLIENT_ID,
             AZURE_CLIENT_SECRET,
-            AZURE_TENANT_ID);
+            AZURE_TENANT_ID,
+            AZURE_DEFAULT_TIMEOUT);
 
     final AzureKeyVaultSignerFactory factory =
         new AzureKeyVaultSignerFactory(new AzureKeyVaultFactory(), new AzureHttpClientFactory());

--- a/signing/src/testFixtures/java/tech/pegasys/web3signer/signing/config/DefaultAzureKeyVaultParameters.java
+++ b/signing/src/testFixtures/java/tech/pegasys/web3signer/signing/config/DefaultAzureKeyVaultParameters.java
@@ -18,19 +18,28 @@ import java.util.Map;
 
 public class DefaultAzureKeyVaultParameters implements AzureKeyVaultParameters {
 
+  private static long AZURE_DEFAULT_TIMEOUT = 60;
+
   private final String keyVaultName;
   private final AzureAuthenticationMode authenticationMode;
   private final String clientId;
   private final String tenantId;
   private final String clientSecret;
   private final Map<String, String> tags = new HashMap<>();
+  private final long timeout;
 
   public DefaultAzureKeyVaultParameters(
       final String keyVaultName,
       final String clientId,
       final String tenantId,
       final String clientSecret) {
-    this(keyVaultName, clientId, tenantId, clientSecret, Collections.emptyMap());
+    this(
+        keyVaultName,
+        clientId,
+        tenantId,
+        clientSecret,
+        Collections.emptyMap(),
+        AZURE_DEFAULT_TIMEOUT);
   }
 
   public DefaultAzureKeyVaultParameters(
@@ -39,12 +48,23 @@ public class DefaultAzureKeyVaultParameters implements AzureKeyVaultParameters {
       final String tenantId,
       final String clientSecret,
       final Map<String, String> tags) {
+    this(keyVaultName, clientId, tenantId, clientSecret, tags, AZURE_DEFAULT_TIMEOUT);
+  }
+
+  public DefaultAzureKeyVaultParameters(
+      final String keyVaultName,
+      final String clientId,
+      final String tenantId,
+      final String clientSecret,
+      final Map<String, String> tags,
+      final long timeout) {
     this.keyVaultName = keyVaultName;
     this.clientId = clientId;
     this.tenantId = tenantId;
     this.clientSecret = clientSecret;
     this.authenticationMode = AzureAuthenticationMode.CLIENT_SECRET;
     this.tags.putAll(tags);
+    this.timeout = timeout;
   }
 
   @Override
@@ -80,5 +100,10 @@ public class DefaultAzureKeyVaultParameters implements AzureKeyVaultParameters {
   @Override
   public Map<String, String> getTags() {
     return tags;
+  }
+
+  @Override
+  public long getTimeout() {
+    return timeout;
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
This PR adds a CLI option to customise the timeout of the http client used in Azure KeyVault library. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #797 
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
