### PR TITLE
perf: eliminate jdbi parsed-SQL cache leak in ValidatorsDao

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## 26.4.1
 ### Bugs Fixed
 - Fix memory leak in the reload endpoint: removed validators were not being offloaded from the slashing-protection in-memory cache, and every reload unnecessarily re-registered all validators, causing old-gen heap pressure. Reload now processes only the delta of added/removed keys. PR [#1167][PR_1167].
+- Fix jdbi parsed-SQL cache growth in `ValidatorsDao` by replacing inlined values and bindList expansions with parameterized array bindings. PR [#1170][PR_1170].
 
 [PR_1167]: https://github.com/Consensys/web3signer/pull/1167
+[PR_1170]: https://github.com/Consensys/web3signer/pull/1170
 
 ---
 ## 26.4.0

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -133,7 +133,7 @@ dependencyManagement {
     dependency 'com.zaxxer:HikariCP:7.0.2'
     dependency 'org.postgresql:postgresql:42.7.8'
 
-    dependencySet(group: 'org.jdbi', version: '3.49.6') {
+    dependencySet(group: 'org.jdbi', version: '3.52.1') {
       entry 'jdbi3-core'
       entry 'jdbi3-sqlobject'
       entry 'jdbi3-testing'

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbConnection.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/DbConnection.java
@@ -89,6 +89,7 @@ public class DbConnection {
         .register(new BytesColumnMapper())
         .register(new Bytes32ColumnMapper())
         .register(new UInt64ColumnMapper());
+    jdbi.registerArrayType(Integer.class, "integer");
     jdbi.setTransactionHandler(new SerializableTransactionRunner());
   }
 

--- a/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/ValidatorsDao.java
+++ b/slashing-protection/src/main/java/tech/pegasys/web3signer/slashingprotection/dao/ValidatorsDao.java
@@ -13,31 +13,30 @@
 package tech.pegasys.web3signer.slashingprotection.dao;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.argument.Argument;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 
 public class ValidatorsDao {
 
   public List<Validator> registerValidators(final Handle handle, final List<Bytes> validators) {
-    // adapted from https://stackoverflow.com/a/66704110/535610
+    // Postgres JDBC's createArrayOf("bytea", ...) requires a byte[][]; jdbi's
+    // bindArray wraps elements into Object[] which breaks for bytea. Bind the
+    // array via an Argument lambda so the byte[][] reaches the driver intact.
+    final byte[][] byteArrays =
+        validators.stream().map(Bytes::toArrayUnsafe).toArray(byte[][]::new);
+    final Argument keysArg =
+        (position, statement, ctx) ->
+            statement.setArray(
+                position, statement.getConnection().createArrayOf("bytea", byteArrays));
     return handle
-        .createQuery(
-            String.format(
-                "SELECT v_id as id, v_public_key as public_key FROM upsert_validators(array[%s])",
-                buildArrayArgument(validators)))
+        .createQuery("SELECT v_id as id, v_public_key as public_key FROM upsert_validators(:keys)")
+        .bind("keys", keysArg)
         .mapToBean(Validator.class)
         .list();
-  }
-
-  private String buildArrayArgument(final List<Bytes> validators) {
-    return validators.stream()
-        .map(Bytes::toUnprefixedHexString)
-        .map(hex -> String.format("decode('%s','hex')", hex))
-        .collect(Collectors.joining(","));
   }
 
   public List<Validator> retrieveValidators(
@@ -80,9 +79,9 @@ public class ValidatorsDao {
       return;
     }
     handle
-        .createUpdate("UPDATE validators SET enabled = :enabled WHERE id IN (<validatorIds>)")
+        .createUpdate("UPDATE validators SET enabled = :enabled WHERE id = ANY(:ids)")
         .bind("enabled", enabled)
-        .bindList("validatorIds", validatorIds)
+        .bindArray("ids", Integer.class, validatorIds)
         .execute();
   }
 


### PR DESCRIPTION
## Summary
Eliminates a pre-existing jdbi parsed-SQL cache leak in `ValidatorsDao`. Discovered while soak-testing the reload-path fix in #1167 — both the reload path and the keymanager-add path were affected.

Together with #1167 (already merged), this addresses the gradual memory growth and eventual OOMs reported in #1073.

## Root cause
- `registerValidators` built a unique SQL string per call by inlining each public key as `decode('<hex>','hex')` via `String.format`. jdbi's `ParsedSql` cache stashed a fresh parsed form with thousands of internal String tokens every reload.
- `setEnabledBatch` used `bindList("validatorIds", ids)` which rewrites `IN (<validatorIds>)` into `IN (:__validatorIds_0, :__validatorIds_1, ...)` at query-rewrite time — so each distinct batch size produces a different cached SQL.

Eclipse MAT on a 30-cycle full-replace soak identified `org.jdbi.v3.core.Jdbi` as the top leak suspect (retained ~65 MB).

## Fix
Both queries now use static SQL with parameterized array bindings:
- `registerValidators` → `upsert_validators(:keys)` where `:keys` is a `bytea[]` bound via an `Argument` lambda. The Postgres JDBC driver needs `byte[][]` passed directly to `createArrayOf`; jdbi's built-in `bindArray` routes through `Object[]` which Postgres rejects for bytea (`UnsupportedOperationException: byte[] nested inside Object[]`).
- `setEnabledBatch` → `WHERE id = ANY(:ids)` where `:ids` is an `integer[]` bound via `bindArray` against a registered array type.

Bumps jdbi to 3.52.1.

## Empirical verification

30-cycle full-replace soak at 5000 keys on JDK-25 images, post-GC heap captured each cycle:

| Build | Cycle 0 heap | Cycle 30 heap | Growth |
|-------|-------------:|--------------:|-------:|
| #1167 only (no jdbi fix) | 45.6 MB | 115.6 MB | **+70 MB** |
| #1167 + this fix | 42.8 MB | 50.2 MB | **+7.4 MB** |

Eclipse MAT on the cycle-30 heap dump after this fix: jdbi retained heap drops from **~65 MB to ~5 MB** (13× reduction). The remaining ~5 MB is normal bounded jdbi LRU.

5-cycle sign-mode soak at 5000 keys (10 k6 VUs, 60 s sustained sign load per cycle): heap stays at ~45 MB across cycles, 0 failed requests, p95 latency ~15 ms.

## Test plan
- [x] `./gradlew :slashing-protection:test` — all DAO and integration tests pass
- [x] 30-cycle full-replace soak vs #1167 baseline — heap growth reduced ~10×
- [x] 5-minute sign-load soak — heap flat, 0 failures

Relates to #1073.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches slashing-protection database write paths and upgrades `org.jdbi` versions; mistakes in Postgres array binding/type registration could break validator registration or batch enable/disable operations at runtime.
> 
> **Overview**
> Prevents unbounded jdbi parsed-SQL cache growth in slashing-protection by replacing dynamically generated SQL and `bindList`-expanded `IN (...)` clauses with **static queries using Postgres array parameters**.
> 
> `ValidatorsDao.registerValidators` now binds validator public keys as a `bytea[]` via a custom `Argument`, and `setEnabledBatch` now uses `WHERE id = ANY(:ids)` with `bindArray` (with `Integer` array type registered in `DbConnection`). Also bumps `org.jdbi` from `3.49.6` to `3.52.1` and documents the fix in the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c962cdd5d0a5c4921581e6fdbb7c2d18e9834b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->