### PR TITLE
Upgrade Netty version to fix CVE-2025-24970

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The above are replaced by:
 
 ### Bugs Fixed:
 - AWS KMS tag filter behavior has been fixed. [#1055][pr_1055]
+- Upgrade Netty library to 4.1.118.Final to fix CVE-2025-24970.
 
 [issue_1018]: https://github.com/Consensys/web3signer/issues/1018
 [pr_1054]: https://github.com/Consensys/web3signer/pull/1054

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
 }
 
 plugins {
-  id 'org.owasp.dependencycheck' version "11.1.0"
+  id 'org.owasp.dependencycheck' version "12.0.2"
   id 'java-test-fixtures'
   id 'com.diffplug.spotless' version '7.0.0.BETA4'
   id 'com.github.ben-manes.versions' version '0.51.0' //`./gradlew dependencyUpdates` to report outdated dependencies
@@ -117,7 +117,6 @@ allprojects {
     maven { url "https://artifacts.consensys.net/public/maven/maven/" }
     maven { url "https://artifacts.consensys.net/public/teku/maven/" }
     maven { url "https://hyperledger.jfrog.io/artifactory/besu-maven" }
-    maven { url "https://hyperledger-org.bintray.com/besu-repo/" }
     maven { url "https://jitpack.io" }
   }
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -176,8 +176,8 @@ dependencyManagement {
     // addresses CVE-2023-3635
     dependency 'com.squareup.okio:okio:3.4.0'
 
-    // addressing CVE-2023-44487, CVE-2024-47535
-    dependencySet(group: 'io.netty', version: '4.1.115.Final') {
+    // addressing CVE-2025-24970
+    dependencySet(group: 'io.netty', version: '4.1.118.Final') {
       entry 'netty-all'
       entry 'netty-codec-http2'
       entry 'netty-handler'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Upgrade Netty version to fix CVE-2025-24970


