### PR TITLE
adding in dependabot and codeowners config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  # Java/Gradle deps
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -1,6 +1,13 @@
 name: renovatebot
 
 on:
+  schedule:
+    - cron: "15 3 1 * *"
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/**'
   workflow_dispatch:
 
 jobs:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+*         @consensys/protocols
+
+.github/workflows/  @consensys/protocols @consensys/protocol-galileo

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "enabledManagers": ["github-actions"],
   "dependencyDashboard": false,
   "packageRules": [
     {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
adding in dependabot and codeowners config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to repo automation/config (dependency update tooling and ownership rules) and don’t affect runtime code paths.
> 
> **Overview**
> Adds repo governance and dependency update automation: introduces a `dependabot.yml` to open weekly Gradle dependency update PRs (labeled `dependencies`) and adds a `CODEOWNERS` file assigning default ownership and additional owners for `.github/workflows/`.
> 
> Updates the existing Renovate setup to run on a monthly schedule and on workflow changes, and restricts Renovate to the `github-actions` manager via `renovate.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a49dd0f1d4dc35e61ac91dc35c8637a9f8a836b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->