### PR TITLE
chore: Simplified switch block

### DIFF
--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/Eth2SignForIdentifierHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/Eth2SignForIdentifierHandler.java
@@ -205,12 +205,12 @@ public class Eth2SignForIdentifierHandler implements Handler<RoutingContext> {
       blockSlot = UInt64.valueOf(eth2SigningRequestBody.block().slot.bigIntegerValue());
     } else {
       final BlockRequest blockRequest = eth2SigningRequestBody.blockRequest();
-      switch (blockRequest.getVersion()) {
-        case PHASE0, ALTAIR ->
-            blockSlot = UInt64.valueOf(blockRequest.getBeaconBlock().slot.bigIntegerValue());
-        default ->
-            blockSlot = UInt64.valueOf(blockRequest.getBeaconBlockHeader().slot.bigIntegerValue());
-      }
+      blockSlot =
+          switch (blockRequest.getVersion()) {
+            case PHASE0, ALTAIR ->
+                UInt64.valueOf(blockRequest.getBeaconBlock().slot.bigIntegerValue());
+            default -> UInt64.valueOf(blockRequest.getBeaconBlockHeader().slot.bigIntegerValue());
+          };
     }
 
     return blockSlot;


### PR DESCRIPTION
Simplified `switch` block as reported by errorprone plugin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of the `switch` used to derive `blockSlot`, with no behavioral change expected. Risk is low and limited to block-slot extraction for `BLOCK_V2` requests.
> 
> **Overview**
> Simplifies `getBlockSlot` in `Eth2SignForIdentifierHandler` by converting the `switch` statement into a single `switch` expression assigned to `blockSlot`, addressing static analysis (error-prone) feedback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57b1f8179dbd494634bd3baa30d6638354439b7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->