### PR TITLE
Validate vertx pool size options

### DIFF
--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/Web3SignerBaseCommand.java
@@ -323,8 +323,9 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
 
   @Override
   public int getVertxWorkerPoolSize() {
-    if (vertxWorkerPoolSize == null && deprecatedWorkerPoolSize == null) {
-      return VERTX_WORKER_POOL_SIZE_DEFAULT;
+    // both values are not allowed on cli, they will be verified in validateArgs() ...
+    if (vertxWorkerPoolSize != null && deprecatedWorkerPoolSize != null) {
+      return -1;
     }
 
     if (vertxWorkerPoolSize != null) {
@@ -335,7 +336,6 @@ public class Web3SignerBaseCommand implements BaseConfig, Runnable {
       return deprecatedWorkerPoolSize;
     }
 
-    // both values are not allowed on cli, they will be verified in validateArgs() ...
     return VERTX_WORKER_POOL_SIZE_DEFAULT;
   }
 

--- a/commandline/src/test/java/tech/pegasys/web3signer/commandline/CommandlineParserTest.java
+++ b/commandline/src/test/java/tech/pegasys/web3signer/commandline/CommandlineParserTest.java
@@ -557,6 +557,60 @@ class CommandlineParserTest {
         .contains("v1", "v2", "v3");
   }
 
+  @Test
+  void vertxWorkerPoolSizeWithWorkerPoolSizeFailsToParse() {
+    String cmdline = validBaseCommandOptions();
+    cmdline +=
+        "--vertx-worker-pool-size=30 --Xworker-pool-size=40 eth2 --slashing-protection-enabled=false";
+
+    parser.registerSubCommands(new MockEth2SubCommand());
+    final int result = parser.parseCommandLine(cmdline.split(" "));
+
+    assertThat(result).isNotZero();
+    assertThat(commandError.toString())
+        .contains(
+            "Error parsing parameters: --vertx-worker-pool-size option and --Xworker-pool-size option can't be used at the same time.");
+  }
+
+  @Test
+  void vertxWorkerPoolSizeDefaultParsesSuccessfully() {
+    String cmdline = validBaseCommandOptions();
+    cmdline += "eth2 --slashing-protection-enabled=false";
+
+    MockEth2SubCommand mockEth2SubCommand = new MockEth2SubCommand();
+    parser.registerSubCommands(mockEth2SubCommand);
+    final int result = parser.parseCommandLine(cmdline.split(" "));
+
+    assertThat(result).isZero();
+    assertThat(mockEth2SubCommand.getConfig().getVertxWorkerPoolSize()).isEqualTo(20);
+  }
+
+  @Test
+  void vertxWorkerPoolSizeDeprecatedParsesSuccessfully() {
+    String cmdline = validBaseCommandOptions();
+    cmdline += "--Xworker-pool-size=40 eth2 --slashing-protection-enabled=false";
+
+    MockEth2SubCommand mockEth2SubCommand = new MockEth2SubCommand();
+    parser.registerSubCommands(mockEth2SubCommand);
+    final int result = parser.parseCommandLine(cmdline.split(" "));
+
+    assertThat(result).isZero();
+    assertThat(mockEth2SubCommand.getConfig().getVertxWorkerPoolSize()).isEqualTo(40);
+  }
+
+  @Test
+  void vertxWorkerPoolSizeParsesSuccessfully() {
+    String cmdline = validBaseCommandOptions();
+    cmdline += "--vertx-worker-pool-size=40 eth2 --slashing-protection-enabled=false";
+
+    MockEth2SubCommand mockEth2SubCommand = new MockEth2SubCommand();
+    parser.registerSubCommands(mockEth2SubCommand);
+    final int result = parser.parseCommandLine(cmdline.split(" "));
+
+    assertThat(result).isZero();
+    assertThat(mockEth2SubCommand.getConfig().getVertxWorkerPoolSize()).isEqualTo(40);
+  }
+
   private <T> void missingOptionalParameterIsValidAndMeetsDefault(
       final String paramToRemove, final Supplier<T> actualValueGetter, final T expectedValue) {
 
@@ -572,6 +626,10 @@ class CommandlineParserTest {
     @Override
     public Runner createRunner() {
       return new NoOpRunner(config);
+    }
+
+    public BaseConfig getConfig() {
+      return config;
     }
   }
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Validate vertx pool size options. The deprecated worker pool size and new vertx worker pool size cli options are mutually exclusive.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
