### PR TITLE
Make vertx worker pool size configurable

### DIFF
--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
@@ -203,6 +203,12 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
       hidden = true)
   private boolean keystoreParallelProcessingEnabled = true;
 
+  @Option(
+      names = "--Xworker-pool-size",
+      description = "Configure the work pool size used for processing requests",
+      hidden = true)
+  private int workerPoolSize = 20;
+
   @CommandLine.Mixin private PicoCliTlsServerOptions picoCliTlsServerOptions;
 
   @Override
@@ -308,6 +314,11 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
   }
 
   @Override
+  public int getWorkerPoolSize() {
+    return workerPoolSize;
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("configFile", configFile)
@@ -325,6 +336,7 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
         .add("metricsHostAllowList", metricsHostAllowList)
         .add("picoCliTlsServerOptions", picoCliTlsServerOptions)
         .add("idleConnectionTimeoutSeconds", idleConnectionTimeoutSeconds)
+        .add("workerPoolSize", workerPoolSize)
         .toString();
   }
 

--- a/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/support/TestBaseConfig.java
+++ b/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/support/TestBaseConfig.java
@@ -136,4 +136,9 @@ public class TestBaseConfig implements BaseConfig {
   public boolean keystoreParallelProcessingEnabled() {
     return true;
   }
+
+  @Override
+  public int getWorkerPoolSize() {
+    return 20;
+  }
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -216,6 +216,7 @@ public abstract class Runner implements Runnable, AutoCloseable {
 
   private VertxOptions createVertxOptions(final MetricsSystem metricsSystem) {
     return new VertxOptions()
+        .setWorkerPoolSize(baseConfig.getWorkerPoolSize())
         .setMetricsOptions(
             new MetricsOptions()
                 .setEnabled(true)

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/BaseConfig.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/BaseConfig.java
@@ -62,4 +62,6 @@ public interface BaseConfig {
   Boolean isAccessLogsEnabled();
 
   boolean keystoreParallelProcessingEnabled();
+
+  int getWorkerPoolSize();
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Make vertx worker pool size configurable. Web3Signer uses the worker pool for signing requests. Increasing the size of the pool might help if there is a spike in signing requests.

It can be configured by using the hidden option --Xworker-pool-size.

Default is set to the same the default in Vertx which is 20. See https://vertx.io/docs/apidocs/io/vertx/core/VertxOptions.html#DEFAULT_WORKER_POOL_SIZE

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [ ] I thought about testing these changes in a realistic/non-local environment.
