### PR TITLE
CircleCI: disable cached docker layer for publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,6 @@ executors:
   machine_executor_amd64:
     machine:
       image: ubuntu-2204:current # https://circleci.com/developer/machine/image/ubuntu-2204
-      docker_layer_caching: true
     working_directory: ~/project
     environment:
       architecture: "amd64"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
CircleCI configuration was using cached docker layer feature which was causing stale layer to be used when creating image for linux/amd64 platform. This was causing old os libraries to get bundled instead of fetching latest libraries during docker build phase.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
