### PR TITLE
log4j: replace status (deprecated) with level

### DIFF
--- a/acceptance-tests/src/test/resources/log4j2.xml
+++ b/acceptance-tests/src/test/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration level="INFO">
   <Properties>
     <Property name="root.log.level">DEBUG</Property>
     <Property name="dependency.log.level">WARN</Property>

--- a/app/src/main/resources/log4j2.xml
+++ b/app/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration level="INFO">
   <Properties>
     <Property name="root.log.level">INFO</Property>
     <Property name="dependency.log.level">INFO</Property>

--- a/core/src/integrationTest/resources/log4j2.xml
+++ b/core/src/integrationTest/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration level="INFO">
   <Properties>
     <Property name="root.log.level">DEBUG</Property>
   </Properties>

--- a/signing/src/test/resources/log4j2-test.xml
+++ b/signing/src/test/resources/log4j2-test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration level="INFO">
     <Properties>
         <Property name="root.log.level">DEBUG</Property>
         <Property name="dependency.log.level">WARN</Property>

--- a/slashing-protection/referencetests/src/test/resources/log4j2.xml
+++ b/slashing-protection/referencetests/src/test/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration level="INFO">
   <Properties>
     <Property name="root.log.level">DEBUG</Property>
     <Property name="dependency.log.level">WARN</Property>

--- a/slashing-protection/src/integration-test/resources/log4j2.xml
+++ b/slashing-protection/src/integration-test/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration level="INFO">
   <Properties>
     <Property name="root.log.level">DEBUG</Property>
   </Properties>

--- a/slashing-protection/src/test/resources/log4j2.xml
+++ b/slashing-protection/src/test/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration level="INFO">
   <Properties>
     <Property name="root.log.level">DEBUG</Property>
   </Properties>


### PR DESCRIPTION
 The attribute status has been deprecated in log4j since log4j version 2.24.0. Reference: https://logging.apache.org/log4j/2.x/manual/configuration.html#configuration-attribute-status


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [ ] I thought about testing these changes in a realistic/non-local environment.
