### PR TITLE
ci: Update cla allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,3 +27,4 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/Consensys/cla/blob/main/CLA.md' 
           branch: 'cla'
+          allowlist: 'protocols-renovate[bot]'


### PR DESCRIPTION
ci: Update cla allowlist. Add protocols-renovate bot user to allow list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that only affects which GitHub user can bypass CLA signing; no runtime or product code is impacted.
> 
> **Overview**
> Updates the CLA Assistant workflow (`.github/workflows/cla.yml`) to **allowlist** `protocols-renovate[bot]`, letting Renovate automation pass CLA checks without manual signing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 691e71f1e7ecbe3b9dd278df47a9564fe40049e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->