### PR TITLE
Aws KMS acceptance test fix

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AwsKmsAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AwsKmsAcceptanceTest.java
@@ -109,6 +109,7 @@ public class AwsKmsAcceptanceTest extends AcceptanceTestBase {
   void keysAreLoadedFromAwsKmsAndReportedByPublicApi(final boolean useConfigFile) {
     final AwsVaultParameters awsVaultParameters =
         AwsVaultParametersBuilder.anAwsParameters()
+            .withEnabled(true)
             .withAuthenticationMode(AwsAuthenticationMode.SPECIFIED)
             .withRegion(AWS_REGION)
             .withAccessKeyId(RO_AWS_ACCESS_KEY_ID)
@@ -150,6 +151,7 @@ public class AwsKmsAcceptanceTest extends AcceptanceTestBase {
     final boolean useConfigFile = false;
     final AwsVaultParameters invalidCredsParams =
         AwsVaultParametersBuilder.anAwsParameters()
+            .withEnabled(true)
             .withAuthenticationMode(AwsAuthenticationMode.SPECIFIED)
             .withRegion("us-east-2")
             .withAccessKeyId("invalid")
@@ -195,6 +197,7 @@ public class AwsKmsAcceptanceTest extends AcceptanceTestBase {
       final boolean useConfigFile) {
     final AwsVaultParameters awsVaultParameters =
         AwsVaultParametersBuilder.anAwsParameters()
+            .withEnabled(true)
             .withAuthenticationMode(AwsAuthenticationMode.ENVIRONMENT)
             .withTagNamesFilter(List.of("TagName2", "TagName3"))
             .withTagValuesFilter(List.of("TagValue0", "TagValue2", "TagValue3"))

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AwsSecretsManagerAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AwsSecretsManagerAcceptanceTest.java
@@ -107,6 +107,7 @@ public class AwsSecretsManagerAcceptanceTest extends AcceptanceTestBase {
   void secretsAreLoadedFromAWSSecretsManagerAndReportedByPublicApi(final boolean useConfigFile) {
     final AwsVaultParameters awsVaultParameters =
         AwsVaultParametersBuilder.anAwsParameters()
+            .withEnabled(true)
             .withAuthenticationMode(AwsAuthenticationMode.SPECIFIED)
             .withRegion(AWS_REGION)
             .withAccessKeyId(RO_AWS_ACCESS_KEY_ID)
@@ -149,6 +150,7 @@ public class AwsSecretsManagerAcceptanceTest extends AcceptanceTestBase {
     final boolean useConfigFile = false;
     final AwsVaultParameters invalidCredsParams =
         AwsVaultParametersBuilder.anAwsParameters()
+            .withEnabled(true)
             .withAuthenticationMode(AwsAuthenticationMode.SPECIFIED)
             .withRegion("us-east-2")
             .withAccessKeyId("invalid")
@@ -181,6 +183,7 @@ public class AwsSecretsManagerAcceptanceTest extends AcceptanceTestBase {
       final boolean useConfigFile) {
     final AwsVaultParameters awsVaultParameters =
         AwsVaultParametersBuilder.anAwsParameters()
+            .withEnabled(true)
             .withAuthenticationMode(AwsAuthenticationMode.ENVIRONMENT)
             .withPrefixesFilter(List.of(awsSecretsManagerUtil.getSecretsManagerPrefix()))
             .withTagNamesFilter(List.of("TagName2", "TagName3"))

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AwsSecretsManagerMultiValueAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/bulkloading/AwsSecretsManagerMultiValueAcceptanceTest.java
@@ -105,6 +105,7 @@ public class AwsSecretsManagerMultiValueAcceptanceTest extends AcceptanceTestBas
   void secretsAreLoadedFromAWSSecretsManagerAndReportedByPublicApi(final boolean useConfigFile) {
     final AwsVaultParameters awsVaultParameters =
         AwsVaultParametersBuilder.anAwsParameters()
+            .withEnabled(true)
             .withAuthenticationMode(AwsAuthenticationMode.SPECIFIED)
             .withRegion(AWS_REGION)
             .withAccessKeyId(RO_AWS_ACCESS_KEY_ID)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Fix AWK KMS tests failing. This was caused by a change in the test fixtures that now honors the enabled flag. Before the test fixture for AwsParameters always returned false for isEnabled.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
