### PR TITLE
fix: Make cached GVR thread-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 - Update postgresql to fix CVE-2024-1597
+- Fix cached gvr to be thread-safe during first boot. [#978](https://github.com/Consensys/web3signer/issues/978)
 
 ## 24.2.0
 

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/validator/GenesisValidatorRootValidatorTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/validator/GenesisValidatorRootValidatorTest.java
@@ -90,7 +90,7 @@ class GenesisValidatorRootValidatorTest {
     executorService.shutdown();
 
     // wait for all threads to finish
-    var successfulTerminate = executorService.awaitTermination(5, MINUTES);
+    var successfulTerminate = executorService.awaitTermination(1, MINUTES);
     assertThat(successfulTerminate).isTrue();
 
     assertThat(allCachedGVRMatches).isTrue();

--- a/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/validator/GenesisValidatorRootValidatorTest.java
+++ b/slashing-protection/src/test/java/tech/pegasys/web3signer/slashingprotection/validator/GenesisValidatorRootValidatorTest.java
@@ -97,8 +97,9 @@ class GenesisValidatorRootValidatorTest {
     latch.await(); // Wait for all threads to finish
     executorService.shutdown(); // Shutdown the executor service
 
-    // Assert that all threads returned true
     assertThat(allTrue.get()).isTrue();
+    verify(metadataDao, times(1)).findGenesisValidatorsRoot(any());
+    verify(metadataDao, times(1)).insertGenesisValidatorsRoot(any(), any());
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Make cached GVR calculation thread-safe. During Web3Signer first boot, if multiple requests for signing comes in, it can result in multiple threads attempting to insert gvr in a fresh database. This would show an constraint violation in database logs.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #978 
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
