### PR TITLE
Remove --validator-ids option from watermark-repair subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 23.9.1
+
+### Breaking Changes
+- Remove --validator-ids option from watermark-repair subcommand [#909](https://github.com/Consensys/web3signer/pull/909)
+
+---
 ## 23.9.0
 
 ### Features Added

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
@@ -43,7 +43,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 
@@ -547,14 +546,6 @@ public class CmdLineParamsConfigFileImpl implements CmdLineParamsBuilder {
                         uri)));
 
     return yamlConfig.toString();
-  }
-
-  private String formatStringList(final String key, final List<String> stringList) {
-    return stringList.isEmpty()
-        ? String.format("%s: []%n", key)
-        : String.format(
-            "%s: [\"%s\"]%n",
-            key, stringList.stream().map(s -> "\"" + s + "\"").collect(Collectors.joining(",")));
   }
 
   private static class CommandArgs {

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
@@ -268,9 +268,6 @@ public class CmdLineParamsConfigFileImpl implements CmdLineParamsBuilder {
               YAML_NUMERIC_FMT,
               "eth2.watermark-repair.epoch",
               watermarkRepairParameters.getEpoch()));
-      yamlConfig.append(
-          formatStringList(
-              "eth2.watermark-repair.validator-ids", watermarkRepairParameters.getValidators()));
     }
 
     return new CommandArgs(params, yamlConfig.toString());

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
@@ -392,10 +392,6 @@ public class CmdLineParamsDefaultImpl implements CmdLineParamsBuilder {
       params.add(Long.toString(watermarkRepairParameters.getEpoch()));
       params.add("--slot");
       params.add(Long.toString(watermarkRepairParameters.getSlot()));
-      if (!watermarkRepairParameters.getValidators().isEmpty()) {
-        params.add(
-            "--validator-ids" + "=" + String.join(",", watermarkRepairParameters.getValidators()));
-      }
     }
 
     return params;


### PR DESCRIPTION
Updating a subset validators is not a used feature as far as we know.

This ensures all validators are updated by the subcommand. Preparing for adding high-watermark features to the watermark-repair subcommand.

Part of #696 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
