### PR TITLE
Prevent signing at or beyond high watermark

### DIFF
--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/HighWatermark.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/HighWatermark.java
@@ -57,4 +57,9 @@ public class HighWatermark {
   public int hashCode() {
     return Objects.hash(slot, epoch);
   }
+
+  @Override
+  public String toString() {
+    return "HighWatermark{" + "slot=" + slot + ", epoch=" + epoch + '}';
+  }
 }

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/AttestationImporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/AttestationImporter.java
@@ -13,6 +13,7 @@
 package tech.pegasys.web3signer.slashingprotection.interchange;
 
 import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
+import tech.pegasys.web3signer.slashingprotection.dao.MetadataDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestationsDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SigningWatermark;
 import tech.pegasys.web3signer.slashingprotection.dao.Validator;
@@ -36,6 +37,7 @@ public class AttestationImporter {
   private final OptionalMinValueTracker minSourceTracker = new OptionalMinValueTracker();
   private final OptionalMinValueTracker minTargetTracker = new OptionalMinValueTracker();
   private final LowWatermarkDao lowWatermarkDao;
+  private final MetadataDao metadataDao;
   private final SignedAttestationsDao signedAttestationsDao;
   private final Validator validator;
   private final Handle handle;
@@ -46,11 +48,13 @@ public class AttestationImporter {
       final Handle handle,
       final ObjectMapper mapper,
       final LowWatermarkDao lowWatermarkDao,
+      final MetadataDao metadataDao,
       final SignedAttestationsDao signedAttestationsDao) {
     this.validator = validator;
     this.handle = handle;
     this.mapper = mapper;
     this.lowWatermarkDao = lowWatermarkDao;
+    this.metadataDao = metadataDao;
     this.signedAttestationsDao = signedAttestationsDao;
   }
 
@@ -68,7 +72,8 @@ public class AttestationImporter {
               jsonAttestation.getTargetEpoch(),
               validator.getId(),
               signedAttestationsDao,
-              lowWatermarkDao);
+              lowWatermarkDao,
+              metadataDao);
 
       final String attestationIdentifierString =
           String.format("Attestation with index %d for validator %s", i, validator.getPublicKey());

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/BlockImporter.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/BlockImporter.java
@@ -13,6 +13,7 @@
 package tech.pegasys.web3signer.slashingprotection.interchange;
 
 import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
+import tech.pegasys.web3signer.slashingprotection.dao.MetadataDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedBlocksDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SigningWatermark;
 import tech.pegasys.web3signer.slashingprotection.dao.Validator;
@@ -35,6 +36,7 @@ public class BlockImporter {
 
   private final OptionalMinValueTracker minSlotTracker = new OptionalMinValueTracker();
   private final LowWatermarkDao lowWatermarkDao;
+  private final MetadataDao metadataDao;
   private final SignedBlocksDao signedBlocksDao;
   private final Validator validator;
   private final Handle handle;
@@ -45,11 +47,13 @@ public class BlockImporter {
       final Handle handle,
       final ObjectMapper mapper,
       final LowWatermarkDao lowWatermarkDao,
+      final MetadataDao metadataDao,
       final SignedBlocksDao signedBlocksDao) {
     this.validator = validator;
     this.handle = handle;
     this.mapper = mapper;
     this.lowWatermarkDao = lowWatermarkDao;
+    this.metadataDao = metadataDao;
     this.signedBlocksDao = signedBlocksDao;
   }
 
@@ -64,7 +68,8 @@ public class BlockImporter {
               jsonBlock.getSlot(),
               validator.getId(),
               signedBlocksDao,
-              lowWatermarkDao);
+              lowWatermarkDao,
+              metadataDao);
 
       final String blockIdentifierString =
           String.format("Block with index %d for validator %s", i, validator.getPublicKey());

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Importer.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/interchange/InterchangeV5Importer.java
@@ -154,7 +154,8 @@ public class InterchangeV5Importer {
       throws JsonProcessingException {
 
     final BlockImporter blockImporter =
-        new BlockImporter(validator, handle, JSON_MAPPER, lowWatermarkDao, signedBlocksDao);
+        new BlockImporter(
+            validator, handle, JSON_MAPPER, lowWatermarkDao, metadataDao, signedBlocksDao);
     blockImporter.importFrom(signedBlocksNode);
   }
 
@@ -164,7 +165,7 @@ public class InterchangeV5Importer {
 
     final AttestationImporter attestationImporter =
         new AttestationImporter(
-            validator, handle, JSON_MAPPER, lowWatermarkDao, signedAttestationsDao);
+            validator, handle, JSON_MAPPER, lowWatermarkDao, metadataDao, signedAttestationsDao);
 
     attestationImporter.importFrom(signedAttestationNode);
   }

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import tech.pegasys.web3signer.slashingprotection.dao.HighWatermark;
 import tech.pegasys.web3signer.slashingprotection.dao.LowWatermarkDao;
 import tech.pegasys.web3signer.slashingprotection.dao.MetadataDao;
 import tech.pegasys.web3signer.slashingprotection.dao.SignedAttestation;
