### PR TITLE
chore: Use info flag with owasp dependency to keep circleci job output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
           name: Dependency vulnerability scan
           no_output_timeout: 40m
           command: |
-            ./gradlew --no-daemon -Dorg.gradle.parallel=false dependencyCheckAggregate -DnvdApiDelay=6000
+            ./gradlew --no-daemon --info dependencyCheckAggregate -DnvdApiDelay=6000
       - capture_test_results
       - capture_test_reports
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Use info flag with owasp dependency to keep circleci job output
