### PR TITLE
Vertx worker pool size cli option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## 23.11.0
+### Upcoming Breaking Changes
+- `--Xworker-pool-size` cli option will be removed in a future release.
 
 ### Bugs fixed
 - Update netty to fix CVE-2023-44487

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 23.11.0
 ### Upcoming Breaking Changes
-- `--Xworker-pool-size` cli option will be removed in a future release.
+- `--Xworker-pool-size` cli option will be removed in a future release. This option has been replaced with `--vertx-worker-pool-size`.
 
 ### Bugs fixed
 - Update netty to fix CVE-2023-44487

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 
-## Next version
+## 23.11.0
 
 ### Bugs fixed
 - Update netty to fix CVE-2023-44487
 
 ### Features Added
 - Google Cloud Secret Manager bulk loading support for BLS keys in eth2 mode via PR [#928](https://github.com/Consensys/web3signer/pull/928) contributed by [Sergey Kisel](https://github.com/skisel-bt).
-- Removed need for KZG trusted setup file and associated --Xtrusted-setup command line argument
+- Removed hidden option `--Xtrusted-setup` as Web3Signer does not need KZG trusted setup file anymore.
+- Make Vert.x worker pool size configurable using cli option `--vertx-worker-pool-size` (deprecated alias: `--Xworker-pool-size`). [#920](https://github.com/Consensys/web3signer/pull/920)
 
 ## 23.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Features Added
 - Google Cloud Secret Manager bulk loading support for BLS keys in eth2 mode via PR [#928](https://github.com/Consensys/web3signer/pull/928) contributed by [Sergey Kisel](https://github.com/skisel-bt).
 - Removed hidden option `--Xtrusted-setup` as Web3Signer does not need KZG trusted setup file anymore.
-- Make Vert.x worker pool size configurable using cli option `--vertx-worker-pool-size` (deprecated alias: `--Xworker-pool-size`). [#920](https://github.com/Consensys/web3signer/pull/920)
+- Make Vert.x worker pool size configurable using cli option `--vertx-worker-pool-size` (replaces the now deprecated: `--Xworker-pool-size`). [#920](https://github.com/Consensys/web3signer/pull/920)
 
 ## 23.9.1
 

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
@@ -204,6 +204,7 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
       hidden = true)
   private boolean keystoreParallelProcessingEnabled = true;
 
+  @SuppressWarnings("ExperimentalCliOptionMustBeCorrectlyDisplayed")
   @Option(
       names = {"--vertx-worker-pool-size", "--Xworker-pool-size"},
       description =

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
@@ -204,13 +204,16 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
       hidden = true)
   private boolean keystoreParallelProcessingEnabled = true;
 
-  @SuppressWarnings("ExperimentalCliOptionMustBeCorrectlyDisplayed")
   @Option(
-      names = {"--vertx-worker-pool-size", "--Xworker-pool-size"},
+      names = "--vertx-worker-pool-size",
       description =
           "Configure the Vert.x worker pool size used for processing requests. (default: ${DEFAULT-VALUE})",
       paramLabel = INTEGER_FORMAT_HELP)
   private int vertxWorkerPoolSize = 20;
+
+  @Deprecated
+  @Option(names = "--Xworker-pool-size", hidden = true)
+  private Integer deprecatedWorkerPoolSize = null;
 
   @CommandLine.Mixin private PicoCliTlsServerOptions picoCliTlsServerOptions;
 
@@ -318,6 +321,9 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
 
   @Override
   public int getVertxWorkerPoolSize() {
+    if (deprecatedWorkerPoolSize != null) {
+      return deprecatedWorkerPoolSize;
+    }
     return vertxWorkerPoolSize;
   }
 

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
@@ -15,6 +15,7 @@ package tech.pegasys.web3signer.commandline;
 import static tech.pegasys.web3signer.commandline.DefaultCommandValues.CONFIG_FILE_OPTION_NAME;
 import static tech.pegasys.web3signer.commandline.DefaultCommandValues.FILE_FORMAT_HELP;
 import static tech.pegasys.web3signer.commandline.DefaultCommandValues.HOST_FORMAT_HELP;
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.INTEGER_FORMAT_HELP;
 import static tech.pegasys.web3signer.commandline.DefaultCommandValues.PORT_FORMAT_HELP;
 import static tech.pegasys.web3signer.common.Web3SignerMetricCategory.DEFAULT_METRIC_CATEGORIES;
 
@@ -204,10 +205,11 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
   private boolean keystoreParallelProcessingEnabled = true;
 
   @Option(
-      names = "--Xworker-pool-size",
-      description = "Configure the work pool size used for processing requests",
-      hidden = true)
-  private int workerPoolSize = 20;
+      names = {"--vertx-worker-pool-size", "--Xworker-pool-size"},
+      description =
+          "Configure the Vert.x worker pool size used for processing requests. (default: ${DEFAULT-VALUE})",
+      paramLabel = INTEGER_FORMAT_HELP)
+  private int vertxWorkerPoolSize = 20;
 
   @CommandLine.Mixin private PicoCliTlsServerOptions picoCliTlsServerOptions;
 
@@ -314,8 +316,8 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
   }
 
   @Override
-  public int getWorkerPoolSize() {
-    return workerPoolSize;
+  public int getVertxWorkerPoolSize() {
+    return vertxWorkerPoolSize;
   }
 
   @Override
@@ -336,7 +338,7 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
         .add("metricsHostAllowList", metricsHostAllowList)
         .add("picoCliTlsServerOptions", picoCliTlsServerOptions)
         .add("idleConnectionTimeoutSeconds", idleConnectionTimeoutSeconds)
-        .add("workerPoolSize", workerPoolSize)
+        .add("vertxWorkerPoolSize", vertxWorkerPoolSize)
         .toString();
   }
 

--- a/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/support/TestBaseConfig.java
+++ b/core/src/integrationTest/java/tech/pegasys/web3signer/core/jsonrpcproxy/support/TestBaseConfig.java
@@ -138,7 +138,7 @@ public class TestBaseConfig implements BaseConfig {
   }
 
   @Override
-  public int getWorkerPoolSize() {
+  public int getVertxWorkerPoolSize() {
     return 20;
   }
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -216,7 +216,7 @@ public abstract class Runner implements Runnable, AutoCloseable {
 
   private VertxOptions createVertxOptions(final MetricsSystem metricsSystem) {
     return new VertxOptions()
-        .setWorkerPoolSize(baseConfig.getWorkerPoolSize())
+        .setWorkerPoolSize(baseConfig.getVertxWorkerPoolSize())
         .setMetricsOptions(
             new MetricsOptions()
                 .setEnabled(true)

--- a/core/src/main/java/tech/pegasys/web3signer/core/config/BaseConfig.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/config/BaseConfig.java
@@ -63,5 +63,5 @@ public interface BaseConfig {
 
   boolean keystoreParallelProcessingEnabled();
 
-  int getWorkerPoolSize();
+  int getVertxWorkerPoolSize();
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Use `--vertx-worker-pool-size` and mark`--Xworker-pool-size` as deprecated.  See #920 for original PR. The `--help` looks like:
```
    --vertx-worker-pool-size=<INTEGER>
                             Configure the Vert.x worker pool size used for
                               processing requests. (default: 20)
```
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
