### PR TITLE
feat: add distroless Docker image variant (#1151)

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -72,6 +72,10 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     environment: docker
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [default, distroless]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -94,21 +98,36 @@ jobs:
 
       - name: Docker Metadata
         id: docker-metadata
+        env:
+          VARIANT: ${{ matrix.variant }}
+          PUBLISH_VERSION: ${{ needs.build.outputs.publish-version }}
         run: |
+          # Resolve variant-specific settings
+          if [ "$VARIANT" = "distroless" ]; then
+            DOCKERFILE="docker/Dockerfile.distroless"
+            SUFFIX="-distroless"
+          else
+            DOCKERFILE="docker/Dockerfile"
+            SUFFIX=""
+          fi
+          echo "dockerfile=$DOCKERFILE" >> $GITHUB_OUTPUT
+          echo "tag-suffix=$SUFFIX" >> $GITHUB_OUTPUT
+          echo "test-tag=consensys/web3signer:test${SUFFIX}" >> $GITHUB_OUTPUT
+
           # Calculate Docker Tags
-          TAGS="consensys/web3signer:${{ needs.build.outputs.publish-version }}"
-          if [ "${{ needs.build.outputs.publish-version }}" != "develop" ]; then
-            TAGS="$TAGS,consensys/web3signer:latest"
+          TAGS="consensys/web3signer:${PUBLISH_VERSION}${SUFFIX}"
+          if [ "$PUBLISH_VERSION" != "develop" ]; then
+            TAGS="$TAGS,consensys/web3signer:latest${SUFFIX}"
           fi
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
-          
+
           # Determine Push Flag
           if [ "${{ github.event_name }}" == "pull_request" ] || [ "${{ github.event_name }}" == "schedule" ]; then
             echo "push=false" >> $GITHUB_OUTPUT
           else
             echo "push=true" >> $GITHUB_OUTPUT
           fi
-          
+
           # Set Build Args
           echo "build-date=$(date --utc --rfc-3339=seconds)" >> $GITHUB_OUTPUT
           echo "vcs-ref=${{ github.sha }}" >> $GITHUB_OUTPUT
@@ -119,7 +138,7 @@ jobs:
         env:
           DOCKER_BUILD_SUMMARY: false
         with:
-          file: docker/Dockerfile
+          file: ${{ steps.docker-metadata.outputs.dockerfile }}
           context: .
           build-args: |
             TAR_FILE=./build/distributions/web3signer-${{ needs.build.outputs.publish-version }}.tar.gz
@@ -129,24 +148,40 @@ jobs:
           no-cache: true
           load: true
           pull: true
-          tags: consensys/web3signer:test
+          tags: ${{ steps.docker-metadata.outputs.test-tag }}
 
       - name: Get absolute path of reports directory
         id: get-reports-dir
         run: echo "path=$(realpath ./build/reports)" >> $GITHUB_OUTPUT
 
-      - name: Run Docker tests
-        run: ./docker/test.sh 'consensys/web3signer:test' '${{ steps.get-reports-dir.outputs.path }}'
+      - name: Run Docker tests (default variant)
+        if: matrix.variant == 'default'
+        run: ./docker/test.sh '${{ steps.docker-metadata.outputs.test-tag }}' '${{ steps.get-reports-dir.outputs.path }}'
+
+      - name: Run Docker smoke test (distroless variant)
+        if: matrix.variant == 'distroless'
+        run: ./docker/test-distroless.sh '${{ steps.docker-metadata.outputs.test-tag }}' '${{ steps.get-reports-dir.outputs.path }}'
 
       - name: Test Summary
         if: always()
+        env:
+          VARIANT: ${{ matrix.variant }}
         run: |
-          SUMMARY_CONTENT="<h2>Docker Test Summary</h2>\n"
+          if [ "$VARIANT" = "distroless" ]; then
+            REPORT_FILE="./build/reports/smoke-report.txt"
+          else
+            REPORT_FILE="./build/reports/goss-report.txt"
+          fi
+          SUMMARY_CONTENT="<h2>Docker Test Summary (${VARIANT})</h2>\n"
           SUMMARY_CONTENT+="<details><summary><strong>Details</strong></summary>\n"
           SUMMARY_CONTENT+="<pre><code>\n"
-          SUMMARY_CONTENT+=$(cat ./build/reports/goss-report.txt)
+          if [ -f "$REPORT_FILE" ]; then
+            SUMMARY_CONTENT+=$(cat "$REPORT_FILE")
+          else
+            SUMMARY_CONTENT+="(no report produced)"
+          fi
           SUMMARY_CONTENT+="\n</code></pre></details>\n"
-          echo -e "$SUMMARY_CONTENT" >> $GITHUB_STEP_SUMMARY  
+          echo -e "$SUMMARY_CONTENT" >> $GITHUB_STEP_SUMMARY
 
       # v4.0.0
       - name: Login to Docker Hub
@@ -161,7 +196,7 @@ jobs:
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           platforms: linux/amd64,linux/arm64
-          file: docker/Dockerfile
+          file: ${{ steps.docker-metadata.outputs.dockerfile }}
           context: .
           build-args: |
             TAR_FILE=./build/distributions/web3signer-${{ needs.build.outputs.publish-version }}.tar.gz
@@ -283,7 +318,11 @@ jobs:
             echo "| [web3signer.zip](https://github.com/Consensys/web3signer/releases/download/${TAG}/web3signer-${TAG}.zip)    | [Checksum](https://github.com/Consensys/web3signer/releases/download/${TAG}/web3signer-${TAG}.zip.sha256) |"
             echo ""
             echo "### Docker"
+            echo "Default image (Ubuntu + Eclipse Temurin JRE 25):"
             echo "\`docker pull consensys/web3signer:${TAG}\`"
+            echo ""
+            echo "Hardened image (Google Distroless, read-only-filesystem compatible):"
+            echo "\`docker pull consensys/web3signer:${TAG}-distroless\`"
             echo ""
             echo "---"
             echo "**Full Changelog**: https://github.com/Consensys/web3signer/compare/${PREV_TAG}...${TAG}"

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -129,7 +129,7 @@ jobs:
           fi
 
           # Set Build Args
-          echo "build-date=$(date --utc --rfc-3339=seconds)" >> $GITHUB_OUTPUT
+          echo "build-date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
           echo "vcs-ref=${{ github.sha }}" >> $GITHUB_OUTPUT
 
       # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
 ## 26.4.1
+### Features Added
+- Publish an additional hardened Docker image under the `-distroless` tag suffix (e.g. `consensys/web3signer:${version}-distroless`). Built from `gcr.io/distroless/java25-debian13:nonroot` — no shell, runs as non-root by default, and is compatible with `docker run --read-only`. See issue [#1151][issue_1151].
+- Docker image labels migrated from the deprecated `org.label-schema.*` schema to the OCI Image Spec `org.opencontainers.image.*` annotations, which are consumed by modern registries and image-scanning tooling.
+
 ### Bugs Fixed
 - Fix memory leak in the reload endpoint: removed validators were not being offloaded from the slashing-protection in-memory cache, and every reload unnecessarily re-registered all validators, causing old-gen heap pressure. Reload now processes only the delta of added/removed keys. PR [#1167][PR_1167].
 - Fix jdbi parsed-SQL cache growth in `ValidatorsDao` by replacing inlined values and bindList expansions with parameterized array bindings. PR [#1170][PR_1170].
 
+[issue_1151]: https://github.com/Consensys/web3signer/issues/1151
 [PR_1167]: https://github.com/Consensys/web3signer/pull/1167
 [PR_1170]: https://github.com/Consensys/web3signer/pull/1170
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 26.4.1
 ### Features Added
-- Publish an additional hardened Docker image under the `-distroless` tag suffix (e.g. `consensys/web3signer:${version}-distroless`). Built from `gcr.io/distroless/java25-debian13:nonroot` — no shell, runs as non-root by default, and is compatible with `docker run --read-only`. See issue [#1151][issue_1151].
+- Publish an additional hardened Docker image under the `-distroless` tag suffix (e.g. `consensys/web3signer:26.4.1-distroless`). Built from `gcr.io/distroless/java25-debian13:nonroot` — no shell, runs as non-root by default, and is compatible with `docker run --read-only`. See issue [#1151][issue_1151].
 - Docker image labels migrated from the deprecated `org.label-schema.*` schema to the OCI Image Spec `org.opencontainers.image.*` annotations, which are consumed by modern registries and image-scanning tooling.
 
 ### Bugs Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -355,6 +355,13 @@ subprojects {
 jar { enabled = false }
 
 apply plugin: 'application'
+// IMPORTANT: JVM flags declared in applicationDefaultJvmArgs below are baked
+// into the gradle-generated bin/web3signer launcher and picked up automatically
+// by docker/Dockerfile (which uses that launcher as its ENTRYPOINT). The
+// distroless image docker/Dockerfile.distroless has no shell, so it invokes
+// `java` directly and hardcodes its own copy of these flags in ENTRYPOINT.
+// When you add/remove/change any JVM flag here, make the matching change in
+// docker/Dockerfile.distroless.
 application {
   mainClass = "tech.pegasys.web3signer.Web3SignerApp"
   applicationDefaultJvmArgs = [

--- a/build.gradle
+++ b/build.gradle
@@ -355,13 +355,13 @@ subprojects {
 jar { enabled = false }
 
 apply plugin: 'application'
-// IMPORTANT: JVM flags declared in applicationDefaultJvmArgs below are baked
-// into the gradle-generated bin/web3signer launcher and picked up automatically
-// by docker/Dockerfile (which uses that launcher as its ENTRYPOINT). The
-// distroless image docker/Dockerfile.distroless has no shell, so it invokes
-// `java` directly and hardcodes its own copy of these flags in ENTRYPOINT.
-// When you add/remove/change any JVM flag here, make the matching change in
-// docker/Dockerfile.distroless.
+// IMPORTANT: the JVM flags listed in applicationDefaultJvmArgs below are baked
+// into the gradle-generated bin/web3signer launcher, which docker/Dockerfile
+// uses as its ENTRYPOINT — so the default image inherits them automatically.
+// The distroless image (docker/Dockerfile.distroless) has no shell and invokes
+// `java` directly, so it reproduces this list by hand (plus a handful of
+// distroless-only hardening flags). When you add/remove/change any flag here,
+// make the matching change in docker/Dockerfile.distroless.
 application {
   mainClass = "tech.pegasys.web3signer.Web3SignerApp"
   applicationDefaultJvmArgs = [

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,15 +17,17 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
 
-LABEL org.label-schema.build-date=$BUILD_DATE \
-      org.label-schema.name="Web3Signer" \
-      org.label-schema.description="Ethereum 2.0 Signing Service" \
-      org.label-schema.url="https://docs.web3signer.consensys.net" \
-      org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.vcs-url="https://github.com/ConsenSys/web3signer.git" \
-      org.label-schema.vendor="Consensys" \
-      org.label-schema.version=$VERSION \
-      org.label-schema.schema-version="1.0"
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.title="Web3Signer" \
+      org.opencontainers.image.description="Ethereum 2.0 Signing Service" \
+      org.opencontainers.image.url="https://docs.web3signer.consensys.net" \
+      org.opencontainers.image.documentation="https://docs.web3signer.consensys.net" \
+      org.opencontainers.image.source="https://github.com/Consensys/web3signer" \
+      org.opencontainers.image.revision=$VCS_REF \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.vendor="Consensys" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.base.name="ubuntu:24.04"
 
 ENV JAVA_HOME="/opt/java/openjdk" \
     PATH="/opt/java/openjdk/bin:${PATH}" \

--- a/docker/Dockerfile.distroless
+++ b/docker/Dockerfile.distroless
@@ -1,0 +1,84 @@
+# syntax=docker/dockerfile:1
+
+# Stage 1: Validate and extract the distribution tar.gz
+FROM alpine AS app-extract
+ARG TAR_FILE
+RUN test -n "$TAR_FILE" || (echo "ERROR: TAR_FILE build argument is required" && exit 1)
+COPY ${TAR_FILE} /tmp/web3signer.tar.gz
+RUN gzip -t /tmp/web3signer.tar.gz || (echo "ERROR: TAR_FILE is not a valid gzip archive" && exit 1) && \
+    mkdir -p /opt/web3signer && \
+    tar -xzf /tmp/web3signer.tar.gz -C /opt/web3signer --strip-components=1 && \
+    rm /tmp/web3signer.tar.gz
+
+# Stage 2: Extract the per-arch libblst.so from jblst-*.jar so the JVM does not
+# have to unpack it to /tmp at runtime. This is the one native library that
+# web3signer itself loads on startup; the other shaded natives in the classpath
+# (Netty transports, netty-tcnative, jffi, conscrypt) are not exercised at
+# runtime because Vert.x uses its NIO transport by default.
+FROM ubuntu:24.04 AS prep
+ARG TARGETARCH
+RUN apt-get update && apt-get install -y --no-install-recommends unzip && rm -rf /var/lib/apt/lists/*
+COPY --from=app-extract /opt/web3signer /opt/web3signer
+RUN set -eu; \
+    case "$TARGETARCH" in \
+      amd64)  BLST_ARCH=amd64 ;; \
+      arm64)  BLST_ARCH=aarch64 ;; \
+      *) echo "Unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /opt/web3signer/native-libs; \
+    JBLST_JAR=$(ls /opt/web3signer/lib/jblst-*.jar); \
+    unzip -j "$JBLST_JAR" "supranational/blst/Linux/${BLST_ARCH}/libblst.so" -d /opt/web3signer/native-libs/
+
+# Stage 3: Runtime on Google Distroless (nonroot by default, no shell, no package manager).
+FROM gcr.io/distroless/java25-debian13:nonroot
+
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.title="Web3Signer" \
+      org.opencontainers.image.description="Ethereum 2.0 Signing Service (distroless, read-only-filesystem compatible)" \
+      org.opencontainers.image.url="https://docs.web3signer.consensys.net" \
+      org.opencontainers.image.documentation="https://docs.web3signer.consensys.net" \
+      org.opencontainers.image.source="https://github.com/Consensys/web3signer" \
+      org.opencontainers.image.revision=$VCS_REF \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.vendor="Consensys" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.base.name="gcr.io/distroless/java25-debian13:nonroot"
+
+ENV WEB3SIGNER_HTTP_LISTEN_HOST="0.0.0.0" \
+    WEB3SIGNER_METRICS_HOST="0.0.0.0"
+
+COPY --from=prep --chown=nonroot:nonroot /opt/web3signer /opt/web3signer
+
+WORKDIR /opt/web3signer
+
+EXPOSE 9000 9001
+
+# JVM flags below must stay in sync with application { applicationDefaultJvmArgs }
+# in build.gradle. The default docker/Dockerfile inherits those flags via the
+# gradle-generated bin/web3signer launcher; this distroless image has no shell,
+# so the flags are hardcoded here and must be updated manually.
+#
+# -XX:-UsePerfData disables the JVM's hsperfdata writes to /tmp, which would
+# otherwise break `docker run --read-only`.
+ENTRYPOINT [ \
+  "java", \
+  "-XX:-UsePerfData", \
+  "-Dvertx.disableFileCPResolving=true", \
+  "-Dlog4j.shutdownHookEnabled=false", \
+  "-Dlog4j2.formatMsgNoLookups=true", \
+  "-Dlog4j.skipJansi=true", \
+  "-Djava.library.path=/opt/web3signer/native-libs", \
+  "-Djna.library.path=/opt/web3signer/native-libs", \
+  "-Djna.noclasspath=true", \
+  "-Dio.netty.tryReflectionSetAccessible=true", \
+  "--enable-native-access=ALL-UNNAMED", \
+  "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED", \
+  "--add-opens=java.base/java.nio=ALL-UNNAMED", \
+  "--add-exports=jdk.crypto.cryptoki/sun.security.pkcs11.wrapper=ALL-UNNAMED", \
+  "-cp", "/opt/web3signer/lib/*", \
+  "tech.pegasys.web3signer.Web3SignerApp" \
+]

--- a/docker/Dockerfile.distroless
+++ b/docker/Dockerfile.distroless
@@ -57,13 +57,21 @@ WORKDIR /opt/web3signer
 
 EXPOSE 9000 9001
 
-# JVM flags below must stay in sync with application { applicationDefaultJvmArgs }
-# in build.gradle. The default docker/Dockerfile inherits those flags via the
-# gradle-generated bin/web3signer launcher; this distroless image has no shell,
-# so the flags are hardcoded here and must be updated manually.
+# JVM flags below split into two groups:
 #
-# -XX:-UsePerfData disables the JVM's hsperfdata writes to /tmp, which would
-# otherwise break `docker run --read-only`.
+# 1. Application flags mirrored from `application { applicationDefaultJvmArgs }`
+#    in build.gradle. The default docker/Dockerfile picks these up automatically
+#    because it runs the gradle-generated bin/web3signer launcher, which bakes
+#    them in. Distroless has no shell so the launcher is not used; we reproduce
+#    the same flags here. Keep them in sync when build.gradle changes.
+#
+# 2. Distroless-only hardening flags (not in the gradle launcher). Needed to
+#    keep startup clean under `docker run --read-only`:
+#      -XX:-UsePerfData             disable JVM hsperfdata_* writes to /tmp
+#      -Dlog4j.skipJansi=true       no TTY; skip Jansi native lib load
+#      -Djava.library.path=...      libblst.so is pre-extracted at build time,
+#      -Djna.library.path=...       so the JVM/JNA do not need to unpack it
+#      -Djna.noclasspath=true       to /tmp at runtime
 ENTRYPOINT [ \
   "java", \
   "-XX:-UsePerfData", \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,94 @@
-To build docker image on developer box, run the following commands (from the root of the project):
+## Web3Signer Docker images
+
+Web3Signer is published as two Docker image variants. Both ship Eclipse Temurin JRE 25 and the same Web3Signer application; they differ in the base image and how Web3Signer is launched.
+
+| Variant | Tag suffix | Base image | Shell / package manager | Read-only filesystem |
+| ------- | ---------- | ---------- | ----------------------- | -------------------- |
+| Default (`docker/Dockerfile`) | *(none)* e.g. `consensys/web3signer:latest` | `ubuntu:24.04` + `eclipse-temurin:25-jre` | Yes | Requires a writable `/tmp` |
+| Distroless (`docker/Dockerfile.distroless`) | `-distroless` e.g. `consensys/web3signer:latest-distroless` | `gcr.io/distroless/java25-debian13:nonroot` | No | Works with `--read-only` out of the box |
+
+Pick the distroless variant when you want a smaller attack surface (no shell, no package manager), non-root execution by default, and the ability to run under a read-only root filesystem.
+
+## Building locally
+
+From the root of the project:
 
 ```sh
 ./gradlew distTar
 
-docker build --no-cache --pull --build-arg TAR_FILE=./build/distributions/web3signer-develop.tar.gz \
--f ./docker/Dockerfile -t web3signer:develop .
+# Default image
+docker build --no-cache --pull \
+  --build-arg TAR_FILE=./build/distributions/web3signer-develop.tar.gz \
+  -f ./docker/Dockerfile -t web3signer:develop .
+
+# Distroless image
+docker build --no-cache --pull \
+  --build-arg TAR_FILE=./build/distributions/web3signer-develop.tar.gz \
+  -f ./docker/Dockerfile.distroless -t web3signer:develop-distroless .
 
 docker run --rm -it web3signer:develop --version
+docker run --rm -it web3signer:develop-distroless --version
 ```
+
+## Running the distroless image
+
+Default run — works exactly like the standard image:
+
+```sh
+docker run -p 9000:9000 consensys/web3signer:latest-distroless eth2 ...
+```
+
+Hardened run with a read-only root filesystem:
+
+```sh
+docker run --read-only -p 9000:9000 \
+  consensys/web3signer:latest-distroless \
+  eth2 --slashing-protection-enabled=false
+```
+
+`--read-only` works without any `--tmpfs /tmp` mount because:
+
+- `-XX:-UsePerfData` disables the JVM's `hsperfdata_*` writes to `/tmp`.
+- `libblst.so` is pre-extracted to `/opt/web3signer/native-libs/` at image build time and pointed to by `-Djava.library.path`, so jblst never unpacks it at startup.
+- The other shaded native libraries in the classpath (Netty native transports, netty-tcnative, jffi, conscrypt) are not exercised by Web3Signer's runtime because Vert.x uses its NIO transport by default.
+
+If you add your own tooling or dependencies that do touch `/tmp`, add `--tmpfs /tmp:rw,size=64m` (or, in Kubernetes, an `emptyDir` volume with `medium: Memory` mounted at `/tmp`) alongside `--read-only`.
+
+### Using the Key Manager API under `--read-only`
+
+Importing a keystore via the Key Manager API normally writes a `.json` file into the configured key-config-path, which fails on a read-only rootfs. Pass the experimental hidden flag `--Xkey-manager-skip-keystore-storage=true` on the `eth2` subcommand to keep imported keys in memory only:
+
+```sh
+docker run --read-only -p 9000:9000 \
+  consensys/web3signer:latest-distroless \
+  eth2 --key-manager-api-enabled=true --Xkey-manager-skip-keystore-storage=true ...
+```
+
+Tradeoff: keys imported at runtime are lost on restart, so operators must have their own re-import or backup strategy.
+
+### Passing JVM options to the distroless image
+
+The default image reads the `JAVA_OPTS` environment variable in its shell launcher. The distroless image has no shell and invokes `java` directly, so `JAVA_OPTS` is ignored. To pass JVM options (heap size, GC flags, system properties, JMX, etc.), use one of the environment variables the JVM launcher itself honors:
+
+- **`JDK_JAVA_OPTIONS`** (JDK 9+, preferred) — only read by the `java` launcher; prints `NOTE: Picked up JDK_JAVA_OPTIONS: ...` once at start.
+- **`JAVA_TOOL_OPTIONS`** — read by every JVM-based tool; prints `Picked up JAVA_TOOL_OPTIONS: ...` on every JVM start (including short-lived tools). Useful if the same env needs to work for both the default and distroless variants.
+
+Example:
+
+```sh
+docker run -p 9000:9000 \
+  -e JDK_JAVA_OPTIONS='-Xmx3g -Xms2g -XX:+UseG1GC' \
+  consensys/web3signer:latest-distroless eth2 ...
+```
+
+Both `-D...` system properties and JMX flags work the same way:
+
+```sh
+-e JDK_JAVA_OPTIONS='-Xmx3g -Dlog4j.configurationFile=/var/config/log4j2.xml -Dcom.sun.management.jmxremote.port=9010 ...'
+```
+
+Note: quoting rules differ from shell — values containing spaces need backslash-escaping (e.g. `-Dfoo=bar\ baz`). For the usual web3signer flags this rarely matters.
+
+### Writable mounts for application data
+
+As with the default image, a writable mount is still required for any on-disk data path (file-based slashing-protection DB, file logs). Mount those paths as volumes; only the container's root filesystem is read-only.

--- a/docker/test-distroless.sh
+++ b/docker/test-distroless.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Smoke test for the distroless Web3Signer image.
+#
+# Runs the container with `--read-only` and no `--tmpfs` mount to prove that
+# nothing anywhere on the rootfs is written at startup. If this test fails,
+# something regressed that started writing outside /opt/web3signer/native-libs
+# (e.g. a new dependency that triggers Netty native transport extraction) —
+# investigate before masking it with `--tmpfs /tmp`.
+
+set -euo pipefail
+
+IMAGE="${1:?Usage: $0 <image> <reports-dir>}"
+REPORTS_DIR="${2:?Usage: $0 <image> <reports-dir>}"
+mkdir -p "$REPORTS_DIR"
+REPORT="$REPORTS_DIR/smoke-report.txt"
+
+NAME="w3s_distroless_smoke_$$"
+cleanup() {
+  docker logs "$NAME" >> "$REPORT" 2>&1 || true
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "Running distroless smoke test against $IMAGE" | tee "$REPORT"
+
+docker run -d --name "$NAME" \
+  --read-only \
+  --sysctl net.ipv6.conf.all.disable_ipv6=1 \
+  -p 9000:9000 \
+  "$IMAGE" \
+  --http-listen-host=0.0.0.0 eth2 --slashing-protection-enabled=false
+
+for i in $(seq 1 30); do
+  if curl -fsS http://localhost:9000/upcheck >/dev/null 2>&1; then
+    echo "upcheck passed after ${i}s" | tee -a "$REPORT"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "upcheck never succeeded" | tee -a "$REPORT"
+exit 1


### PR DESCRIPTION
## Summary
- Publish an additional hardened Docker image at `consensys/web3signer:<ver>-distroless` (and `:latest-distroless`). Built from `gcr.io/distroless/java25-debian13:nonroot` — no shell, non-root by default, runs under `docker run --read-only` out of the box.
- Modernise `docker/Dockerfile` labels from the deprecated `org.label-schema.*` to OCI `org.opencontainers.image.*` annotations.
- Fixes #1151. Based on the work of #1152.

## Design notes
- **Why distroless works under bare `--read-only` (no `--tmpfs /tmp`):** `-XX:-UsePerfData` suppresses the JVM's `hsperfdata` writes, and `libblst.so` is pre-extracted to `/opt/web3signer/native-libs/` at image build time. Vert.x uses its NIO transport by default, so the other shaded natives (Netty epoll, tcnative, jffi, conscrypt) are not exercised. The smoke test runs with bare `--read-only` so any future regression that reintroduces a `/tmp` write trips CI.
- **JVM-flag sync:** flags in `build.gradle:applicationDefaultJvmArgs` are picked up by the default image via the gradle launcher, but the distroless image has no shell — so they are mirrored into `docker/Dockerfile.distroless` ENTRYPOINT. A comment above `application { ... }` in `build.gradle` points maintainers at the sync requirement.
- **Multi-arch:** `TARGETARCH` BuildKit arg selects the correct per-arch `libblst.so` (amd64/aarch64) at build time.
- **`JAVA_OPTS` compatibility:** the distroless image ignores `JAVA_OPTS` (no shell to expand it). Use `JDK_JAVA_OPTIONS` (preferred, JDK 9+) or `JAVA_TOOL_OPTIONS` — these are read by the JVM launcher itself. Documented in `docker/README.md`.
- **`--Xkey-manager-skip-keystore-storage`:** called out in the README as the complementary flag for running the Key Manager API under `--read-only` (imported keystores stay in memory rather than writing to disk).

## CI changes
- The existing `docker` job is now a matrix over `variant: [default, distroless]`. Both variants are built, tested, and pushed from the same pipeline with the correct tag suffix.
- Default variant keeps its existing goss test unchanged; distroless variant runs a new bare-`--read-only` smoke test (`docker/test-distroless.sh`).
- Release body lists both pull commands.

## Test plan
- [x] Local build on apple silicon (linux/arm64): smoke test passes in 3s under `--read-only`.
- [x] Cross-build and run under QEMU (linux/amd64): smoke test passes in 15s, startup log confirms `linux-x86_64` JRE 25, jblst loads the correct per-arch `libblst.so`.
- [x] End-to-end compose test with Postgres-backed slashing protection and 50 bulk-loaded BLS keystores: healthcheck UP, all 50 keys loaded, `slashing-protection-db-health-check: UP`.
- [x] k6 loadtest (50 VUs / 20s): 1000 iters, 100% pass, p95 29.62 ms, 224 MiB RSS steady state.
- [x] `./gradlew spotlessApply` — no changes produced.
- [x] CI run on PR validates matrix (default goss + distroless smoke) for both amd64 and arm64 pushes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the Docker build/release pipeline and introduces a new distroless runtime image/entrypoint; mistakes could break image startup, tagging, or multi-arch publishing.
> 
> **Overview**
> Adds a new hardened *distroless* Docker image variant (`-distroless` tag suffix) built from `gcr.io/distroless/java25-debian13:nonroot`, including a custom `java` `ENTRYPOINT` and build-time extraction of `libblst.so` to support running with `--read-only`.
> 
> Updates CI to build/test/push both Docker variants via a matrix, running the existing goss-based tests for the default image and a new `docker/test-distroless.sh` smoke test for the distroless image, and updates release notes/docs to advertise the new pull tag.
> 
> Modernizes Docker image metadata by migrating labels in `docker/Dockerfile` to OCI `org.opencontainers.image.*` annotations and adds build.gradle guidance to keep JVM flags in sync with the distroless entrypoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b1c0755591595da06d1bcf8e83fa919ade038d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->