### PR TITLE
specs for glamsterdam

### DIFF
--- a/openapi-specs/eth2/signing/paths/sign.yaml
+++ b/openapi-specs/eth2/signing/paths/sign.yaml
@@ -31,6 +31,7 @@ post:
             - $ref: '../schemas.yaml#/components/schemas/SyncCommitteeSelectionProofSigning'
             - $ref: '../schemas.yaml#/components/schemas/SyncCommitteeContributionAndProofSigning'
             - $ref: '../schemas.yaml#/components/schemas/ValidatorRegistrationSigning'
+            - $ref: '../schemas.yaml#/components/schemas/PayloadAttestationMessageSigning'
           discriminator:
             propertyName: type
             mapping:
@@ -47,6 +48,7 @@ post:
               SYNC_COMMITTEE_SELECTION_PROOF: '../schemas.yaml#/components/schemas/SyncCommitteeSelectionProofSigning'
               SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF: '../schemas.yaml#/components/schemas/SyncCommitteeContributionAndProofSigning'
               VALIDATOR_REGISTRATION: '../schemas.yaml#/components/schemas/ValidatorRegistrationSigning'
+              PAYLOAD_ATTESTATION_MESSAGE: '../schemas.yaml#/components/schemas/PayloadAttestationMessageSigning'
         examples:
           BLOCK_V2 (FULU):
             value:

--- a/openapi-specs/eth2/signing/schemas.yaml
+++ b/openapi-specs/eth2/signing/schemas.yaml
@@ -324,6 +324,21 @@ components:
           required:
             - type
             - contribution_and_proof
+    PayloadAttestationMessageSigning:
+      allOf:
+        - $ref: '#/components/schemas/Signing'
+        - type: object
+          properties:
+            type:
+              type: "string"
+              description: Signing Request type
+              enum:
+                - 'PAYLOAD_ATTESTATION_MESSAGE'
+            payload_attestation_message:
+              $ref: "#/components/schemas/PayloadAttestationData"
+          required:
+            - type
+            - payload_attestation_message
     ValidatorRegistrationSigning:
       allOf:
         - type: object
@@ -571,6 +586,26 @@ components:
         selection_proof:
           type: string
           description: Bytes96 hexadecimal
+    PayloadAttestationData:
+      type: object
+      description: >-
+        The data component of a PayloadAttestationMessage, signed by a PTC
+        validator using DOMAIN_PTC_ATTESTER (0x0C000000).
+      properties:
+        beacon_block_root:
+          type: string
+          description: Bytes32 hexadecimal
+          example: '0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2'
+        slot:
+          type: string
+          format: uint64
+          example: '1'
+        payload_present:
+          type: boolean
+          description: Whether the execution payload for this slot is present
+        blob_data_available:
+          type: boolean
+          description: Whether blob data is available for this slot
     SyncCommitteeMessage:
       type: object
       properties:


### PR DESCRIPTION
## PR Description

  - schemas.yaml: Added PayloadAttestationMessageSigning (the signing request schema) and PayloadAttestationData (the inner data object with its 4 fields)
  - sign.yaml: Added PayloadAttestationMessageSigning to the oneOf list and PAYLOAD_ATTESTATION_MESSAGE to the discriminator mapping


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [ ] I thought about testing these changes in a realistic/non-local environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive OpenAPI schema changes only; main risk is downstream client/server codegen needing to handle the new discriminator type.
> 
> **Overview**
> Adds a new signing request type, `PAYLOAD_ATTESTATION_MESSAGE`, to the signing API spec.
> 
> Updates `paths/sign.yaml` to accept the new request in the `oneOf` payload and discriminator mapping, and extends `schemas.yaml` with `PayloadAttestationMessageSigning` plus its inner `PayloadAttestationData` object (block root, slot, and two availability booleans).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fecee021be33387da3255022c59d3d9b7a17fb4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->