### PR TITLE
fix(dashboard): update for Besu OpenMetrics and add pipeline panels

### DIFF
--- a/dashboard/web3signer-eth2-dashboard-grafana.json
+++ b/dashboard/web3signer-eth2-dashboard-grafana.json
@@ -40,6 +40,12 @@
       "id": "stat",
       "name": "Stat",
       "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
     }
   ],
   "annotations": {
@@ -77,7 +83,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -90,7 +96,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -128,7 +134,7 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
+        "w": 8,
         "x": 0,
         "y": 1
       },
@@ -198,8 +204,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
-        "x": 4,
+        "w": 8,
+        "x": 8,
         "y": 1
       },
       "id": 102,
@@ -260,8 +266,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
-        "x": 8,
+        "w": 8,
+        "x": 16,
         "y": 1
       },
       "id": 120,
@@ -288,7 +294,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "jvm_memory_bytes_max{area=\"heap\", instance=~\"$system\", job=\"$job\"}",
+          "expr": "jvm_memory_max_bytes{area=\"heap\", instance=~\"$system\", job=\"$job\"}",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -329,7 +335,7 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
+        "w": 8,
         "x": 0,
         "y": 4
       },
@@ -356,7 +362,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "http_bls_malformed_request_count{instance=~\"$system\"}",
+          "expr": "http_bls_malformed_request_count_total{instance=~\"$system\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -396,8 +402,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
-        "x": 4,
+        "w": 8,
+        "x": 8,
         "y": 4
       },
       "id": 96,
@@ -423,7 +429,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "eth2_slashingprotection_prevented_signings{instance=~\"$system\"}",
+          "expr": "eth2_slashingprotection_prevented_signings_total{instance=~\"$system\"}",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -464,8 +470,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 4,
-        "x": 8,
+        "w": 8,
+        "x": 16,
         "y": 4
       },
       "id": 104,
@@ -491,7 +497,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "signing_bls_missing_identifier_count{instance=~\"$system\"}",
+          "expr": "signing_bls_missing_identifier_count_total{instance=~\"$system\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -505,7 +511,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -519,7 +525,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -692,7 +698,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -700,13 +706,294 @@
         "x": 0,
         "y": 16
       },
+      "id": 122,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Signing Pipeline",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 17
+      },
+      "id": 123,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "eth2_slashingprotection_database_duration{instance=~\"$system\", job=\"$job\", quantile=~\"0.5|0.95|0.99\"}",
+          "legendFormat": "{{signingOperation}} p{{quantile}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Slashing DB Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 17
+      },
+      "id": 124,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "http_vertx_worker_pool_usage{instance=~\"$system\", job=\"$job\", quantile=\"0.95\"}",
+          "legendFormat": "{{poolName}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Worker Pool Usage (p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 17
+      },
+      "id": 125,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(http_vertx_worker_pool_rejected_total{instance=~\"$system\", job=\"$job\"}[1m])",
+          "legendFormat": "{{poolName}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Worker Pool Rejections",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
       "id": 14,
       "panels": [],
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -737,7 +1024,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 17
+        "y": 26
       },
       "hiddenSeries": false,
       "id": 110,
@@ -837,7 +1124,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 17
+        "y": 26
       },
       "hiddenSeries": false,
       "id": 112,
@@ -883,7 +1170,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "jvm_memory_bytes_used{instance=~\"$system\", area=\"heap\", job=\"$job\"} + ignoring(area) jvm_memory_bytes_used{instance=~\"$system\", area=\"nonheap\"}",
+          "expr": "jvm_memory_used_bytes{instance=~\"$system\", area=\"heap\", job=\"$job\"} + ignoring(area) jvm_memory_used_bytes{instance=~\"$system\", area=\"nonheap\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -897,7 +1184,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "jvm_memory_bytes_max{instance=~\"$system\", area=\"heap\", job=\"$job\"} + ignoring(area) jvm_memory_bytes_max{instance=~\"$system\", area=\"nonheap\"}",
+          "expr": "jvm_memory_max_bytes{instance=~\"$system\", area=\"heap\", job=\"$job\"} + ignoring(area) jvm_memory_max_bytes{instance=~\"$system\", area=\"nonheap\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -959,7 +1246,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 17
+        "y": 26
       },
       "hiddenSeries": false,
       "id": 114,
@@ -1060,7 +1347,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 26
+        "y": 35
       },
       "hiddenSeries": false,
       "id": 116,
@@ -1168,7 +1455,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 26
+        "y": 35
       },
       "hiddenSeries": false,
       "id": 118,
@@ -1410,6 +1697,6 @@
   "timezone": "",
   "title": "Web3Signer Overview",
   "uid": "dkIJoOVMk",
-  "version": 14,
+  "version": 15,
   "weekStart": ""
 }


### PR DESCRIPTION
## PR Description
- Rename counter/gauge metrics for Besu 25.x OpenMetrics model (counters gain `_total` suffix; `jvm_memory_bytes_{used,max}` -> `jvm_memory_{used,max}_bytes`). Without these the Stats and System panels render empty against current builds.
- Template remaining hardcoded datasource uids to `${DS_PROMETHEUS}` and bump revision to 15 so the file is publish-ready for grafana.com dashboard 13687.
- Widen Stats panels (w=4 -> w=8, 2x3 grid) so titles no longer truncate and the section fills the full grid width.
- Add "Signing Pipeline" row with three timeseries panels: slashing DB duration, worker pool usage (p95), and worker pool rejection rate -- visibility into the three most common causes of signing latency regressions.

<img width="1180" height="1289" alt="image" src="https://github.com/user-attachments/assets/f00c221d-a730-41c9-a26c-fc575670c5b0" />

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to a Grafana dashboard JSON, but incorrect Prometheus metric names or templated datasource variables could cause panels to render empty.
> 
> **Overview**
> Updates the `web3signer-eth2-dashboard-grafana.json` dashboard to align with newer OpenMetrics/Besu metric naming (e.g., JVM memory metrics and counters now using the updated names and `_total` suffix) and replaces hardcoded Prometheus datasource UIDs with the `${DS_PROMETHEUS}` input.
> 
> Improves layout by widening the top stat panels, and adds a new **Signing Pipeline** section with three `timeseries` panels for slashing DB duration, worker pool usage (p95), and worker pool rejection rate; dashboard `version` is bumped to `15`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4863ce0f3c1ee9fe8ee2781bcffecb2d62b7056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->