### PR TITLE
Prepare web3signer for 24.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 24.1.1
+
+This is an optional release for mainnet Ethereum and it includes the updated network configuration for the Sepolia, Holesky and Chiado Deneb forks.
+
 ## 24.1.0
 
 This is an optional release for mainnet Ethereum and it includes the updated network configuration for the Goerli Deneb fork.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-besuVersion=23.10.3
+besuVersion=24.1.0
 besuDistroUrl=https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/${besuVersion}/besu-${besuVersion}.tar.gz
 
 hashicorpVaultVersion=1.9.2

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -85,12 +85,12 @@ dependencyManagement {
       entry 'mockito-junit-jupiter'
     }
 
-    dependency 'org.hyperledger.besu:plugin-api:23.10.3'
-    dependency 'org.hyperledger.besu.internal:metrics-core:23.10.3'
+    dependency 'org.hyperledger.besu:plugin-api:24.1.0'
+    dependency 'org.hyperledger.besu.internal:metrics-core:24.1.0'
 
     dependency 'org.xipki.iaik:sunpkcs11-wrapper:1.4.10'
 
-    dependencySet(group: 'tech.pegasys.teku.internal', version: '24.1.0') {
+    dependencySet(group: 'tech.pegasys.teku.internal', version: '24.1.1') {
       entry ('bls') {
         exclude group: 'org.bouncycastle', name: 'bcprov-jdk15on'
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Prepare web3signer for 24.1.1 release

* Update Teku to 24.1.1 to get network config for Deneb Sepolia, Holesky and Chiado forks
* Update Besu to 24.1.0
* Update Changelog for 24.1.1 release

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
