### PR TITLE
Added trusted-setup cli arg back in for teku acceptance testing

### DIFF
--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
@@ -127,6 +127,15 @@ public class Eth2SubCommand extends ModeSubCommand {
   private UInt64 denebForkEpoch;
 
   @CommandLine.Option(
+      names = {"--Xtrusted-setup"},
+      hidden = true,
+      paramLabel = "<STRING>",
+      description =
+          "The trusted setup which is needed for KZG commitments. Only required when creating a custom network. This value should be a file or URL pointing to a trusted setup.",
+      arity = "1")
+  private String trustedSetup = null; // Depends on network configuration
+
+  @CommandLine.Option(
       names = {"--key-manager-api-enabled", "--enable-key-manager-api"},
       paramLabel = "<BOOL>",
       description = "Enable the key manager API to manage key stores (default: ${DEFAULT-VALUE}).",
@@ -205,6 +214,9 @@ public class Eth2SubCommand extends ModeSubCommand {
     }
     if (denebForkEpoch != null) {
       builder.denebForkEpoch(denebForkEpoch);
+    }
+    if (trustedSetup != null) {
+      builder.trustedSetup(trustedSetup);
     }
     return builder.build();
   }


### PR DESCRIPTION
I think ultimately this should be less important at some point but if it's present it allows me to actually test some changes now, rather than waiting for future builds that build in some changes to teku that remove the need to define trustedSetup, so ideally it's ok to have this defined as a dev flag for testing for now...

The problem I was having was acceptance-tests use custom configuration and there was no way to specify this argument, so I wasn't able to check deneb for external-signer changes in teku...

I've got another change for teku that should make this less important again (default trusted-setup basically) but it'll be hard to coordinate that change plus external-signer changes without some blocking, unless this flag exists, and then i can just start testing things now.

Given this is hidden i didn't add it to changelog but happy to if needed... The only place calling it will be a teku acceptance test once i merge that...

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [X] I thought about testing these changes in a realistic/non-local environment.
