### PR TITLE
build: require Java 25 for build and runtime

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Setup Java and Gradle
         id: setup-java-gradle
-        uses: ConsenSys/github-actions/java-setup-gradle@733e99a6aeb0f7ca132c7c557814d146ed9e7cac # main
+        uses: ConsenSys/github-actions/java-setup-gradle@6b2259b3261b3fd364c32917b75943fce6473c1c # main
         with:
           VERSION: '25'
 

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -30,7 +30,9 @@ jobs:
 
       - name: Setup Java and Gradle
         id: setup-java-gradle
-        uses: ConsenSys/github-actions/java-setup-gradle@b7f698d0ad4db965700c920de5a2c243f0ce0f8c # main
+        uses: ConsenSys/github-actions/java-setup-gradle@733e99a6aeb0f7ca132c7c557814d146ed9e7cac # main
+        with:
+          VERSION: '25'
 
       - name: Determine Web3Signer version
         id: project-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Upcoming Release
+### Breaking Changes
+- Java 25 is now required to build Web3Signer (previously Java 21).
+- The `.tar.gz` and `.zip` binary distributions now require Java 25 on the host machine to run Web3Signer (previously Java 21).
+- Docker images are unchanged — they have shipped Java 25 since 25.12.0.
+- Contributors no longer need to install JDK 25 manually. The build now uses a Gradle toolchain (`JavaLanguageVersion.of(25)`) with the foojay resolver, so Gradle will auto-detect a locally installed JDK 25 and download Temurin 25 if none is found. The Gradle daemon itself can run on any JDK supported by Gradle 9 (17+).
+
+---
 ## 26.4.2
 ### Features Added
 - Published Docker images are now signed (keyless cosign via Sigstore) and ship with SLSA provenance + SPDX SBOM attestations. See `docker/README.md` for verification commands.

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -171,6 +171,7 @@ tasks.register('acceptanceTest', Test) {
   // embedded pg initdb needs following
   environment "LC_CTYPE", "en_US.UTF-8"
   environment "LC_ALL", "en_US.UTF-8"
+  jvmArgs '--enable-native-access=ALL-UNNAMED'
   useJUnitPlatform()
   // toggle to show standard out and standard error of the test JVM(s) on the console
   testLogging.showStandardStreams = false

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -41,9 +41,9 @@ dependencies {
   testImplementation 'tech.pegasys.teku.internal:spec'
   testImplementation 'tech.pegasys.teku.internal:networks'
   testImplementation 'tech.pegasys.teku.internal:json'
-  testImplementation (group: 'tech.pegasys.teku.internal', name: 'spec', classifier: 'test-fixtures')
-  testImplementation (group: 'tech.pegasys.teku.internal', name: 'bls', classifier: 'test-fixtures')
-  testImplementation (group: 'tech.pegasys.teku.internal', name: 'kzg', classifier: 'test-fixtures')
+  testImplementation 'tech.pegasys.teku.internal:spec::test-fixtures'
+  testImplementation 'tech.pegasys.teku.internal:bls::test-fixtures'
+  testImplementation 'tech.pegasys.teku.internal:kzg::test-fixtures'
   testImplementation 'tech.pegasys.teku.internal:serializer'
   testImplementation 'tech.pegasys.teku.internal:unsigned'
   testImplementation 'tech.pegasys.teku.internal:async'

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/BlsSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/BlsSigningAcceptanceTest.java
@@ -369,9 +369,9 @@ public class BlsSigningAcceptanceTest extends SigningAcceptanceTestBase {
   private void setupMinimalWeb3Signer(final ArtifactType artifactType) {
     switch (artifactType) {
       case BLOCK_V2,
-              SYNC_COMMITTEE_MESSAGE,
-              SYNC_COMMITTEE_SELECTION_PROOF,
-              SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF ->
+          SYNC_COMMITTEE_MESSAGE,
+          SYNC_COMMITTEE_SELECTION_PROOF,
+          SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF ->
           setupEth2Signer(Eth2Network.MINIMAL, SpecMilestone.ALTAIR);
       default -> setupEth2Signer(Eth2Network.MINIMAL, SpecMilestone.PHASE0);
     }

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/BlsSigningRootPropertyAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/BlsSigningRootPropertyAcceptanceTest.java
@@ -89,9 +89,9 @@ public class BlsSigningRootPropertyAcceptanceTest extends SigningAcceptanceTestB
   private void setupMinimalWeb3Signer(final ArtifactType artifactType) {
     switch (artifactType) {
       case BLOCK_V2,
-              SYNC_COMMITTEE_MESSAGE,
-              SYNC_COMMITTEE_SELECTION_PROOF,
-              SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF ->
+          SYNC_COMMITTEE_MESSAGE,
+          SYNC_COMMITTEE_SELECTION_PROOF,
+          SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF ->
           setupEth2Signer(Eth2Network.MINIMAL, SpecMilestone.ALTAIR);
       default -> setupEth2Signer(Eth2Network.MINIMAL, SpecMilestone.PHASE0);
     }

--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,10 @@ allprojects {
       '--add-opens',
       'java.base/java.util=ALL-UNNAMED',
       '--add-opens',
-      'java.base/java.util.concurrent=ALL-UNNAMED'
+      'java.base/java.util.concurrent=ALL-UNNAMED',
+      // Suppress JDK 24+ restricted-method warning emitted by jblst's
+      // System.loadLibrary call. Mirrors applicationDefaultJvmArgs.
+      '--enable-native-access=ALL-UNNAMED'
     ]
     Set toImport = [
       'root.log.level',
@@ -321,7 +324,7 @@ subprojects {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     outputs.upToDateWhen { false }
-    jvmArgs = ['-Xms512m', '-Xmx1g']
+    jvmArgs = ['-Xms512m', '-Xmx1g', '--enable-native-access=ALL-UNNAMED']
     useJUnitPlatform()
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,11 +37,6 @@ plugins {
   id 'org.ajoberstar.grgit' version '5.3.3'
 }
 
-if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
-  throw new GradleException("Java 21 or later is required to build Web3Signer.\n" +
-  "  Detected version ${JavaVersion.current()}")
-}
-
 rootProject.version = calculatePublishVersion()
 def specificVersion = calculateVersion()
 
@@ -108,8 +103,9 @@ allprojects {
   }
 
   java {
-    sourceCompatibility = 21
-    targetCompatibility = 21
+    toolchain {
+      languageVersion = JavaLanguageVersion.of(25)
+    }
   }
 
   repositories {
@@ -136,7 +132,7 @@ allprojects {
         exclude '**/build/**'
       }
       // See gradle.properties for exports/opens flags required by JDK 16 and Google Java Format plugin
-      googleJavaFormat('1.22.0')
+      googleJavaFormat('1.35.0')
       importOrder 'tech.pegasys', 'java', ''
       trimTrailingWhitespace()
       endWithNewline()

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,6 +11,10 @@
  * specific language governing permissions and limitations under the License.
  */
 
+plugins {
+  id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
 rootProject.name='web3signer'
 include 'app'
 include 'acceptance-tests'


### PR DESCRIPTION
## PR Description

Bump the build floor from Java 21 to Java 25 to match what the Docker images already ship since 25.12.0. The `.tar.gz` / `.zip` binary distributions likewise now require a Java 25 host JVM.

Key changes:

- **Gradle toolchain** (`build.gradle`, `settings.gradle`): Replaced the manual `JavaVersion.current().isCompatibleWith(VERSION_21)` pre-flight check and `sourceCompatibility` / `targetCompatibility = 21` with a real toolchain block (`JavaLanguageVersion.of(25)`) plus the `org.gradle.toolchains.foojay-resolver-convention` plugin. Contributors no longer need to install JDK 25 manually — Gradle auto-detects locally installed JDK 25 and downloads Temurin 25 via foojay if none is found. The Gradle daemon itself can run on any JDK 17+.
- **Spotless / google-java-format** (`build.gradle`): Bumped `googleJavaFormat('1.22.0')` to `'1.35.0'`. 1.22.0 hits `NoSuchMethodError` on JDK 25's javac (`Log$DeferredDiagnosticHandler.getDiagnostics()` signature changed). Note: Spotless 8.4.0's default (1.28.0) is also too old, so the explicit pin must stay.
- **CI** (`.github/workflows/ci_main.yml`): Bumped `ConsenSys/github-actions/java-setup-gradle` pin to `6b225…` and passed `VERSION: '25'`.
- **CHANGELOG**: New `## Upcoming Release` entry under Breaking Changes.
- **Test files**: Two acceptance test files received indentation-only reformatting from gjf 1.35.0 (switch-case continuation lines).

## Fixed Issue(s)

fixes #1185

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.

Verified locally:
- `./gradlew javaToolchains` — confirms toolchain auto-detects locally installed Temurin 25 and lists `Auto-download: Enabled`.
- `./gradlew spotlessApply` — clean run on JDK 25 with gjf 1.35.0.
- `./gradlew clean build` — all 90 tasks green (unit tests, spotlessCheck, javadoc, dependencyCheck) under JDK 25 toolchain.
- Integration / acceptance tests will run in CI on the new JDK 25 setup.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises the minimum Java version for building and running the non-Docker distributions to 25, which can break developer/CI environments and user deployments relying on Java 21. Also changes Gradle/JVM test execution flags, which could surface new build/test compatibility issues.
> 
> **Overview**
> Updates the build to **require Java 25** by switching from Java 21 compatibility settings to a Gradle `toolchain` (`JavaLanguageVersion.of(25)`) and enabling the `foojay` toolchain resolver in `settings.gradle` for auto-provisioning JDK 25.
> 
> CI is adjusted to provision Java 25, formatting tooling is updated by bumping `googleJavaFormat` to `1.35.0`, and tests are updated to run with `--enable-native-access=ALL-UNNAMED` (plus minor acceptance-test dependency notation and formatting-only changes). The changelog documents the new Java 25 build/runtime requirement for `.tar.gz`/`.zip` distributions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4caf27298487c08e600ae65f0fc5149ecc2f5bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->