### PR TITLE
upgrade postgres to 42.5.5 to fix CVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is a required update for Mainnet users containing the configuration for the
 
 ### Bugs fixed
 - Ensure that Web3Signer stops the http server when a sigterm is received
+- Update postgresql to fix CVE-2024-1597
 
 ## 24.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Next Version
+
+### Upcoming Breaking Changes
+
+### Features Added
+
+### Bugs fixed
+- Update postgresql to fix CVE-2024-1597
+
 ## 24.2.0
 
 This is a required update for Mainnet users containing the configuration for the Deneb upgrade on March 13th. This update is required for Gnosis Deneb network upgrade on March 11th. For all other networks, this update is optional.
@@ -13,7 +22,6 @@ This is a required update for Mainnet users containing the configuration for the
 
 ### Bugs fixed
 - Ensure that Web3Signer stops the http server when a sigterm is received
-- Update postgresql to fix CVE-2024-1597
 
 ## 24.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Next Version
 
-### Upcoming Breaking Changes
-
-### Features Added
-
 ### Bugs fixed
 - Update postgresql to fix CVE-2024-1597
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -133,7 +133,7 @@ dependencyManagement {
     dependency 'com.azure:azure-identity:1.11.1'
 
     dependency 'com.zaxxer:HikariCP:5.0.1'
-    dependency 'org.postgresql:postgresql:42.5.3'
+    dependency 'org.postgresql:postgresql:42.5.5'
 
     dependencySet(group: 'org.jdbi', version: '3.36.0') {
       entry 'jdbi3-core'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
This Pr upgrades postgres to 42.5.5 to fix CVE-2024-1597

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
