### PR TITLE
Log warning when calculating time taken to load keys

### DIFF
--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
@@ -43,6 +43,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.VisibleForTesting;
 
 public class SignerLoader {
 
@@ -120,7 +121,8 @@ public class SignerLoader {
     return MappedResults.newInstance(signingMetadataList, errorCount.get());
   }
 
-  private static Optional<String> calculateTimeTaken(final Instant start) {
+  @VisibleForTesting
+  static Optional<String> calculateTimeTaken(final Instant start) {
     final Instant now = Instant.now();
     final long timeTaken = Duration.between(start, now).toMillis();
     if (timeTaken < 0) {

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -71,7 +72,7 @@ public class SignerLoader {
     LOG.info(
         "Signer configuration metadata files read in memory {} in {}",
         configFileContent.getContentMap().size(),
-        calculateTimeTaken(start));
+        calculateTimeTaken(start).orElse("unknown duration"));
 
     final Instant conversionStartInstant = Instant.now();
     // Step 1: convert yaml file content to list of SigningMetadata
@@ -95,7 +96,7 @@ public class SignerLoader {
         "Total Artifact Signer loaded via configuration files: {}\nError count {}\nTime Taken: {}.",
         artifactSigners.getValues().size(),
         artifactSigners.getErrorCount(),
-        calculateTimeTaken(conversionStartInstant));
+        calculateTimeTaken(conversionStartInstant).orElse("unknown duration"));
 
     return artifactSigners;
   }
@@ -119,13 +120,14 @@ public class SignerLoader {
     return MappedResults.newInstance(signingMetadataList, errorCount.get());
   }
 
-  private static String calculateTimeTaken(final Instant start) {
+  private static Optional<String> calculateTimeTaken(final Instant start) {
     final Instant now = Instant.now();
     final long timeTaken = Duration.between(start, now).toMillis();
     if (timeTaken < 0) {
       LOG.warn("System Clock returned time in past. Start: {}, Now: {}.", start, now);
+      return Optional.empty();
     }
-    return DurationFormatUtils.formatDurationHMS(Math.abs(timeTaken));
+    return Optional.of(DurationFormatUtils.formatDurationHMS(timeTaken));
   }
 
   private ConfigFileContent getNewOrModifiedConfigFilesContents(

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
@@ -38,12 +38,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.VisibleForTesting;
 
 public class SignerLoader {
 

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/SignerLoader.java
@@ -120,7 +120,12 @@ public class SignerLoader {
   }
 
   private static String calculateTimeTaken(final Instant start) {
-    return DurationFormatUtils.formatDurationHMS(Duration.between(start, Instant.now()).toMillis());
+    final Instant now = Instant.now();
+    final long timeTaken = Duration.between(start, now).toMillis();
+    if (timeTaken < 0) {
+      LOG.warn("System Clock returned time in past. Start: {}, Now: {}.", start, now);
+    }
+    return DurationFormatUtils.formatDurationHMS(Math.abs(timeTaken));
   }
 
   private ConfigFileContent getNewOrModifiedConfigFilesContents(

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/config/SignerLoaderTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/config/SignerLoaderTest.java
@@ -36,10 +36,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -291,6 +294,20 @@ class SignerLoaderTest {
     assertThat(reloadedArtifactSigner).hasSize(1);
     assertThat(reloadedArtifactSigner.stream().findFirst().get().getIdentifier())
         .isEqualTo(blsKeyPair3.getPublicKey().toHexString());
+  }
+
+  @Test
+  void calculateTimeTakenWithFutureTimeShouldReturnEmpty() {
+    final Optional<String> timeTaken =
+        SignerLoader.calculateTimeTaken(Instant.now().plus(5, ChronoUnit.MINUTES));
+    assertThat(timeTaken).isEmpty();
+  }
+
+  @Test
+  void calculateTimeTakenWithPastTimeShouldReturnValue() {
+    final Optional<String> timeTaken =
+        SignerLoader.calculateTimeTaken(Instant.now().minus(5, ChronoUnit.MINUTES));
+    assertThat(timeTaken).isNotEmpty();
   }
 
   private Path createFileInConfigsDirectory(final String fileName, final String privateKeyHex)


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Log warning instead of runtime exception if difference of time taken is negative i.e. system clock returned time in past.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#934 
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
