### PR TITLE
fix(distroless): load BLS native library under --read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 26.4.2
+### Bugs Fixed
+- Fix distroless image failing to load BLS native library under `docker run --read-only`. Issue [#1175][issue_1175], PR [#1176][PR_1176].
+
+[issue_1175]: https://github.com/Consensys/web3signer/issues/1175
+[PR_1176]: https://github.com/Consensys/web3signer/pull/1176
+
+---
 ## 26.4.1
 ### Features Added
 - Publish an additional hardened Docker image under the `-distroless` tag suffix (e.g. `consensys/web3signer:26.4.1-distroless`). Built from `gcr.io/distroless/java25-debian13:nonroot` — no shell, runs as non-root by default, and is compatible with `docker run --read-only`. See issue [#1151][issue_1151].

--- a/docker/Dockerfile.distroless
+++ b/docker/Dockerfile.distroless
@@ -10,14 +10,19 @@ RUN gzip -t /tmp/web3signer.tar.gz || (echo "ERROR: TAR_FILE is not a valid gzip
     tar -xzf /tmp/web3signer.tar.gz -C /opt/web3signer --strip-components=1 && \
     rm /tmp/web3signer.tar.gz
 
-# Stage 2: Extract the per-arch libblst.so from jblst-*.jar so the JVM does not
-# have to unpack it to /tmp at runtime. This is the one native library that
-# web3signer itself loads on startup; the other shaded natives in the classpath
-# (Netty transports, netty-tcnative, jffi, conscrypt) are not exercised at
-# runtime because Vert.x uses its NIO transport by default.
+# Stage 2: Extract the per-arch libblst.so from jblst-*.jar and then strip it
+# from the jar so the jblst static initializer (supranational.blst.blstJNI)
+# cannot find it as a classpath resource. When the resource is absent, jblst
+# falls through to System.loadLibrary("blst"), which honours the
+# -Djava.library.path set on the runtime ENTRYPOINT. If the resource is left
+# in place, jblst unconditionally copies it into Files.createTempDirectory
+# ("blst@..."), i.e. /tmp — which breaks under `docker run --read-only`.
+# The other shaded natives in the classpath (Netty transports, netty-tcnative,
+# jffi, conscrypt) are not exercised at runtime because Vert.x uses its NIO
+# transport by default.
 FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS prep
 ARG TARGETARCH
-RUN apt-get update && apt-get install -y --no-install-recommends unzip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends unzip zip && rm -rf /var/lib/apt/lists/*
 COPY --from=app-extract /opt/web3signer /opt/web3signer
 RUN set -eu; \
     case "$TARGETARCH" in \
@@ -27,7 +32,8 @@ RUN set -eu; \
     esac; \
     mkdir -p /opt/web3signer/native-libs; \
     JBLST_JAR=$(ls /opt/web3signer/lib/jblst-*.jar); \
-    unzip -j "$JBLST_JAR" "supranational/blst/Linux/${BLST_ARCH}/libblst.so" -d /opt/web3signer/native-libs/
+    unzip -j "$JBLST_JAR" "supranational/blst/Linux/${BLST_ARCH}/libblst.so" -d /opt/web3signer/native-libs/; \
+    zip -d "$JBLST_JAR" "supranational/blst/Linux/${BLST_ARCH}/libblst.so"
 
 # Stage 3: Runtime on Google Distroless (nonroot by default, no shell, no package manager).
 FROM gcr.io/distroless/java25-debian13:nonroot@sha256:efb9a5000ce8ff56745d56c88c8e61017e674ed053b67e0c44af25ddabf1faa8
@@ -72,6 +78,13 @@ EXPOSE 9000 9001
 #      -Djava.library.path=...      libblst.so is pre-extracted at build time,
 #      -Djna.library.path=...       so the JVM/JNA do not need to unpack it
 #      -Djna.noclasspath=true       to /tmp at runtime
+#      -Dsupranational.blst.jniResource=/__stripped__
+#                                   Belt-and-braces with the jar-strip in
+#                                   stage 2 (prep). If the native resource is
+#                                   ever reintroduced into jblst-*.jar, this
+#                                   still forces supranational.blst.blstJNI to
+#                                   skip its classpath-extract-to-/tmp branch
+#                                   and fall through to System.loadLibrary.
 ENTRYPOINT [ \
   "java", \
   "-XX:-UsePerfData", \
@@ -82,6 +95,7 @@ ENTRYPOINT [ \
   "-Djava.library.path=/opt/web3signer/native-libs", \
   "-Djna.library.path=/opt/web3signer/native-libs", \
   "-Djna.noclasspath=true", \
+  "-Dsupranational.blst.jniResource=/__stripped__", \
   "-Dio.netty.tryReflectionSetAccessible=true", \
   "--enable-native-access=ALL-UNNAMED", \
   "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED", \

--- a/docker/test-distroless.sh
+++ b/docker/test-distroless.sh
@@ -5,8 +5,14 @@
 # Runs the container with `--read-only` and no `--tmpfs` mount to prove that
 # nothing anywhere on the rootfs is written at startup. If this test fails,
 # something regressed that started writing outside /opt/web3signer/native-libs
-# (e.g. a new dependency that triggers Netty native transport extraction) —
-# investigate before masking it with `--tmpfs /tmp`.
+# (e.g. a new dependency that triggers Netty native transport extraction, or
+# jblst reverting the jar-strip in Dockerfile.distroless stage 2) — investigate
+# before masking it with `--tmpfs /tmp`.
+#
+# The test also bulk-loads an EIP-2335 keystore via --keystores-path. This
+# forces the jblst static initializer to load libblst.so, which is the exact
+# code path that failed in issue #1175 before the jar-strip fix. Asserting the
+# pubkey is returned from /api/v1/eth2/publicKeys proves BLS actually loaded.
 
 set -euo pipefail
 
@@ -15,10 +21,34 @@ REPORTS_DIR="${2:?Usage: $0 <image> <reports-dir>}"
 mkdir -p "$REPORTS_DIR"
 REPORT="$REPORTS_DIR/smoke-report.txt"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KEYSTORE_SRC="$SCRIPT_DIR/../acceptance-tests/src/test/resources/eth2/bls_keystore.json"
+KEYSTORE_PASSWORD="somepassword"
+EXPECTED_PUBKEY="0x98d083489b3b06b8740da2dfec5cc3c01b2086363fe023a9d7dc1f907633b1ff11f7b99b19e0533e969862270061d884"
+
+STAGE_DIR="$(mktemp -d)"
+cp "$KEYSTORE_SRC" "$STAGE_DIR/keystore.json"
+printf '%s' "$KEYSTORE_PASSWORD" > "$STAGE_DIR/password.txt"
+# Distroless runs as uid 65532 (nonroot); mktemp defaults to mode 0700 owned
+# by the host user. Open the dir/files so the container process can read them
+# across the bind mount.
+chmod 0755 "$STAGE_DIR"
+chmod 0644 "$STAGE_DIR/keystore.json" "$STAGE_DIR/password.txt"
+
 NAME="w3s_distroless_smoke_$$"
 cleanup() {
-  docker logs "$NAME" >> "$REPORT" 2>&1 || true
+  {
+    echo
+    echo "--- container logs ---"
+    docker logs "$NAME" 2>&1 || true
+  } >> "$REPORT"
   docker rm -f "$NAME" >/dev/null 2>&1 || true
+  rm -rf "$STAGE_DIR"
+}
+dump_logs_on_failure() {
+  echo
+  echo "--- container logs (tail) ---"
+  docker logs --tail 80 "$NAME" 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -27,17 +57,39 @@ echo "Running distroless smoke test against $IMAGE" | tee "$REPORT"
 docker run -d --name "$NAME" \
   --read-only \
   --sysctl net.ipv6.conf.all.disable_ipv6=1 \
+  -v "$STAGE_DIR":/keys:ro \
   -p 9000:9000 \
   "$IMAGE" \
-  --http-listen-host=0.0.0.0 eth2 --slashing-protection-enabled=false
+  --http-listen-host=0.0.0.0 \
+  eth2 --slashing-protection-enabled=false \
+       --keystores-path=/keys \
+       --keystores-password-file=/keys/password.txt
 
 for i in $(seq 1 30); do
   if curl -fsS http://localhost:9000/upcheck >/dev/null 2>&1; then
     echo "upcheck passed after ${i}s" | tee -a "$REPORT"
+    break
+  fi
+  sleep 1
+  if [ "$i" -eq 30 ]; then
+    echo "upcheck never succeeded" | tee -a "$REPORT"
+    dump_logs_on_failure
+    exit 1
+  fi
+done
+
+# Keystore loading runs in a background thread; wait up to 15s for BLS +
+# decryption to finish and the pubkey to appear.
+for i in $(seq 1 15); do
+  PUBKEYS_JSON="$(curl -fsS http://localhost:9000/api/v1/eth2/publicKeys || true)"
+  if [[ "$PUBKEYS_JSON" == *"$EXPECTED_PUBKEY"* ]]; then
+    echo "keystore loaded and BLS native library resolved under --read-only" | tee -a "$REPORT"
     exit 0
   fi
   sleep 1
 done
 
-echo "upcheck never succeeded" | tee -a "$REPORT"
+echo "publicKeys response: $PUBKEYS_JSON" | tee -a "$REPORT"
+echo "expected pubkey $EXPECTED_PUBKEY not found in /api/v1/eth2/publicKeys" | tee -a "$REPORT"
+dump_logs_on_failure
 exit 1


### PR DESCRIPTION
## PR Description

When the distroless image is run with `docker run --read-only` (no `/tmp` mount), importing or bulk-loading BLS keystores fails with:

```
BlstLoader | Couldn't load native BLS library
  at supranational.blst.blstJNI.<clinit>(blstJNI.java:44)
Caused by: java.lang.RuntimeException: /tmp/blst@…: Read-only file system
```

The `supranational.blst.blstJNI` static initializer unconditionally extracts `libblst.so` from its jar to `Files.createTempDirectory("blst@…")` (i.e. `java.io.tmpdir` = `/tmp`) and only falls through to `System.loadLibrary("blst")` when the native resource is *not* present on the classpath. Because `jblst-*.jar` ships the per-arch `libblst.so` as a classpath resource, the extraction branch always wins and our pre-existing `-Djava.library.path=/opt/web3signer/native-libs` setting was never actually used.

Fix, in `docker/Dockerfile.distroless` stage 2 (prep):
1. After `unzip -j` extracts the per-`TARGETARCH` `libblst.so` into `/opt/web3signer/native-libs/`, `zip -d` removes that same entry from `jblst-*.jar`.
2. With the resource gone, `Class.getResourceAsStream(...)` in `blstJNI.<clinit>` returns `null`, jblst falls through to `System.loadLibrary("blst")`, and `-Djava.library.path` finally does what it was meant to.
3. Belt-and-braces: the runtime ENTRYPOINT also sets `-Dsupranational.blst.jniResource=/__stripped__`. If the native resource is ever reintroduced into the jar by a dependency bump, the property still forces the classpath lookup to miss — the two mechanisms are independent.

Also extends `docker/test-distroless.sh`: it now stages `acceptance-tests/src/test/resources/eth2/bls_keystore.json` as a read-only bind mount, passes `--keystores-path` / `--keystores-password-file`, and asserts the expected pubkey from `GET /api/v1/eth2/publicKeys`. This actually exercises the jblst native-load path, so a regression of this class will fail CI next time. (Previously the smoke test only hit `/upcheck` and never touched BLS.)

### Verification performed locally (linux/arm64 distroless)
- Before the fix: reporter's stack trace reproduces with `read_only: true` + Keymanager-API import.
- After the fix, all three paths succeed with `--read-only` (no `/tmp` mount, no `--tmpfs`):
  - Bulk keystore load on startup — 3 keystores → 3 pubkeys returned from `/api/v1/eth2/publicKeys`.
  - `POST /eth/v1/keystores` via Keymanager API — both keystores return `"status": "imported"` (HTTP 200).
  - k6 sign-loadtest (10 VUs / 30s, 5 keys, slashing protection enabled, Postgres backed): 300/300 iterations, 0 failures; p95 26.5 ms.
- Extended `docker/test-distroless.sh` passes against the rebuilt image.

## Fixed Issue(s)

fixes #1175

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

No user-facing docs change — the distroless image's hardening contract is unchanged (`--read-only` compatible, no `/tmp` mount required). The behavioural fix is self-contained in the image build.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

Added under **26.4.2** in `CHANGELOG.md`.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.

Verified against the local docker-compose setup (Postgres + Flyway + Keymanager API) plus a k6 sign-loadtest, all under `docker run --read-only`. CI's distroless variant runs the extended smoke test on every build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the distroless image build/runtime behavior around native library loading and modifies the smoke test to exercise keystore/BLS initialization; failures would surface at container startup in hardened deployments.
> 
> **Overview**
> Fixes distroless `--read-only` startup when BLS keystores are used by **pre-extracting `libblst.so` and stripping it from `jblst-*.jar`** so jblst falls back to `System.loadLibrary` via `-Djava.library.path` (plus an extra `-Dsupranational.blst.jniResource=/__stripped__` safeguard).
> 
> Strengthens the distroless smoke test to actually exercise BLS loading: it bind-mounts a test EIP-2335 keystore/password, starts Web3Signer with `--keystores-path`, and asserts the expected pubkey appears in `GET /api/v1/eth2/publicKeys` under `--read-only`. Updates `CHANGELOG.md` with the 26.4.2 bugfix entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e179c3d2819552604097ef47203070be7679ebb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->