### PR TITLE
feat: Commit boost API - Get Public Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Features Added
 - Java 21 for build and runtime. [#995](https://github.com/Consensys/web3signer/pull/995)
 - Electra fork support. [#1020](https://github.com/Consensys/web3signer/pull/1020) and [#1023](https://github.com/Consensys/web3signer/pull/1023)
+- Commit boost API - Get Public Keys. [#1031](https://github.com/Consensys/web3signer/pull/1031)
 
 ### Bugs fixed
 - Override protobuf-java to 3.25.5 which is a transitive dependency from google-cloud-secretmanager. It fixes CVE-2024-7254.

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/PicoCommitBoostApiParameters.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/config/PicoCommitBoostApiParameters.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.commandline.config;
+
+import static tech.pegasys.web3signer.commandline.DefaultCommandValues.PATH_FORMAT_HELP;
+
+import tech.pegasys.web3signer.signing.config.KeystoresParameters;
+
+import java.nio.file.Path;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParameterException;
+import picocli.CommandLine.Spec;
+
+public class PicoCommitBoostApiParameters implements KeystoresParameters {
+  @Spec private CommandSpec commandSpec; // injected by picocli
+
+  @CommandLine.Option(
+      names = {"--commit-boost-api-enabled"},
+      paramLabel = "<BOOL>",
+      description = "Enable the commit boost API (default: ${DEFAULT-VALUE}).",
+      arity = "1")
+  private boolean isCommitBoostApiEnabled = false;
+
+  @Option(
+      names = {"--proxy-keystores-path"},
+      description =
+          "The path to a writeable directory to store v3 and v4 proxy keystores for commit boost API.",
+      paramLabel = PATH_FORMAT_HELP)
+  private Path keystoresPath;
+
+  @Option(
+      names = {"--proxy-keystores-password-file"},
+      description =
+          "The path to the password file used to encrypt/decrypt proxy keystores for commit boost API.",
+      paramLabel = PATH_FORMAT_HELP)
+  private Path keystoresPasswordFile;
+
+  @Override
+  public Path getKeystoresPath() {
+    return keystoresPath;
+  }
+
+  @Override
+  public Path getKeystoresPasswordsPath() {
+    return null;
+  }
+
+  @Override
+  public Path getKeystoresPasswordFile() {
+    return keystoresPasswordFile;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return isCommitBoostApiEnabled;
+  }
+
+  public void validateParameters() throws ParameterException {
+    if (!isCommitBoostApiEnabled) {
+      return;
+    }
+
+    if (keystoresPath == null) {
+      throw new ParameterException(
+          commandSpec.commandLine(),
+          "Commit boost API is enabled, but --proxy-keystores-path not set");
+    }
+
+    if (keystoresPasswordFile == null) {
+      throw new ParameterException(
+          commandSpec.commandLine(),
+          "Commit boost API is enabled, but --proxy-keystores-password-file not set");
+    }
+  }
+}

--- a/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
+++ b/commandline/src/main/java/tech/pegasys/web3signer/commandline/subcommands/Eth2SubCommand.java
@@ -29,6 +29,7 @@ import tech.pegasys.web3signer.commandline.PicoCliAwsSecretsManagerParameters;
 import tech.pegasys.web3signer.commandline.PicoCliEth2AzureKeyVaultParameters;
 import tech.pegasys.web3signer.commandline.PicoCliGcpSecretManagerParameters;
 import tech.pegasys.web3signer.commandline.PicoCliSlashingProtectionParameters;
+import tech.pegasys.web3signer.commandline.config.PicoCommitBoostApiParameters;
 import tech.pegasys.web3signer.commandline.config.PicoKeystoresParameters;
 import tech.pegasys.web3signer.common.config.AwsAuthenticationMode;
 import tech.pegasys.web3signer.core.Eth2Runner;
@@ -164,6 +165,7 @@ public class Eth2SubCommand extends ModeSubCommand {
   @Mixin private PicoKeystoresParameters keystoreParameters;
   @Mixin private PicoCliAwsSecretsManagerParameters awsSecretsManagerParameters;
   @Mixin private PicoCliGcpSecretManagerParameters gcpSecretManagerParameters;
+  @Mixin private PicoCommitBoostApiParameters commitBoostApiParameters;
   private tech.pegasys.teku.spec.Spec eth2Spec;
 
   public Eth2SubCommand() {
@@ -183,7 +185,8 @@ public class Eth2SubCommand extends ModeSubCommand {
         gcpSecretManagerParameters,
         eth2Spec,
         isKeyManagerApiEnabled,
-        signingExtEnabled);
+        signingExtEnabled,
+        commitBoostApiParameters);
   }
 
   private void logNetworkSpecInformation() {
@@ -261,6 +264,7 @@ public class Eth2SubCommand extends ModeSubCommand {
     validateKeystoreParameters(keystoreParameters);
     validateAwsSecretsManageParameters();
     validateGcpSecretManagerParameters();
+    commitBoostApiParameters.validateParameters();
   }
 
   private void validateGcpSecretManagerParameters() {

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth1Runner.java
@@ -50,6 +50,7 @@ import tech.pegasys.web3signer.signing.secp256k1.azure.AzureKeyVaultSignerFactor
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -114,7 +115,8 @@ public class Eth1Runner extends Runner {
                           awsKmsSignerFactory)
                       .getValues());
               return signers;
-            });
+            },
+            Optional.empty());
 
     // uses eth1 address as identifier
     final ArtifactSignerProvider secpArtifactSignerProvider =

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -89,6 +89,7 @@ public class Eth2Runner extends Runner {
   private final Spec eth2Spec;
   private final boolean isKeyManagerApiEnabled;
   private final boolean signingExtEnabled;
+  private final KeystoresParameters commitBoostApiParameters;
 
   public Eth2Runner(
       final BaseConfig baseConfig,
@@ -99,7 +100,8 @@ public class Eth2Runner extends Runner {
       final GcpSecretManagerParameters gcpSecretManagerParameters,
       final Spec eth2Spec,
       final boolean isKeyManagerApiEnabled,
-      final boolean signingExtEnabled) {
+      final boolean signingExtEnabled,
+      final KeystoresParameters commitBoostApiParameters) {
     super(baseConfig);
     this.slashingProtectionContext = createSlashingProtection(slashingProtectionParameters);
     this.azureKeyVaultParameters = azureKeyVaultParameters;
@@ -111,6 +113,7 @@ public class Eth2Runner extends Runner {
     this.awsVaultParameters = awsVaultParameters;
     this.gcpSecretManagerParameters = gcpSecretManagerParameters;
     this.signingExtEnabled = signingExtEnabled;
+    this.commitBoostApiParameters = commitBoostApiParameters;
   }
 
   private Optional<SlashingProtectionContext> createSlashingProtection(
@@ -138,7 +141,9 @@ public class Eth2Runner extends Runner {
     if (isKeyManagerApiEnabled) {
       new KeyManagerApiRoute(context, baseConfig, slashingProtectionContext).register();
     }
-    new CommitBoostPublicKeysRoute(context).register();
+    if (commitBoostApiParameters.isEnabled()) {
+      new CommitBoostPublicKeysRoute(context).register();
+    }
   }
 
   @Override
@@ -168,7 +173,8 @@ public class Eth2Runner extends Runner {
 
                 return signers;
               }
-            }));
+            },
+            Optional.of(commitBoostApiParameters)));
   }
 
   private MappedResults<ArtifactSigner> loadSignersFromKeyConfigFiles(

--- a/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Eth2Runner.java
@@ -25,6 +25,7 @@ import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.web3signer.core.config.BaseConfig;
 import tech.pegasys.web3signer.core.routes.PublicKeysListRoute;
 import tech.pegasys.web3signer.core.routes.ReloadRoute;
+import tech.pegasys.web3signer.core.routes.eth2.CommitBoostPublicKeysRoute;
 import tech.pegasys.web3signer.core.routes.eth2.Eth2SignExtensionRoute;
 import tech.pegasys.web3signer.core.routes.eth2.Eth2SignRoute;
 import tech.pegasys.web3signer.core.routes.eth2.HighWatermarkRoute;
@@ -137,6 +138,7 @@ public class Eth2Runner extends Runner {
     if (isKeyManagerApiEnabled) {
       new KeyManagerApiRoute(context, baseConfig, slashingProtectionContext).register();
     }
+    new CommitBoostPublicKeysRoute(context).register();
   }
 
   @Override

--- a/core/src/main/java/tech/pegasys/web3signer/core/routes/eth2/CommitBoostPublicKeysRoute.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/routes/eth2/CommitBoostPublicKeysRoute.java
@@ -44,7 +44,11 @@ public class CommitBoostPublicKeysRoute implements Web3SignerRoute {
               if (statusCode == 500) {
                 ctx.response()
                     .setStatusCode(statusCode)
-                    .end(new JsonObject().put("error", "Internal Server Error").encode());
+                    .end(
+                        new JsonObject()
+                            .put("code", statusCode)
+                            .put("message", "Internal Server Error")
+                            .encode());
               } else {
                 ctx.next(); // go to global failure handler
               }

--- a/core/src/main/java/tech/pegasys/web3signer/core/routes/eth2/CommitBoostPublicKeysRoute.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/routes/eth2/CommitBoostPublicKeysRoute.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.routes.eth2;
+
+import tech.pegasys.web3signer.core.Context;
+import tech.pegasys.web3signer.core.routes.Web3SignerRoute;
+import tech.pegasys.web3signer.core.service.http.handlers.commitboost.CommitBoostPublicKeysHandler;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.impl.BlockingHandlerDecorator;
+
+public class CommitBoostPublicKeysRoute implements Web3SignerRoute {
+  private static final String PATH = "/signer/v1/get_pubkeys";
+  private final Context context;
+
+  public CommitBoostPublicKeysRoute(final Context context) {
+    this.context = context;
+  }
+
+  @Override
+  public void register() {
+    context
+        .getRouter()
+        .route(HttpMethod.GET, PATH)
+        .produces(JSON_HEADER)
+        .handler(
+            new BlockingHandlerDecorator(
+                new CommitBoostPublicKeysHandler(context.getArtifactSignerProviders()), false))
+        .failureHandler(context.getErrorHandler())
+        .failureHandler(
+            ctx -> {
+              final int statusCode = ctx.statusCode();
+              if (statusCode == 500) {
+                ctx.response()
+                    .setStatusCode(statusCode)
+                    .end(new JsonObject().put("error", "Internal Server Error").encode());
+              } else {
+                ctx.next(); // go to global failure handler
+              }
+            });
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/commitboost/CommitBoostPublicKeysHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/commitboost/CommitBoostPublicKeysHandler.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service.http.handlers.commitboost;
+
+import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
+import static tech.pegasys.web3signer.core.service.http.handlers.ContentTypes.JSON_UTF_8;
+
+import tech.pegasys.web3signer.core.service.http.SigningObjectMapperFactory;
+import tech.pegasys.web3signer.core.service.http.handlers.commitboost.json.PublicKeyMappings;
+import tech.pegasys.web3signer.core.service.http.handlers.commitboost.json.PublicKeysResponse;
+import tech.pegasys.web3signer.signing.ArtifactSignerProvider;
+import tech.pegasys.web3signer.signing.KeyType;
+import tech.pegasys.web3signer.signing.config.DefaultArtifactSignerProvider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class CommitBoostPublicKeysHandler implements Handler<RoutingContext> {
+  private static final Logger LOG = LogManager.getLogger();
+  private final List<ArtifactSignerProvider> artifactSignerProviders;
+  private final ObjectMapper objectMapper = SigningObjectMapperFactory.createObjectMapper();
+
+  public CommitBoostPublicKeysHandler(final List<ArtifactSignerProvider> artifactSignerProviders) {
+    this.artifactSignerProviders = artifactSignerProviders;
+  }
+
+  @Override
+  public void handle(final RoutingContext context) {
+    // obtain DefaultArtifactSignerProvider as that is the only one we are dealing in eth2 mode.
+    final ArtifactSignerProvider artifactSignerProvider =
+        artifactSignerProviders.stream()
+            .filter(provider -> provider instanceof DefaultArtifactSignerProvider)
+            .findFirst()
+            .orElseThrow();
+
+    final PublicKeysResponse publicKeysResponse = toPublicKeysResponse(artifactSignerProvider);
+    try {
+      final String jsonEncoded = objectMapper.writeValueAsString(publicKeysResponse);
+      context.response().putHeader(CONTENT_TYPE, JSON_UTF_8).end(jsonEncoded);
+    } catch (final JsonProcessingException e) {
+      // this is not meant to happen
+      LOG.error("Failed to encode public keys response", e);
+      context.fail(500);
+    }
+  }
+
+  private PublicKeysResponse toPublicKeysResponse(final ArtifactSignerProvider provider) {
+    return new PublicKeysResponse(
+        provider.availableIdentifiers().stream()
+            .map(identifier -> toPublicKeyMappings(provider, identifier))
+            .collect(Collectors.toList()));
+  }
+
+  private static PublicKeyMappings toPublicKeyMappings(
+      final ArtifactSignerProvider provider, final String identifier) {
+    final Map<KeyType, List<String>> proxyIdentifiers = provider.getProxyIdentifiers(identifier);
+    final List<String> proxyBlsPublicKeys =
+        proxyIdentifiers.computeIfAbsent(KeyType.BLS, k -> List.of());
+    final List<String> proxyEcdsaPublicKeys =
+        proxyIdentifiers.computeIfAbsent(KeyType.SECP256K1, k -> List.of());
+    return new PublicKeyMappings(identifier, proxyBlsPublicKeys, proxyEcdsaPublicKeys);
+  }
+}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/commitboost/json/PublicKeyMappings.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/commitboost/json/PublicKeyMappings.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core.service.http.handlers.commitboost.json;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the public key mappings for get_pubkeys API
+ *
+ * @param consensus BLS Public Key in hex string format
+ * @param proxyBlsPublicKeys List of Proxy BLS Public Key in hex string format
+ * @param proxyEcdsaPublicKeys List of Proxy ECDSA (SECP256K1) Public Key in hex string format
+ */
+public record PublicKeyMappings(
+    @JsonProperty(value = "consensus") String consensus,
+    @JsonProperty(value = "proxy_bls") List<String> proxyBlsPublicKeys,
+    @JsonProperty(value = "proxy_ecdsa") List<String> proxyEcdsaPublicKeys) {}

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/commitboost/json/PublicKeysResponse.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/commitboost/json/PublicKeysResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ConsenSys AG.
+ * Copyright 2024 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,15 +10,11 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.web3signer.signing;
+package tech.pegasys.web3signer.core.service.http.handlers.commitboost.json;
 
-import org.apache.tuweni.bytes.Bytes;
+import java.util.List;
 
-public interface ArtifactSigner {
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-  String getIdentifier();
-
-  ArtifactSignature sign(final Bytes message);
-
-  KeyType getKeyType();
-}
+public record PublicKeysResponse(
+    @JsonProperty(value = "keys") List<PublicKeyMappings> publicKeys) {}

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/ArtifactSignerProvider.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/ArtifactSignerProvider.java
@@ -13,22 +13,61 @@
 package tech.pegasys.web3signer.signing;
 
 import java.io.Closeable;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Future;
 
 public interface ArtifactSignerProvider extends Closeable {
 
+  /**
+   * Load the signers from the underlying providers.
+   *
+   * @return a future that completes when the signers are loaded
+   */
   Future<Void> load();
 
+  /**
+   * Get the signer for the given identifier.
+   *
+   * @param identifier the identifier of the signer
+   * @return the signer or empty if no signer is found
+   */
   Optional<ArtifactSigner> getSigner(final String identifier);
 
+  /**
+   * Get the available identifiers for the loaded signers.
+   *
+   * @return the available identifiers
+   */
   Set<String> availableIdentifiers();
 
+  /**
+   * Get the proxy identifiers for the given identifier. Used for commit boost API.
+   *
+   * @param identifier the identifier of the signer
+   * @return Map of Key Type (BLS, SECP256K1) and corresponding proxy identifiers
+   */
+  Map<KeyType, List<String>> getProxyIdentifiers(final String identifier);
+
+  /**
+   * Add a new signer to the signer provider.
+   *
+   * @param signer the signer to add
+   * @return a future that completes when the signer is added
+   */
   Future<Void> addSigner(final ArtifactSigner signer);
 
+  /**
+   * Remove a signer from the signer provider.
+   *
+   * @param identifier signer to remove
+   * @return a future that completes when the signer is removed
+   */
   Future<Void> removeSigner(final String identifier);
 
+  /** Close the executor service and release any resources. */
   @Override
   void close();
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/BlsArtifactSigner.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/BlsArtifactSigner.java
@@ -51,6 +51,11 @@ public class BlsArtifactSigner implements ArtifactSigner {
     return new BlsArtifactSignature(BLS.sign(keyPair.getSecretKey(), data));
   }
 
+  @Override
+  public KeyType getKeyType() {
+    return KeyType.BLS;
+  }
+
   public Optional<String> getPath() {
     return path;
   }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/EthSecpArtifactSigner.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/EthSecpArtifactSigner.java
@@ -39,6 +39,11 @@ public class EthSecpArtifactSigner implements ArtifactSigner {
   }
 
   @Override
+  public KeyType getKeyType() {
+    return KeyType.SECP256K1;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/DefaultArtifactSignerProvider.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/DefaultArtifactSignerProvider.java
@@ -12,6 +12,9 @@
  */
 package tech.pegasys.web3signer.signing.config;
 
+import static tech.pegasys.web3signer.signing.KeyType.BLS;
+import static tech.pegasys.web3signer.signing.KeyType.SECP256K1;
+
 import tech.pegasys.web3signer.keystorage.common.MappedResults;
 import tech.pegasys.web3signer.signing.ArtifactSigner;
 import tech.pegasys.web3signer.signing.ArtifactSignerProvider;
@@ -19,6 +22,7 @@ import tech.pegasys.web3signer.signing.KeyType;
 import tech.pegasys.web3signer.signing.bulkloading.BlsKeystoreBulkLoader;
 import tech.pegasys.web3signer.signing.bulkloading.SecpV3KeystoresBulkLoader;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -72,47 +76,25 @@ public class DefaultArtifactSignerProvider implements ArtifactSignerProvider {
               .forEach(signers::putIfAbsent);
 
           // for each loaded signer, load commit boost proxy signers (if any)
-          commitBoostKeystoresParameters.ifPresent(
-              keystoreParameter -> {
-                if (!keystoreParameter.isEnabled()) {
-                  return;
-                }
-                signers.forEach(
-                    (identifier, __) -> {
-                      final Path identifierPath =
-                          keystoreParameter.getKeystoresPath().resolve(identifier);
-                      if (identifierPath.toFile().canRead()
-                          && identifierPath.toFile().isDirectory()) {
-                        final Path v4Dir = identifierPath.resolve("v4");
-
-                        if (v4Dir.toFile().canRead() && v4Dir.toFile().isDirectory()) {
-                          // load v4 proxy signers
-                          final BlsKeystoreBulkLoader v4Loader = new BlsKeystoreBulkLoader();
-                          final MappedResults<ArtifactSigner> blsSignersResult =
-                              v4Loader.loadKeystoresUsingPasswordFile(
-                                  v4Dir, keystoreParameter.getKeystoresPasswordFile());
-                          final Collection<ArtifactSigner> blsSigners =
-                              blsSignersResult.getValues();
-                          proxySigners
-                              .computeIfAbsent(identifier, k -> new ArrayList<>())
-                              .addAll(blsSigners);
-                        }
-
-                        final Path v3Dir = identifierPath.resolve("v3");
-                        if (v3Dir.toFile().canRead() && v3Dir.toFile().isDirectory()) {
-                          // load v3 proxy signers
-                          final MappedResults<ArtifactSigner> secpSignersResults =
-                              SecpV3KeystoresBulkLoader.loadV3KeystoresUsingPasswordFileOrDir(
-                                  v3Dir, keystoreParameter.getKeystoresPasswordFile());
-                          final Collection<ArtifactSigner> secpSigners =
-                              secpSignersResults.getValues();
-                          proxySigners
-                              .computeIfAbsent(identifier, k -> new ArrayList<>())
-                              .addAll(secpSigners);
-                        }
-                      }
-                    });
-              });
+          commitBoostKeystoresParameters
+              .filter(KeystoresParameters::isEnabled)
+              .ifPresent(
+                  keystoreParameter ->
+                      signers
+                          .keySet()
+                          .forEach(
+                              signerIdentifier -> {
+                                LOG.trace(
+                                    "Loading proxy signers for signer '{}' ...", signerIdentifier);
+                                final Path identifierPath =
+                                    keystoreParameter.getKeystoresPath().resolve(signerIdentifier);
+                                if (canReadFromDirectory(identifierPath)) {
+                                  loadBlsProxySigners(
+                                      keystoreParameter, signerIdentifier, identifierPath);
+                                  loadSecpProxySigners(
+                                      keystoreParameter, signerIdentifier, identifierPath);
+                                }
+                              }));
 
           LOG.info("Total signers (keys) currently loaded in memory: {}", signers.size());
           return null;
@@ -168,5 +150,42 @@ public class DefaultArtifactSignerProvider implements ArtifactSignerProvider {
   @Override
   public void close() {
     executorService.shutdownNow();
+  }
+
+  private static boolean canReadFromDirectory(final Path path) {
+    final File file = path.toFile();
+    return file.canRead() && file.isDirectory();
+  }
+
+  private void loadSecpProxySigners(
+      final KeystoresParameters keystoreParameter,
+      final String identifier,
+      final Path identifierPath) {
+    final Path proxySecpDir = identifierPath.resolve(SECP256K1.name());
+    if (canReadFromDirectory(proxySecpDir)) {
+      // load secp proxy signers
+      final MappedResults<ArtifactSigner> secpSignersResults =
+          SecpV3KeystoresBulkLoader.loadV3KeystoresUsingPasswordFileOrDir(
+              proxySecpDir, keystoreParameter.getKeystoresPasswordFile());
+      final Collection<ArtifactSigner> secpSigners = secpSignersResults.getValues();
+      proxySigners.computeIfAbsent(identifier, k -> new ArrayList<>()).addAll(secpSigners);
+    }
+  }
+
+  private void loadBlsProxySigners(
+      final KeystoresParameters keystoreParameter,
+      final String identifier,
+      final Path identifierPath) {
+    final Path proxyBlsDir = identifierPath.resolve(BLS.name());
+
+    if (canReadFromDirectory(proxyBlsDir)) {
+      // load bls proxy signers
+      final BlsKeystoreBulkLoader blsKeystoreBulkLoader = new BlsKeystoreBulkLoader();
+      final MappedResults<ArtifactSigner> blsSignersResult =
+          blsKeystoreBulkLoader.loadKeystoresUsingPasswordFile(
+              proxyBlsDir, keystoreParameter.getKeystoresPasswordFile());
+      final Collection<ArtifactSigner> blsSigners = blsSignersResult.getValues();
+      proxySigners.computeIfAbsent(identifier, k -> new ArrayList<>()).addAll(blsSigners);
+    }
   }
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/SecpArtifactSignerProviderAdapter.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/SecpArtifactSignerProviderAdapter.java
@@ -17,8 +17,10 @@ import static tech.pegasys.web3signer.signing.util.IdentifierUtils.normaliseIden
 
 import tech.pegasys.web3signer.signing.ArtifactSigner;
 import tech.pegasys.web3signer.signing.ArtifactSignerProvider;
+import tech.pegasys.web3signer.signing.KeyType;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -64,6 +66,11 @@ public class SecpArtifactSignerProviderAdapter implements ArtifactSignerProvider
   @Override
   public Set<String> availableIdentifiers() {
     return Set.copyOf(signers.keySet());
+  }
+
+  @Override
+  public Map<KeyType, List<String>> getProxyIdentifiers(final String identifier) {
+    throw new NotImplementedException();
   }
 
   @Override

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/config/DefaultArtifactSignerProviderTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/config/DefaultArtifactSignerProviderTest.java
@@ -156,7 +156,7 @@ class DefaultArtifactSignerProviderTest {
 
   @Test
   void emptyProxySignersAreLoadedSuccessfully() {
-    // enable commit boose without existing proxy keys
+    // enable commit boost without existing proxy keys
     final KeystoresParameters commitBoostParameters =
         new TestCommitBoostParameters(commitBoostKeystoresPath, commitBoostPasswordDir);
 
@@ -183,7 +183,8 @@ class DefaultArtifactSignerProviderTest {
   private List<BLSKeyPair> randomBLSV4Keystores(SecureRandom secureRandom, String identifier)
       throws IOException {
     final Path v4Dir =
-        Files.createDirectories(commitBoostKeystoresPath.resolve(identifier).resolve("v4"));
+        Files.createDirectories(
+            commitBoostKeystoresPath.resolve(identifier).resolve(KeyType.BLS.name()));
 
     return IntStream.range(0, 4)
         .mapToObj(
@@ -198,7 +199,8 @@ class DefaultArtifactSignerProviderTest {
   private List<ECKeyPair> randomSecpV3Keystores(
       final SecureRandom secureRandom, final String identifier) throws IOException {
     final Path v3Dir =
-        Files.createDirectories(commitBoostKeystoresPath.resolve(identifier).resolve("v3"));
+        Files.createDirectories(
+            commitBoostKeystoresPath.resolve(identifier).resolve(KeyType.SECP256K1.name()));
     return IntStream.range(0, 4)
         .mapToObj(
             i -> {

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/config/DefaultArtifactSignerProviderTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/config/DefaultArtifactSignerProviderTest.java
@@ -47,7 +47,7 @@ class DefaultArtifactSignerProviderTest {
     final ArtifactSigner mockSigner = mock(ArtifactSigner.class);
     when(mockSigner.getIdentifier()).thenReturn(PUBLIC_KEY1);
 
-    signerProvider = new DefaultArtifactSignerProvider(() -> List.of(mockSigner));
+    signerProvider = new DefaultArtifactSignerProvider(() -> List.of(mockSigner), Optional.empty());
     assertThatCode(() -> signerProvider.load().get()).doesNotThrowAnyException();
 
     final Optional<ArtifactSigner> signer = signerProvider.getSigner(PUBLIC_KEY1);
@@ -62,7 +62,9 @@ class DefaultArtifactSignerProviderTest {
     final ArtifactSigner mockSigner2 = mock(ArtifactSigner.class);
     when(mockSigner2.getIdentifier()).thenReturn(PUBLIC_KEY1);
 
-    signerProvider = new DefaultArtifactSignerProvider(() -> List.of(mockSigner1, mockSigner2));
+    signerProvider =
+        new DefaultArtifactSignerProvider(
+            () -> List.of(mockSigner1, mockSigner2), Optional.empty());
     assertThatCode(() -> signerProvider.load().get()).doesNotThrowAnyException();
 
     assertThat(signerProvider.availableIdentifiers()).hasSize(1);
@@ -76,7 +78,9 @@ class DefaultArtifactSignerProviderTest {
     final ArtifactSigner mockSigner2 = mock(ArtifactSigner.class);
     when(mockSigner2.getIdentifier()).thenReturn(PUBLIC_KEY2);
 
-    signerProvider = new DefaultArtifactSignerProvider(() -> List.of(mockSigner1, mockSigner2));
+    signerProvider =
+        new DefaultArtifactSignerProvider(
+            () -> List.of(mockSigner1, mockSigner2), Optional.empty());
     assertThatCode(() -> signerProvider.load().get()).doesNotThrowAnyException();
     assertThat(signerProvider.availableIdentifiers()).hasSize(2);
     assertThat(signerProvider.availableIdentifiers()).containsOnly(PUBLIC_KEY1, PUBLIC_KEY2);

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/config/DefaultArtifactSignerProviderTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/config/DefaultArtifactSignerProviderTest.java
@@ -17,23 +17,44 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import tech.pegasys.teku.bls.BLSKeyPair;
+import tech.pegasys.web3signer.KeystoreUtil;
 import tech.pegasys.web3signer.signing.ArtifactSigner;
 import tech.pegasys.web3signer.signing.ArtifactSignerProvider;
+import tech.pegasys.web3signer.signing.KeyType;
+import tech.pegasys.web3signer.signing.secp256k1.EthPublicKeyUtils;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.web3j.crypto.ECKeyPair;
+import org.web3j.crypto.Keys;
+import org.web3j.crypto.WalletUtils;
+import org.web3j.crypto.exception.CipherException;
 
 class DefaultArtifactSignerProviderTest {
 
   private static final String PUBLIC_KEY1 =
-      "989d34725a2bfc3f15105f3f5fc8741f436c25ee1ee4f948e425d6bcb8c56bce6e06c269635b7e985a7ffa639e2409bf";
+      "0x989d34725a2bfc3f15105f3f5fc8741f436c25ee1ee4f948e425d6bcb8c56bce6e06c269635b7e985a7ffa639e2409bf";
   private static final String PUBLIC_KEY2 =
-      "a99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c";
+      "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c";
 
   private ArtifactSignerProvider signerProvider;
+
+  @TempDir private Path commitBoostKeystoresPath;
+
+  @TempDir private Path commitBoostPasswordDir;
 
   @AfterEach
   void cleanup() {
@@ -84,5 +105,139 @@ class DefaultArtifactSignerProviderTest {
     assertThatCode(() -> signerProvider.load().get()).doesNotThrowAnyException();
     assertThat(signerProvider.availableIdentifiers()).hasSize(2);
     assertThat(signerProvider.availableIdentifiers()).containsOnly(PUBLIC_KEY1, PUBLIC_KEY2);
+  }
+
+  @Test
+  void proxySignersAreLoadedCorrectly() throws IOException {
+    final SecureRandom secureRandom = new SecureRandom();
+
+    // create random proxy signers
+    final KeystoresParameters commitBoostParameters =
+        new TestCommitBoostParameters(commitBoostKeystoresPath, commitBoostPasswordDir);
+
+    // create random BLS key pairs as proxy keys for public key1 and public key2
+    final List<BLSKeyPair> key1ProxyKeyPairs = randomBLSV4Keystores(secureRandom, PUBLIC_KEY1);
+    final List<BLSKeyPair> key2ProxyKeyPairs = randomBLSV4Keystores(secureRandom, PUBLIC_KEY2);
+
+    // create random secp key pairs as proxy keys for public key1 and public key2
+    final List<ECKeyPair> key1SecpKeyPairs = randomSecpV3Keystores(secureRandom, PUBLIC_KEY1);
+    final List<ECKeyPair> key2SecpKeyPairs = randomSecpV3Keystores(secureRandom, PUBLIC_KEY2);
+
+    // set up mock signers
+    final ArtifactSigner mockSigner1 = mock(ArtifactSigner.class);
+    when(mockSigner1.getIdentifier()).thenReturn(PUBLIC_KEY1);
+    final ArtifactSigner mockSigner2 = mock(ArtifactSigner.class);
+    when(mockSigner2.getIdentifier()).thenReturn(PUBLIC_KEY2);
+
+    signerProvider =
+        new DefaultArtifactSignerProvider(
+            () -> List.of(mockSigner1, mockSigner2), Optional.of(commitBoostParameters));
+
+    // methods under test
+    assertThatCode(() -> signerProvider.load().get()).doesNotThrowAnyException();
+
+    // assert that the proxy keys are loaded correctly
+    final Map<KeyType, List<String>> key1ProxyPublicKeys =
+        signerProvider.getProxyIdentifiers(PUBLIC_KEY1);
+
+    assertThat(key1ProxyPublicKeys.get(KeyType.BLS))
+        .containsExactlyInAnyOrder(getPublicKeysArray(key1ProxyKeyPairs));
+    assertThat(key1ProxyPublicKeys.get(KeyType.SECP256K1))
+        .containsExactlyInAnyOrder(getSecpPublicKeysArray(key1SecpKeyPairs));
+
+    final Map<KeyType, List<String>> key2ProxyPublicKeys =
+        signerProvider.getProxyIdentifiers(PUBLIC_KEY2);
+
+    assertThat(key2ProxyPublicKeys.get(KeyType.BLS))
+        .containsExactlyInAnyOrder(getPublicKeysArray(key2ProxyKeyPairs));
+    assertThat(key2ProxyPublicKeys.get(KeyType.SECP256K1))
+        .containsExactlyInAnyOrder(getSecpPublicKeysArray(key2SecpKeyPairs));
+  }
+
+  private List<BLSKeyPair> randomBLSV4Keystores(SecureRandom secureRandom, String identifier)
+      throws IOException {
+    final Path v4Dir =
+        Files.createDirectories(commitBoostKeystoresPath.resolve(identifier).resolve("v4"));
+
+    return IntStream.range(0, 4)
+        .mapToObj(
+            i -> {
+              final BLSKeyPair blsKeyPair = BLSKeyPair.random(secureRandom);
+              KeystoreUtil.createKeystoreFile(blsKeyPair, v4Dir, "password");
+              return blsKeyPair;
+            })
+        .toList();
+  }
+
+  private List<ECKeyPair> randomSecpV3Keystores(
+      final SecureRandom secureRandom, final String identifier) throws IOException {
+    final Path v3Dir =
+        Files.createDirectories(commitBoostKeystoresPath.resolve(identifier).resolve("v3"));
+    return IntStream.range(0, 4)
+        .mapToObj(
+            i -> {
+              try {
+                final ECKeyPair ecKeyPair = Keys.createEcKeyPair(secureRandom);
+                WalletUtils.generateWalletFile("password", ecKeyPair, v3Dir.toFile(), false);
+                return ecKeyPair;
+              } catch (GeneralSecurityException | CipherException | IOException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .toList();
+  }
+
+  private static String[] getPublicKeysArray(final List<BLSKeyPair> blsKeyPairs) {
+    return blsKeyPairs.stream()
+        .map(keyPair -> keyPair.getPublicKey().toString())
+        .toList()
+        .toArray(String[]::new);
+  }
+
+  private static String[] getSecpPublicKeysArray(final List<ECKeyPair> ecKeyPairs) {
+    return ecKeyPairs.stream()
+        .map(
+            keyPair ->
+                EthPublicKeyUtils.toHexString(
+                    EthPublicKeyUtils.createPublicKey(keyPair.getPublicKey())))
+        .toList()
+        .toArray(String[]::new);
+  }
+
+  private static class TestCommitBoostParameters implements KeystoresParameters {
+    private final Path keystorePath;
+    private final Path passwordFile;
+
+    public TestCommitBoostParameters(final Path keystorePath, final Path passwordDir) {
+      this.keystorePath = keystorePath;
+      // create password file in passwordDir
+      this.passwordFile = passwordDir.resolve("password.txt");
+      // write text to password file
+      try {
+        Files.writeString(passwordFile, "password");
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    @Override
+    public Path getKeystoresPath() {
+      return keystorePath;
+    }
+
+    @Override
+    public Path getKeystoresPasswordsPath() {
+      return null;
+    }
+
+    @Override
+    public Path getKeystoresPasswordFile() {
+      return passwordFile;
+    }
+
+    @Override
+    public boolean isEnabled() {
+      return true;
+    }
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
feat: Commit boost API - Get Public Keys. Implementing commit boost API as defined at https://commit-boost.github.io/commit-boost-client/api

### **Note:** This PR does not return compressed SECP public key. This will be handled in PR #1033 

 - [x] CLI options. 
 - [x] `--commit-boost-api-enabled=<true|false>`. To enable commit boost API 
 - [x] `--proxy-keystores-path`. Path to the directory that will read and store encrypted proxy keys in v4 (BLS) and v3 (SECP) formats.
 - [x] `--proxy-keystores-password-file`. The path to file that contains password to encrypt and decrypt proxy keystores.
 - [x] Implement route and handlers for `/signer/v1/get_pubkeys`
 - [x] Load proxy signers from local directories

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
See #1017

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.
