### PR TITLE
ci: temporarily disable renovatebot auto-trigger

### DIFF
--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -1,11 +1,6 @@
 name: renovatebot
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - '.github/workflows/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Remove push trigger from renovatebot workflow, keeping only `workflow_dispatch`
- `ConsenSys/github-actions/renovatebot` internally calls `renovatebot/github-action@v40.1.11` which is not in the org's allowed actions list
- Can be re-enabled once sysops adds the exception

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes GitHub Actions workflow triggers and does not affect runtime application code. The main impact is reduced automated dependency update coverage until re-enabled.
> 
> **Overview**
> **Renovatebot is no longer auto-triggered on pushes.** The `.github/workflows/renovatebot.yml` workflow removes the `push` trigger (including the workflow-path filter) and keeps only `workflow_dispatch`, so Renovate runs only when manually started.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe0b2e1b3191e255b34c059aed87565bf10add31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->