@@ -150,6 +151,21 @@ public class DbSlashingProtectionTest {
   }
 
   @Test
+  public void blockCannotSignWhenSlotIsAtOrBeyondHighWatermark() {
+    final SignedBlock signedBlock = new SignedBlock(VALIDATOR_ID, SLOT, SIGNING_ROOT);
+    when(metadataDao.findHighWatermark(any()))
+        // current equals high-watermark
+        .thenReturn(Optional.of(new HighWatermark(SLOT, null)))
+        // current beyond high-watermark
+        .thenReturn(Optional.of(new HighWatermark(SLOT.subtract(1L), null)));
+
+    assertThat(dbSlashingProtection.maySignBlock(PUBLIC_KEY1, SIGNING_ROOT, SLOT, GVR)).isFalse();
+    assertThat(dbSlashingProtection.maySignBlock(PUBLIC_KEY1, SIGNING_ROOT, SLOT, GVR)).isFalse();
+
+    verify(signedBlocksDao, never()).insertBlockProposal(any(), refEq(signedBlock));
+  }
+
+  @Test
   public void blockCannotSignWhenNoRegisteredValidator(final Jdbi jdbi) {
     final DbSlashingProtection dbSlashingProtection =
         new DbSlashingProtection(
@@ -236,6 +252,50 @@ public class DbSlashingProtectionTest {
         .isFalse();
     verify(signedAttestationsDao, never()).insertAttestation(any(), refEq(attestation));
     verify(lowWatermarkDao).findLowWatermarkForValidator(any(), eq(VALIDATOR_ID));
+  }
+
+  @Test
+  public void cannotSignAttestationWhenSourceIsAtOrBeyondHighWatermark() {
+    final SignedAttestation attestation =
+        new SignedAttestation(VALIDATOR_ID, SOURCE_EPOCH, SOURCE_EPOCH, SIGNING_ROOT);
+    when(metadataDao.findHighWatermark(any()))
+        // current equals at high-watermark
+        .thenReturn(Optional.of(new HighWatermark(null, SOURCE_EPOCH)))
+        // current beyond high-watermark
+        .thenReturn(Optional.of(new HighWatermark(null, SOURCE_EPOCH.subtract(1L))));
+
+    assertThat(
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, SOURCE_EPOCH, GVR))
+        .isFalse();
+    assertThat(
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, SOURCE_EPOCH, GVR))
+        .isFalse();
+
+    verify(signedAttestationsDao, never()).insertAttestation(any(), refEq(attestation));
+  }
+
+  @Test
+  public void cannotSignAttestationWhenTargetIsAtOrBeyondHighWatermark() {
+    final SignedAttestation attestation =
+        new SignedAttestation(VALIDATOR_ID, SOURCE_EPOCH, TARGET_EPOCH, SIGNING_ROOT);
+    when(metadataDao.findHighWatermark(any()))
+        // current equals at high-watermark
+        .thenReturn(Optional.of(new HighWatermark(null, TARGET_EPOCH)))
+        // current beyond high-watermark
+        .thenReturn(Optional.of(new HighWatermark(null, TARGET_EPOCH.subtract(1L))));
+
+    assertThat(
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, TARGET_EPOCH, GVR))
+        .isFalse();
+    assertThat(
+            dbSlashingProtection.maySignAttestation(
+                PUBLIC_KEY1, SIGNING_ROOT, SOURCE_EPOCH, TARGET_EPOCH, GVR))
+        .isFalse();
+
+    verify(signedAttestationsDao, never()).insertAttestation(any(), refEq(attestation));
   }
 
   @Test

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/DbSlashingProtectionTest.java
@@ -166,7 +166,7 @@ public class DbSlashingProtectionTest {
   }
 
   @Test
-  public void blockCanSignWhenSlotIsAtOrBeyondHighWatermark() {
+  public void blockCanSignWhenSlotIsBelowHighWatermark() {
     final SignedBlock signedBlock = new SignedBlock(VALIDATOR_ID, SLOT, SIGNING_ROOT);
     when(metadataDao.findHighWatermark(any()))
         .thenReturn(Optional.of(new HighWatermark(SLOT.add(1L), null)));


### PR DESCRIPTION
Prevent signing at or beyond high watermark for both blocks and attestations.

Part of https://github.com/Consensys/web3signer/issues/696#issuecomment-1699947083

(previously tracked on https://github.com/siladu/web3signer/pull/1)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [ ] I thought about testing these changes in a realistic/non-local environment.
