### PR TITLE
ci: make in CI workflow green

### DIFF
--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -34,11 +34,6 @@ runs:
       run: echo "<h2>Test Results</h2>" >> $GITHUB_STEP_SUMMARY
       shell: bash
 
-    # v1.0.10
-    - name: Summarize tests results
-      uses: jeantessier/test-summary-action@1899972db6579bbc1678a74921a876e04c355180
-      if: always()
-
     - name: Upload build reports
       uses: actions/upload-artifact@v7
       if: always()

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -29,11 +29,6 @@ runs:
       run: ./gradlew acceptanceTest
       shell: bash
 
-    - name: Build Step Output
-      if: always()
-      run: echo "<h2>Test Results</h2>" >> $GITHUB_STEP_SUMMARY
-      shell: bash
-
     - name: Upload build reports
       uses: actions/upload-artifact@v7
       if: always()

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -160,7 +160,7 @@ jobs:
 
       # 4
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@603b7971775f0a3592c3008453f65675e076628b
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -148,23 +148,6 @@ jobs:
           SUMMARY_CONTENT+="\n</code></pre></details>\n"
           echo -e "$SUMMARY_CONTENT" >> $GITHUB_STEP_SUMMARY  
 
-      # 0.35.0
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
-        with:
-          image-ref: 'consensys/web3signer:test'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-
-      # 4
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
-
       # v4.0.0
       - name: Login to Docker Hub
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -36,13 +36,6 @@ jobs:
         id: project-version
         uses: ConsenSys/github-actions/java-get-project-version@main
 
-      # v0.3.0
-      - name: Start LocalStack (AWS)
-        id: localstack
-        uses: LocalStack/setup-localstack@2e0e14048ddaf0db551b45fdaa39d3553f2c6399
-        with:
-          image-tag: 'latest'
-          configuration: LOCALSTACK_DEBUG=1
       # v3
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
@@ -55,14 +48,6 @@ jobs:
         id: build-test
         uses: ./.github/actions/build-test
         env:
-          AWS_REGION: 'us-east-2'
-          AWS_ACCESS_KEY_ID: 'test'
-          AWS_SECRET_ACCESS_KEY: 'test'
-          RW_AWS_ACCESS_KEY_ID: 'test'
-          RW_AWS_SECRET_ACCESS_KEY: 'test'
-          AWS_ACCESS_KEY_ID_TEST2: 'test2'
-          AWS_SECRET_ACCESS_KEY_TEST2: 'test2'
-          AWS_ENDPOINT_OVERRIDE: 'http://127.0.0.1:4566'
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_INVALID_KEY_VAULT_NAME: ${{ secrets.AZURE_INVALID_KEY_VAULT_NAME }}

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -160,7 +160,7 @@ jobs:
 
       # 4
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@914d7a8ee403759976378e9102c842b0059e5163
+        uses: github/codeql-action/upload-sarif@603b7971775f0a3592c3008453f65675e076628b
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
       # 4
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@603b7971775f0a3592c3008453f65675e076628b
         with:
           languages: java-kotlin
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -44,7 +44,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@603b7971775f0a3592c3008453f65675e076628b
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -59,4 +59,4 @@ jobs:
 
       # 4
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@603b7971775f0a3592c3008453f65675e076628b

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
       # 4
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@603b7971775f0a3592c3008453f65675e076628b
+        uses: github/codeql-action/init@v4
         with:
           languages: java-kotlin
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -44,7 +44,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@603b7971775f0a3592c3008453f65675e076628b
+        uses: github/codeql-action/autobuild@v4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -59,4 +59,4 @@ jobs:
 
       # 4
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@603b7971775f0a3592c3008453f65675e076628b
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

Temporarily disable actions that are not in the Consensys org allowed list to unblock CI.

- **LocalStack**: Disable `LocalStack/setup-localstack` step and remove associated AWS env variables (auth token not yet configured)
- **test-summary-action**: Remove `jeantessier/test-summary-action` step and its summary header (not in org allowed list)
- **Trivy scanner**: Disable `aquasecurity/trivy-action` and its sarif upload step (`setup-trivy` transitive dependency not in allowed list — pending sysops exception)

These should be re-enabled once the org allowed actions list is updated.