### PR TITLE
Moved teku deserializers from teku into web3signer

### DIFF
--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/SigningObjectMapperFactory.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/SigningObjectMapperFactory.java
@@ -26,17 +26,17 @@ import tech.pegasys.teku.infrastructure.jackson.deserializers.bytes.DoubleSerial
 import tech.pegasys.teku.infrastructure.jackson.deserializers.uints.UInt64Deserializer;
 import tech.pegasys.teku.infrastructure.jackson.deserializers.uints.UInt64Serializer;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
-import tech.pegasys.teku.provider.BLSPubKeyDeserializer;
-import tech.pegasys.teku.provider.BLSPubKeySerializer;
-import tech.pegasys.teku.provider.BLSSignatureDeserializer;
-import tech.pegasys.teku.provider.BLSSignatureSerializer;
-import tech.pegasys.teku.provider.SszBitvectorSerializer;
 import tech.pegasys.web3signer.common.JacksonSerializers.HexDeserialiser;
 import tech.pegasys.web3signer.common.JacksonSerializers.HexSerialiser;
 import tech.pegasys.web3signer.common.JacksonSerializers.StringUInt64Deserializer;
 import tech.pegasys.web3signer.common.JacksonSerializers.StringUInt64Serialiser;
 import tech.pegasys.web3signer.core.service.http.handlers.signing.eth2.BlockRequest;
 import tech.pegasys.web3signer.core.service.http.handlers.signing.eth2.json.BlockRequestDeserializer;
+import tech.pegasys.web3signer.core.service.http.serializers.BLSPubKeyDeserializer;
+import tech.pegasys.web3signer.core.service.http.serializers.BLSPubKeySerializer;
+import tech.pegasys.web3signer.core.service.http.serializers.BLSSignatureDeserializer;
+import tech.pegasys.web3signer.core.service.http.serializers.BLSSignatureSerializer;
+import tech.pegasys.web3signer.core.service.http.serializers.SszBitvectorSerializer;
 import tech.pegasys.web3signer.signing.config.metadata.parser.SigningMetadataModule;
 import tech.pegasys.web3signer.signing.config.metadata.parser.SigningMetadataModule.Bytes32Serializer;
 

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/serializers/BLSPubKeyDeserializer.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/serializers/BLSPubKeyDeserializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service.http.serializers;
+
+import tech.pegasys.teku.api.schema.BLSPubKey;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import org.apache.tuweni.bytes.Bytes;
+
+public class BLSPubKeyDeserializer extends JsonDeserializer<BLSPubKey> {
+  public BLSPubKeyDeserializer() {}
+
+  @Override
+  public BLSPubKey deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    return new BLSPubKey(Bytes.fromHexString(p.getValueAsString()));
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/serializers/BLSPubKeySerializer.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/serializers/BLSPubKeySerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service.http.serializers;
+
+import tech.pegasys.teku.api.schema.BLSPubKey;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+public class BLSPubKeySerializer extends JsonSerializer<BLSPubKey> {
+  public BLSPubKeySerializer() {}
+
+  @Override
+  public void serialize(BLSPubKey value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeString(value.toHexString().toLowerCase(Locale.ROOT));
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/serializers/BLSSignatureDeserializer.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/serializers/BLSSignatureDeserializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service.http.serializers;
+
+import tech.pegasys.teku.api.schema.BLSSignature;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+public class BLSSignatureDeserializer extends JsonDeserializer<BLSSignature> {
+  public BLSSignatureDeserializer() {}
+
+  @Override
+  public BLSSignature deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    return BLSSignature.fromHexString(p.getValueAsString());
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/serializers/BLSSignatureSerializer.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/serializers/BLSSignatureSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service.http.serializers;
+
+import tech.pegasys.teku.api.schema.BLSSignature;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+public class BLSSignatureSerializer extends JsonSerializer<BLSSignature> {
+  public BLSSignatureSerializer() {}
+
+  @Override
+  public void serialize(BLSSignature value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeString(value.toHexString().toLowerCase(Locale.ROOT));
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/serializers/SszBitvectorSerializer.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/serializers/SszBitvectorSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service.http.serializers;
+
+import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+public class SszBitvectorSerializer extends JsonSerializer<SszBitvector> {
+  public SszBitvectorSerializer() {}
+
+  @Override
+  public void serialize(SszBitvector value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeString(value.sszSerialize().toHexString().toLowerCase(Locale.ROOT));
+  }
+}


### PR DESCRIPTION
Web3signer is referencing a few deserializers / serializers from teku, and I'm removing them from teku, so I've recreated them in web3signer to reduce integration issues...

I did have problems running tests, but I'm not sure why, this should be a relatively clean lift and shift...

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [X] I thought about testing these changes in a realistic/non-local environment.
