### PR TITLE
add renovatebot

### DIFF
--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -1,0 +1,23 @@
+name: renovatebot
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+jobs:
+  renovatebot-check:
+    runs-on: ubuntu-24.04
+    environment: security
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run renovatebot
+        uses: ConsenSys/github-actions/renovatebot@0dbddeeb180c249e624dc1681c67f22325daedd5 # main
+        with:
+          GH_APP_ID: ${{ secrets.GH_APP_ID }}
+          GH_PRIVATE_KEY: ${{ secrets.GH_PRIVATE_KEY }}
+          GH_REPOSITORY: ${{ github.repository }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "dependencyDashboard": false,
+  "packageRules": [
+    {
+      "description": "1. Pin all GitHub Actions to sha256 digests by default",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    },
+    {
+      "description": "2. For trusted actions, allow updates",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "actions/**",
+        "consensys/github-actions/**"
+      ],
+      "pinDigests": true
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
add renovatebot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an automated dependency update workflow and Renovate configuration without changing runtime code paths. Main risk is CI noise or misconfigured secrets/permissions for the GitHub App execution.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/renovatebot.yml`) to run Renovate via the `ConsenSys/github-actions/renovatebot` action, using GitHub App credentials from repository secrets and scoped to the `security` environment.
> 
> Introduces a `renovate.json` config extending `config:recommended`, disabling the dependency dashboard, and enforcing digest pinning for GitHub Actions (with trusted `actions/**` and `consensys/github-actions/**` included in the rule set).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76fa68c07d77455be7d3d313ee5122d7e264ce79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->