### PR TITLE
correct typo in documentations 

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -3,7 +3,7 @@
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
+contributors and maintainers pledge to make participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal

--- a/COMMUNITY_MEMBERSHIP.md
+++ b/COMMUNITY_MEMBERSHIP.md
@@ -67,7 +67,7 @@ issues and PRs assigned to them.
 ## Approver
 
 Code approvers are members that have signed an ICLA and have been granted
-additional commit privileges. While members are expected to provided code
+additional commit privileges. While members are expected to provide code
 reviews that focus on code quality and correctness, approval is focused on
 holistic acceptance of a contribution including: backwards / forwards
 compatibility, adhering to API and flag conventions, subtle performance and


### PR DESCRIPTION
## PR Description

## Documentation
correct typos in documentations to match proper grammar


