### PR TITLE
Remove KZG as it is not needed by web3signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Bugs fixed
 - Update netty to fix CVE-2023-44487
 
+### Features Added
+- Removed need for KZG trusted setup file and associated --Xtrusted-setup command line argument
+
 ## 23.9.1
 
 ### Breaking Changes

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfiguration.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfiguration.java
@@ -70,7 +70,6 @@ public class SignerConfiguration {
   private final Optional<Long> denebForkEpoch;
   private final Optional<String> network;
   private final boolean keyManagerApiEnabled;
-  private final Optional<String> trustedSetup;
   private Optional<WatermarkRepairParameters> watermarkRepairParameters;
   private int downstreamHttpPort;
   private Optional<ClientTlsOptions> downstreamTlsOptions;
@@ -121,7 +120,6 @@ public class SignerConfiguration {
       final int downstreamHttpPort,
       final Optional<ClientTlsOptions> downstreamTlsOptions,
       final ChainIdProvider chainIdProvider,
-      final Optional<String> trustedSetup,
       final Optional<KeystoresParameters> v3KeystoresBulkloadParameters) {
     this.hostname = hostname;
     this.logLevel = logLevel;
@@ -165,7 +163,6 @@ public class SignerConfiguration {
     this.downstreamHttpPort = downstreamHttpPort;
     this.downstreamTlsOptions = downstreamTlsOptions;
     this.chainIdProvider = chainIdProvider;
-    this.trustedSetup = trustedSetup;
     this.v3KeystoresBulkloadParameters = v3KeystoresBulkloadParameters;
   }
 
@@ -343,10 +340,6 @@ public class SignerConfiguration {
 
   public ChainIdProvider getChainIdProvider() {
     return chainIdProvider;
-  }
-
-  public Optional<String> getTrustedSetup() {
-    return trustedSetup;
   }
 
   public Optional<KeystoresParameters> getV3KeystoresBulkloadParameters() {

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfigurationBuilder.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/SignerConfigurationBuilder.java
@@ -78,7 +78,6 @@ public class SignerConfigurationBuilder {
   private ClientTlsOptions downstreamTlsOptions;
 
   private ChainIdProvider chainIdProvider = new ConfigurationChainId(DEFAULT_CHAIN_ID);
-  private String trustedSetup;
 
   private KeystoresParameters v3KeystoresBulkloadParameters;
 
@@ -305,11 +304,6 @@ public class SignerConfigurationBuilder {
     return this;
   }
 
-  public SignerConfigurationBuilder withTrustedSetup(final String trustedSetup) {
-    this.trustedSetup = trustedSetup;
-    return this;
-  }
-
   public SignerConfigurationBuilder withV3KeystoresBulkloadParameters(
       final KeystoresParameters v3KeystoresBulkloadParameters) {
     this.v3KeystoresBulkloadParameters = v3KeystoresBulkloadParameters;
@@ -363,7 +357,6 @@ public class SignerConfigurationBuilder {
         downstreamHttpPort,
         Optional.ofNullable(downstreamTlsOptions),
         chainIdProvider,
-        Optional.ofNullable(trustedSetup),
         Optional.ofNullable(v3KeystoresBulkloadParameters));
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsConfigFileImpl.java
@@ -484,12 +484,6 @@ public class CmdLineParamsConfigFileImpl implements CmdLineParamsBuilder {
               signerConfig.getDenebForkEpoch().get()));
     }
 
-    if (signerConfig.getTrustedSetup().isPresent()) {
-      yamlConfig.append(
-          String.format(
-              YAML_STRING_FMT, "eth2.Xtrusted-setup", signerConfig.getTrustedSetup().get()));
-    }
-
     if (signerConfig.getNetwork().isPresent()) {
       yamlConfig.append(
           String.format(YAML_STRING_FMT, "eth2.network", signerConfig.getNetwork().get()));

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/runner/CmdLineParamsDefaultImpl.java
@@ -292,11 +292,6 @@ public class CmdLineParamsDefaultImpl implements CmdLineParamsBuilder {
       params.add(Long.toString(signerConfig.getDenebForkEpoch().get()));
     }
 
-    if (signerConfig.getTrustedSetup().isPresent()) {
-      params.add("--Xtrusted-setup");
-      params.add(signerConfig.getTrustedSetup().get());
-    }
-
     if (signerConfig.getNetwork().isPresent()) {
       params.add("--network");
       params.add(signerConfig.getNetwork().get());

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/Eth2CustomNetworkFileAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/Eth2CustomNetworkFileAcceptanceTest.java
@@ -19,7 +19,6 @@ import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSecretKey;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.networks.Eth2NetworkConfiguration;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecFactory;
 import tech.pegasys.teku.spec.datastructures.util.ForkAndSpecMilestone;
@@ -31,7 +30,6 @@ import tech.pegasys.web3signer.signing.KeyType;
 
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Objects;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.io.Resources;
@@ -53,10 +51,6 @@ public class Eth2CustomNetworkFileAcceptanceTest extends SigningAcceptanceTestBa
       BLSSecretKey.fromBytes(Bytes32.fromHexString(PRIVATE_KEY));
   private static final BLSKeyPair KEY_PAIR = new BLSKeyPair(KEY);
   private static final BLSPublicKey PUBLIC_KEY = KEY_PAIR.getPublicKey();
-  private static final String TRUSTED_SETUP_PATH =
-      Objects.requireNonNull(
-              Eth2NetworkConfiguration.class.getResource("minimal-trusted-setup.txt"))
-          .toExternalForm();
 
   @BeforeEach
   void setup() {
@@ -65,11 +59,7 @@ public class Eth2CustomNetworkFileAcceptanceTest extends SigningAcceptanceTestBa
     METADATA_FILE_HELPERS.createUnencryptedYamlFileAt(keyConfigFile, PRIVATE_KEY, KeyType.BLS);
 
     final SignerConfigurationBuilder builder = new SignerConfigurationBuilder();
-    builder
-        .withKeyStoreDirectory(testDirectory)
-        .withMode("eth2")
-        .withNetwork(NETWORK_CONFIG_PATH)
-        .withTrustedSetup(TRUSTED_SETUP_PATH);
+    builder.withKeyStoreDirectory(testDirectory).withMode("eth2").withNetwork(NETWORK_CONFIG_PATH);
     startSigner(builder.build());
   }
 
@@ -79,8 +69,7 @@ public class Eth2CustomNetworkFileAcceptanceTest extends SigningAcceptanceTestBa
         SpecFactory.create(
             NETWORK_CONFIG_PATH.toString(),
             specConfigBuilder ->
-                specConfigBuilder.denebBuilder(
-                    denebBuilder -> denebBuilder.trustedSetupPath(TRUSTED_SETUP_PATH)));
+                specConfigBuilder.denebBuilder(denebBuilder -> denebBuilder.kzgNoop(true)));
     final List<ForkAndSpecMilestone> enabledMilestones = spec.getEnabledMilestones();
     assertThat(enabledMilestones.size()).isEqualTo(5);
 

--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,12 @@ allprojects {
     skipProjects = [
       ':acceptance-tests'
     ]
+    analyzers {
+      retirejs {
+        enabled = false
+      }
+      assemblyEnabled = false
+    }
   }
 
   tasks.withType(JavaCompile) {

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
@@ -126,15 +126,6 @@ public class Eth2SubCommand extends ModeSubCommand {
   private UInt64 denebForkEpoch;
 
   @CommandLine.Option(
-      names = {"--Xtrusted-setup"},
-      hidden = true,
-      paramLabel = "<STRING>",
-      description =
-          "The trusted setup which is needed for KZG commitments. Only required when creating a custom network. This value should be a file or URL pointing to a trusted setup.",
-      arity = "1")
-  private String trustedSetup = null; // Depends on network configuration
-
-  @CommandLine.Option(
       names = {"--key-manager-api-enabled", "--enable-key-manager-api"},
       paramLabel = "<BOOL>",
       description = "Enable the key manager API to manage key stores (default: ${DEFAULT-VALUE}).",
@@ -190,7 +181,7 @@ public class Eth2SubCommand extends ModeSubCommand {
 
   private Eth2NetworkConfiguration createEth2NetworkConfig() {
     Eth2NetworkConfiguration.Builder builder = Eth2NetworkConfiguration.builder();
-    builder.applyNetworkDefaults(network);
+    builder.applyNetworkDefaults(network).kzgNoop(true);
     if (altairForkEpoch != null) {
       builder.altairForkEpoch(altairForkEpoch);
     }
@@ -202,9 +193,6 @@ public class Eth2SubCommand extends ModeSubCommand {
     }
     if (denebForkEpoch != null) {
       builder.denebForkEpoch(denebForkEpoch);
-    }
-    if (trustedSetup != null) {
-      builder.trustedSetup(trustedSetup);
     }
     return builder.build();
   }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -90,7 +90,7 @@ dependencyManagement {
 
     dependency 'org.xipki.iaik:sunpkcs11-wrapper:1.4.10'
 
-    dependencySet(group: 'tech.pegasys.teku.internal', version: '23.9.1') {
+    dependencySet(group: 'tech.pegasys.teku.internal', version: '23.10.0') {
       entry ('bls') {
         exclude group: 'org.bouncycastle', name: 'bcprov-jdk15on'
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Remove KZG as it is not needed by web3signer. This also removes the need to specify the trusted setup when using a custom network.

- Removed the js dependency vulnerability scanning as we don't use js and it's broken the build
- Removed the .net assembly scanner as it logs warning messages and we don't use it
- Upgraded Teku to latest version 23.10.0
- Changed spec to be initialised with the kzgNoop enabled
- Removed -Xtrusted-setup command line option since we no longer need it

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
