### PR TITLE
feat: implement Hashicorp Vault Kubernetes authentication support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Upcoming Release
+### Features Added
+- Support for Hashicorp Vault Kubernetes authentication [PR 1195](https://github.com/Consensys/web3signer/pull/1195)
+
 ### Bugs Fixed
 - Fix Key Manager API (`POST /eth/v1/keystores`) accepting a keystore whose JSON `pubkey` field does not match the decrypted private key. A mismatched import now returns `status: "error"` for that entry rather than poisoning the slashing-protection database under the claimed (unverified) pubkey.
 

--- a/keystorage/src/integrationTest/java/tech/pegasys/web3signer/keystore/hashicorp/HashicorpKubernetesAuthIntegrationTest.java
+++ b/keystorage/src/integrationTest/java/tech/pegasys/web3signer/keystore/hashicorp/HashicorpKubernetesAuthIntegrationTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.keystore.hashicorp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import tech.pegasys.web3signer.keystorage.hashicorp.HashicorpConnection;
+import tech.pegasys.web3signer.keystorage.hashicorp.HashicorpConnectionFactory;
+import tech.pegasys.web3signer.keystorage.hashicorp.config.ConnectionParameters;
+import tech.pegasys.web3signer.keystorage.hashicorp.config.KeyDefinition;
+import tech.pegasys.web3signer.keystorage.hashicorp.config.KubernetesAuthOptions;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.JsonBody;
+
+class HashicorpKubernetesAuthIntegrationTest {
+
+  private static final String DEFAULT_HOST = "localhost";
+  private static final String ROLE = "web3signer-role";
+  private static final String JWT = "mock-jwt-token";
+  private static final String VAULT_TOKEN = "hvs.mock-vault-token";
+  private static final String KEY_PATH = "/v1/secret/data/my-secret";
+  private static final String EXPECTED_KEY_STRING = "my-precious-key";
+
+  private HashicorpConnectionFactory factory;
+  private ClientAndServer mockServer;
+
+  @BeforeEach
+  void setup() {
+    factory = new HashicorpConnectionFactory();
+    mockServer = new ClientAndServer(0);
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (factory != null) {
+      factory.close();
+    }
+    if (mockServer != null) {
+      mockServer.stop();
+    }
+  }
+
+  @Test
+  void authenticateWithKubernetesAndFetchKeySucceeds(@TempDir final Path tempDir)
+      throws IOException {
+    // 1. Prepare mock JWT file
+    final Path jwtFile = tempDir.resolve("token");
+    Files.writeString(jwtFile, JWT);
+
+    // 2. Mock Vault Login
+    mockServer
+        .when(
+            request()
+                .withMethod("POST")
+                .withPath("/v1/auth/kubernetes/login")
+                .withBody(new JsonBody("{\"role\":\"" + ROLE + "\",\"jwt\":\"" + JWT + "\"}")))
+        .respond(
+            response()
+                .withStatusCode(200)
+                .withBody("{\"auth\":{\"client_token\":\"" + VAULT_TOKEN + "\"}}"));
+
+    // 3. Mock Vault Secret Read
+    mockServer
+        .when(
+            request().withMethod("GET").withPath(KEY_PATH).withHeader("X-Vault-Token", VAULT_TOKEN))
+        .respond(
+            response()
+                .withStatusCode(200)
+                .withBody("{\"data\":{\"data\":{\"value\":\"" + EXPECTED_KEY_STRING + "\"}}}"));
+
+    // 4. Execute authentication and fetch
+    final ConnectionParameters connectionParameters =
+        ConnectionParameters.newBuilder()
+            .withServerHost(DEFAULT_HOST)
+            .withServerPort(mockServer.getLocalPort())
+            .build();
+
+    final HashicorpConnection connection = factory.create(connectionParameters);
+
+    final KubernetesAuthOptions authOptions = new KubernetesAuthOptions(ROLE, jwtFile, null);
+    final String token = connection.authenticateWithKubernetes(authOptions);
+    assertThat(token).isEqualTo(VAULT_TOKEN);
+
+    final KeyDefinition keyDefinition = new KeyDefinition(KEY_PATH, Optional.empty(), token);
+    final String fetchedKey = connection.fetchKey(keyDefinition);
+
+    assertThat(fetchedKey).isEqualTo(EXPECTED_KEY_STRING);
+  }
+}

--- a/keystorage/src/main/java/tech/pegasys/web3signer/keystorage/hashicorp/HashicorpConnection.java
+++ b/keystorage/src/main/java/tech/pegasys/web3signer/keystorage/hashicorp/HashicorpConnection.java
@@ -14,15 +14,22 @@ package tech.pegasys.web3signer.keystorage.hashicorp;
 
 import tech.pegasys.web3signer.keystorage.hashicorp.config.ConnectionParameters;
 import tech.pegasys.web3signer.keystorage.hashicorp.config.KeyDefinition;
+import tech.pegasys.web3signer.keystorage.hashicorp.config.KubernetesAuthOptions;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
+
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonObject;
 
 public class HashicorpConnection {
 
@@ -47,6 +54,118 @@ public class HashicorpConnection {
                     "Error communicating with Hashicorp vault: Requested Secret name does not exist."));
   }
 
+  /**
+   * Authenticates with HashiCorp Vault using the Kubernetes auth method.
+   *
+   * <p>Reads the pod's service-account JWT from {@link
+   * KubernetesAuthOptions#getServiceAccountTokenPath()}, then exchanges it for a short-lived Vault
+   * client token by posting to {@code POST /v1/auth/<authPath>/login}.
+   *
+   * @param kubernetesAuthOptions Kubernetes auth configuration
+   * @return the Vault client token returned by the login endpoint
+   * @throws HashicorpException if authentication fails for any reason
+   */
+  public String authenticateWithKubernetes(final KubernetesAuthOptions kubernetesAuthOptions) {
+    final String jwt = readServiceAccountToken(kubernetesAuthOptions);
+    final URI loginUri = buildKubernetesLoginUri(kubernetesAuthOptions.getAuthPath());
+    final String requestBody =
+        new JsonObject()
+            .put("role", kubernetesAuthOptions.getKubernetesRole())
+            .put("jwt", jwt)
+            .encode();
+
+    final HttpRequest httpRequest =
+        HttpRequest.newBuilder(loginUri)
+            .header("Content-Type", "application/json")
+            .timeout(Duration.ofMillis(connectionParameters.getTimeoutMilliseconds()))
+            .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8))
+            .build();
+
+    final HttpResponse<String> response;
+    try {
+      response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new HashicorpException("Interrupted while authenticating with Hashicorp Vault", e);
+    } catch (final IOException | RuntimeException e) {
+      throw new HashicorpException(
+          "Error authenticating with Hashicorp Vault using Kubernetes auth method: "
+              + e.getMessage(),
+          e);
+    }
+
+    if (response.statusCode() != 200) {
+      throw new HashicorpException(
+          String.format(
+              "Kubernetes auth login to Hashicorp Vault failed with HTTP status %d. "
+                  + "Check that the Vault role '%s' exists and the service account is bound to it.",
+              response.statusCode(), kubernetesAuthOptions.getKubernetesRole()));
+    }
+
+    return parseClientToken(response.body(), kubernetesAuthOptions.getKubernetesRole());
+  }
+
+  private String readServiceAccountToken(final KubernetesAuthOptions kubernetesAuthOptions) {
+    try {
+      final String jwt =
+          Files.readString(
+              kubernetesAuthOptions.getServiceAccountTokenPath(), StandardCharsets.UTF_8);
+      if (jwt == null || jwt.isBlank()) {
+        throw new HashicorpException(
+            "Kubernetes service-account token is empty at path: "
+                + kubernetesAuthOptions.getServiceAccountTokenPath());
+      }
+      return jwt.strip();
+    } catch (final IOException e) {
+      throw new HashicorpException(
+          "Failed to read Kubernetes service-account token from: "
+              + kubernetesAuthOptions.getServiceAccountTokenPath(),
+          e);
+    }
+  }
+
+  private URI buildKubernetesLoginUri(final String authPath) {
+    // e.g. http://vault:8200/v1/auth/kubernetes/login
+    try {
+      final URI base = connectionParameters.getVaultURI();
+      return new URI(
+          base.getScheme(),
+          null,
+          base.getHost(),
+          base.getPort(),
+          "/v1/auth/" + authPath + "/login",
+          null,
+          null);
+    } catch (final URISyntaxException e) {
+      throw new HashicorpException(
+          "Invalid Kubernetes auth path '" + authPath + "': " + e.getMessage(), e);
+    }
+  }
+
+  private String parseClientToken(final String responseBody, final String roleName) {
+    try {
+      final JsonObject json = new JsonObject(responseBody);
+      final JsonObject auth = json.getJsonObject("auth");
+      if (auth == null) {
+        throw new HashicorpException(
+            "Kubernetes auth login response did not contain 'auth' field. "
+                + "Vault may have rejected the request.");
+      }
+      final String clientToken = auth.getString("client_token");
+      if (clientToken == null || clientToken.isBlank()) {
+        throw new HashicorpException(
+            "Kubernetes auth login response did not contain a valid 'client_token'. "
+                + "Vault role '"
+                + roleName
+                + "' may not be configured correctly.");
+      }
+      return clientToken;
+    } catch (final DecodeException e) {
+      throw new HashicorpException(
+          "Failed to parse Kubernetes auth login response from Hashicorp Vault", e);
+    }
+  }
+
   private Map<String, String> fetchKeyValuesFromVault(final KeyDefinition keyDefinition) {
     final URI vaultReadURI =
         connectionParameters.getVaultURI().resolve(keyDefinition.getKeyPath()).normalize();
@@ -60,7 +179,10 @@ public class HashicorpConnection {
     final HttpResponse<String> response;
     try {
       response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
-    } catch (final IOException | InterruptedException | RuntimeException e) {
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new HashicorpException("Interrupted while communicating with Hashicorp Vault", e);
+    } catch (final IOException | RuntimeException e) {
       throw new HashicorpException(
           "Error communicating with Hashicorp vault: " + e.getMessage(), e);
     }

--- a/keystorage/src/main/java/tech/pegasys/web3signer/keystorage/hashicorp/VaultAuthMethod.java
+++ b/keystorage/src/main/java/tech/pegasys/web3signer/keystorage/hashicorp/VaultAuthMethod.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.keystorage.hashicorp;
+
+/** Authentication methods supported for HashiCorp Vault. */
+public enum VaultAuthMethod {
+  /** Authenticate using a static Vault token (default, backward-compatible). */
+  TOKEN,
+
+  /**
+   * Authenticate using the Vault Kubernetes auth method. The pod's service-account JWT is exchanged
+   * for a short-lived Vault client token via {@code POST /v1/auth/<mount>/login}.
+   */
+  KUBERNETES
+}

--- a/keystorage/src/main/java/tech/pegasys/web3signer/keystorage/hashicorp/config/KubernetesAuthOptions.java
+++ b/keystorage/src/main/java/tech/pegasys/web3signer/keystorage/hashicorp/config/KubernetesAuthOptions.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.keystorage.hashicorp.config;
+
+import java.nio.file.Path;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Configuration options for the Vault Kubernetes auth method.
+ *
+ * <p>When using Kubernetes auth, the pod's service-account JWT is read from {@code
+ * serviceAccountTokenPath} and exchanged for a short-lived Vault client token via {@code POST
+ * /v1/auth/<authPath>/login}.
+ */
+public class KubernetesAuthOptions {
+
+  /** Default path for the Kubernetes service-account JWT token injected by the kubelet. */
+  public static final Path DEFAULT_SERVICE_ACCOUNT_TOKEN_PATH =
+      Path.of("/var/run/secrets/kubernetes.io/serviceaccount/token");
+
+  /** Default Vault auth mount path for the Kubernetes auth method. */
+  public static final String DEFAULT_AUTH_PATH = "kubernetes";
+
+  private final String kubernetesRole;
+  private final Path serviceAccountTokenPath;
+  private final String authPath;
+
+  /**
+   * @param kubernetesRole the Vault role name bound to this Kubernetes service account (required)
+   * @param serviceAccountTokenPath path to the Kubernetes service-account JWT file; if {@code
+   *     null}, defaults to {@link #DEFAULT_SERVICE_ACCOUNT_TOKEN_PATH}
+   * @param authPath Vault auth mount path; if {@code null}, defaults to {@link #DEFAULT_AUTH_PATH}
+   */
+  public KubernetesAuthOptions(
+      final String kubernetesRole, final Path serviceAccountTokenPath, final String authPath) {
+    this.kubernetesRole = kubernetesRole;
+    this.serviceAccountTokenPath =
+        serviceAccountTokenPath != null
+            ? serviceAccountTokenPath
+            : DEFAULT_SERVICE_ACCOUNT_TOKEN_PATH;
+
+    String processedAuthPath =
+        (authPath != null && !authPath.isBlank()) ? authPath.strip() : DEFAULT_AUTH_PATH;
+
+    processedAuthPath = StringUtils.strip(processedAuthPath, "/");
+
+    this.authPath = processedAuthPath;
+
+    for (final String segment : this.authPath.split("/", -1)) {
+      if (segment.isEmpty() || segment.equals(".") || segment.equals("..")) {
+        throw new IllegalArgumentException(
+            "kubernetesAuthPath must not contain '.' or '..' or empty path segments");
+      }
+    }
+  }
+
+  /** The Vault role name bound to this pod's Kubernetes service account. */
+  public String getKubernetesRole() {
+    return kubernetesRole;
+  }
+
+  /**
+   * Path to the Kubernetes service-account JWT file, defaults to {@link
+   * #DEFAULT_SERVICE_ACCOUNT_TOKEN_PATH}.
+   */
+  public Path getServiceAccountTokenPath() {
+    return serviceAccountTokenPath;
+  }
+
+  /**
+   * Vault auth mount path for the Kubernetes auth method, defaults to {@link #DEFAULT_AUTH_PATH}.
+   */
+  public String getAuthPath() {
+    return authPath;
+  }
+}

--- a/keystorage/src/test/java/tech/pegasys/web3signer/keystorage/hashicorp/config/KubernetesAuthOptionsTest.java
+++ b/keystorage/src/test/java/tech/pegasys/web3signer/keystorage/hashicorp/config/KubernetesAuthOptionsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.keystorage.hashicorp.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class KubernetesAuthOptionsTest {
+
+  @Test
+  void constructsSuccessfullyWithValidParameters() {
+    final KubernetesAuthOptions options =
+        new KubernetesAuthOptions("my-role", Path.of("/tmp/token"), "auth-path");
+    assertThat(options.getKubernetesRole()).isEqualTo("my-role");
+    assertThat(options.getServiceAccountTokenPath()).isEqualTo(Path.of("/tmp/token"));
+    assertThat(options.getAuthPath()).isEqualTo("auth-path");
+  }
+
+  @Test
+  void usesDefaultsWhenOptionalParametersAreNull() {
+    final KubernetesAuthOptions options = new KubernetesAuthOptions("my-role", null, null);
+    assertThat(options.getKubernetesRole()).isEqualTo("my-role");
+    assertThat(options.getServiceAccountTokenPath())
+        .isEqualTo(KubernetesAuthOptions.DEFAULT_SERVICE_ACCOUNT_TOKEN_PATH);
+    assertThat(options.getAuthPath()).isEqualTo(KubernetesAuthOptions.DEFAULT_AUTH_PATH);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        ".",
+        "..",
+        "auth/../path",
+        "auth/./path",
+        "../auth",
+        "./auth",
+        "auth/..",
+        "auth/."
+      })
+  void throwsExceptionWhenAuthPathContainsDotOrDotDot(final String invalidAuthPath) {
+    assertThatThrownBy(() -> new KubernetesAuthOptions("my-role", null, invalidAuthPath))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("kubernetesAuthPath must not contain '.' or '..' or empty path segments");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"/kubernetes", "kubernetes/", "/kubernetes/", "//kubernetes", "kubernetes//"})
+  void stripsLeadingAndTrailingSlashesFromAuthPath(final String authPathWithSlashes) {
+    final KubernetesAuthOptions options =
+        new KubernetesAuthOptions("my-role", null, authPathWithSlashes);
+    assertThat(options.getAuthPath()).isEqualTo("kubernetes");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"kubernetes//login", "auth//path"})
+  void throwsExceptionWhenAuthPathContainsEmptySegments(final String invalidAuthPath) {
+    assertThatThrownBy(() -> new KubernetesAuthOptions("my-role", null, invalidAuthPath))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("kubernetesAuthPath must not contain '.' or '..' or empty path segments");
+  }
+}

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AbstractArtifactSignerFactory.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/AbstractArtifactSignerFactory.java
@@ -18,9 +18,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import tech.pegasys.web3signer.keystorage.azure.AzureKeyVault;
 import tech.pegasys.web3signer.keystorage.hashicorp.HashicorpConnection;
 import tech.pegasys.web3signer.keystorage.hashicorp.HashicorpConnectionFactory;
+import tech.pegasys.web3signer.keystorage.hashicorp.HashicorpException;
 import tech.pegasys.web3signer.keystorage.hashicorp.TrustStoreType;
+import tech.pegasys.web3signer.keystorage.hashicorp.VaultAuthMethod;
 import tech.pegasys.web3signer.keystorage.hashicorp.config.ConnectionParameters;
 import tech.pegasys.web3signer.keystorage.hashicorp.config.KeyDefinition;
+import tech.pegasys.web3signer.keystorage.hashicorp.config.KubernetesAuthOptions;
 import tech.pegasys.web3signer.keystorage.hashicorp.config.TlsOptions;
 import tech.pegasys.web3signer.signing.KeyType;
 import tech.pegasys.web3signer.signing.config.AzureKeyVaultFactory;
@@ -75,13 +78,36 @@ public abstract class AbstractArtifactSignerFactory implements ArtifactSignerFac
       final HashicorpConnection connection =
           hashicorpConnectionFactory.create(connectionParameters);
 
+      final String token;
+      if (metadata.getAuthMethod() == VaultAuthMethod.KUBERNETES) {
+        if (metadata.getKubernetesRole() == null || metadata.getKubernetesRole().isBlank()) {
+          throw new SigningMetadataException(
+              "kubernetesRole must be provided when using KUBERNETES auth method");
+        }
+        final Path resolvedTokenPath =
+            metadata.getKubernetesServiceAccountTokenPath() != null
+                ? makeRelativePathAbsolute(metadata.getKubernetesServiceAccountTokenPath())
+                : null;
+        final KubernetesAuthOptions kubernetesAuthOptions =
+            new KubernetesAuthOptions(
+                metadata.getKubernetesRole(), resolvedTokenPath, metadata.getKubernetesAuthPath());
+        token = connection.authenticateWithKubernetes(kubernetesAuthOptions);
+      } else {
+        if (metadata.getToken() == null || metadata.getToken().isBlank()) {
+          throw new SigningMetadataException("token must be provided when using TOKEN auth method");
+        }
+        token = metadata.getToken();
+      }
+
       final String secret =
           connection.fetchKey(
               new KeyDefinition(
-                  metadata.getKeyPath(),
-                  Optional.ofNullable(metadata.getKeyName()),
-                  metadata.getToken()));
+                  metadata.getKeyPath(), Optional.ofNullable(metadata.getKeyName()), token));
       return Bytes.fromHexString(secret);
+    } catch (final SigningMetadataException e) {
+      throw e;
+    } catch (final HashicorpException e) {
+      throw new SigningMetadataException(e.getMessage(), e);
     } catch (final Exception e) {
       throw new SigningMetadataException("Failed to fetch secret from hashicorp vault", e);
     }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/HashicorpSigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/HashicorpSigningMetadata.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.web3signer.signing.config.metadata;
 
+import tech.pegasys.web3signer.keystorage.hashicorp.VaultAuthMethod;
 import tech.pegasys.web3signer.signing.ArtifactSigner;
 import tech.pegasys.web3signer.signing.KeyType;
 
@@ -37,11 +38,16 @@ public class HashicorpSigningMetadata extends SigningMetadata {
   private Path tlsKnownServerFile = null;
   private HttpClient.Version httpProtocolVersion;
 
+  private VaultAuthMethod authMethod = VaultAuthMethod.TOKEN;
+  private String kubernetesRole;
+  private Path kubernetesServiceAccountTokenPath;
+  private String kubernetesAuthPath;
+
   @JsonCreator
   public HashicorpSigningMetadata(
       @JsonProperty(value = "serverHost", required = true) final String serverHost,
       @JsonProperty(value = "keyPath", required = true) final String keyPath,
-      @JsonProperty(value = "token", required = true) final String token,
+      @JsonProperty(value = "token") final String token,
       @JsonProperty(value = "keyType") final KeyType keyType) {
     super(TYPE, keyType != null ? keyType : KeyType.BLS);
     this.serverHost = serverHost;
@@ -79,6 +85,28 @@ public class HashicorpSigningMetadata extends SigningMetadata {
     this.httpProtocolVersion = httpProtocolVersion;
   }
 
+  @JsonSetter("authMethod")
+  public void setAuthMethod(final VaultAuthMethod authMethod) {
+    if (authMethod != null) {
+      this.authMethod = authMethod;
+    }
+  }
+
+  @JsonSetter("kubernetesRole")
+  public void setKubernetesRole(final String kubernetesRole) {
+    this.kubernetesRole = kubernetesRole;
+  }
+
+  @JsonSetter("kubernetesServiceAccountTokenPath")
+  public void setKubernetesServiceAccountTokenPath(final Path kubernetesServiceAccountTokenPath) {
+    this.kubernetesServiceAccountTokenPath = kubernetesServiceAccountTokenPath;
+  }
+
+  @JsonSetter("kubernetesAuthPath")
+  public void setKubernetesAuthPath(final String kubernetesAuthPath) {
+    this.kubernetesAuthPath = kubernetesAuthPath;
+  }
+
   public String getServerHost() {
     return serverHost;
   }
@@ -113,6 +141,22 @@ public class HashicorpSigningMetadata extends SigningMetadata {
 
   public HttpClient.Version getHttpProtocolVersion() {
     return httpProtocolVersion;
+  }
+
+  public VaultAuthMethod getAuthMethod() {
+    return authMethod;
+  }
+
+  public String getKubernetesRole() {
+    return kubernetesRole;
+  }
+
+  public Path getKubernetesServiceAccountTokenPath() {
+    return kubernetesServiceAccountTokenPath;
+  }
+
+  public String getKubernetesAuthPath() {
+    return kubernetesAuthPath;
   }
 
   @Override

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/config/metadata/BlsArtifactSignerFactoryTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/config/metadata/BlsArtifactSignerFactoryTest.java
@@ -15,6 +15,9 @@ package tech.pegasys.web3signer.signing.config.metadata;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import tech.pegasys.teku.bls.BLSKeyPair;
 import tech.pegasys.teku.bls.BLSPublicKey;
@@ -28,7 +31,11 @@ import tech.pegasys.web3signer.bls.keystore.model.KdfParam;
 import tech.pegasys.web3signer.bls.keystore.model.KeyStoreData;
 import tech.pegasys.web3signer.bls.keystore.model.SCryptParam;
 import tech.pegasys.web3signer.keystorage.aws.AwsSecretsManagerProvider;
+import tech.pegasys.web3signer.keystorage.hashicorp.HashicorpConnection;
 import tech.pegasys.web3signer.keystorage.hashicorp.HashicorpConnectionFactory;
+import tech.pegasys.web3signer.keystorage.hashicorp.VaultAuthMethod;
+import tech.pegasys.web3signer.keystorage.hashicorp.config.ConnectionParameters;
+import tech.pegasys.web3signer.keystorage.hashicorp.config.KubernetesAuthOptions;
 import tech.pegasys.web3signer.signing.ArtifactSigner;
 import tech.pegasys.web3signer.signing.BlsArtifactSigner;
 import tech.pegasys.web3signer.signing.KeyType;
@@ -37,6 +44,7 @@ import tech.pegasys.web3signer.signing.config.AzureKeyVaultFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
@@ -190,7 +198,54 @@ class BlsArtifactSignerFactoryTest {
 
     assertThatThrownBy(() -> artifactSignerFactory.create(metaData))
         .isInstanceOf(SigningMetadataException.class)
-        .hasMessage("Failed to fetch secret from hashicorp vault");
+        .hasMessage("Unable to initialise connection to hashicorp vault.");
+  }
+
+  @Test
+  void kubernetesAuthServiceAccountTokenPathIsResolvedToAbsolute() {
+    final Path relativeTokenPath = Path.of("relative-token");
+    final HashicorpSigningMetadata metaData =
+        new HashicorpSigningMetadata("localhost", "keyPath", null, KeyType.BLS);
+    metaData.setAuthMethod(VaultAuthMethod.KUBERNETES);
+    metaData.setKubernetesRole("my-role");
+    metaData.setKubernetesServiceAccountTokenPath(relativeTokenPath);
+
+    final AtomicReference<KubernetesAuthOptions> capturedAuthOptions = new AtomicReference<>();
+
+    final HashicorpConnection mockConnection = mock(HashicorpConnection.class);
+
+    when(mockConnection.authenticateWithKubernetes(any()))
+        .thenAnswer(
+            invocation -> {
+              final KubernetesAuthOptions kubernetesAuthOptions = invocation.getArgument(0);
+              capturedAuthOptions.set(kubernetesAuthOptions);
+              throw new SigningMetadataException("Authentication intercepted");
+            });
+
+    final HashicorpConnectionFactory connectionFactory =
+        new HashicorpConnectionFactory() {
+          @Override
+          public HashicorpConnection create(final ConnectionParameters connectionParameters) {
+            return mockConnection;
+          }
+        };
+
+    final ArtifactSignerFactory customFactory =
+        new BlsArtifactSignerFactory(
+            configDir,
+            new NoOpMetricsSystem(),
+            connectionFactory,
+            awsSecretsManagerProvider,
+            (args) -> new BlsArtifactSigner(args.getKeyPair(), args.getOrigin()),
+            azureKeyVaultFactory);
+
+    assertThatThrownBy(() -> customFactory.create(metaData))
+        .isInstanceOf(SigningMetadataException.class)
+        .hasMessage("Authentication intercepted");
+
+    assertThat(capturedAuthOptions.get()).isNotNull();
+    assertThat(capturedAuthOptions.get().getServiceAccountTokenPath())
+        .isEqualTo(configDir.resolve(relativeTokenPath));
   }
 
   private static void createKeyStoreFile(final Path keyStoreFilePath) {

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/config/metadata/HashicorpSigningMetadataTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/config/metadata/HashicorpSigningMetadataTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.signing.config.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import tech.pegasys.web3signer.keystorage.hashicorp.VaultAuthMethod;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import org.junit.jupiter.api.Test;
+
+class HashicorpSigningMetadataTest {
+
+  private final YAMLMapper yamlMapper = new YAMLMapper();
+
+  @Test
+  void deserializesTokenAuthMethodByDefault() throws IOException {
+    final String yaml =
+        """
+        type: "hashicorp"
+        serverHost: "localhost"
+        serverPort: 8200
+        keyPath: "/v1/secret/data/mykey"
+        token: "my-token"
+        """;
+
+    final HashicorpSigningMetadata metadata =
+        yamlMapper.readValue(yaml, HashicorpSigningMetadata.class);
+
+    assertThat(metadata.getAuthMethod()).isEqualTo(VaultAuthMethod.TOKEN);
+    assertThat(metadata.getToken()).isEqualTo("my-token");
+  }
+
+  @Test
+  void deserializesKubernetesAuthMethod() throws IOException {
+    final String yaml =
+        """
+        type: "hashicorp"
+        serverHost: "localhost"
+        serverPort: 8200
+        keyPath: "/v1/secret/data/mykey"
+        authMethod: "KUBERNETES"
+        kubernetesRole: "my-role"
+        kubernetesAuthPath: "my-auth-path"
+        kubernetesServiceAccountTokenPath: "/tmp/token"
+        """;
+
+    final HashicorpSigningMetadata metadata =
+        yamlMapper.readValue(yaml, HashicorpSigningMetadata.class);
+
+    assertThat(metadata.getAuthMethod()).isEqualTo(VaultAuthMethod.KUBERNETES);
+    assertThat(metadata.getKubernetesRole()).isEqualTo("my-role");
+    assertThat(metadata.getKubernetesAuthPath()).isEqualTo("my-auth-path");
+    assertThat(metadata.getKubernetesServiceAccountTokenPath()).isEqualTo(Path.of("/tmp/token"));
+    assertThat(metadata.getToken()).isNull();
+  }
+
+  @Test
+  void deserializesWithoutAuthMethodDefaultsToToken() throws IOException {
+    final String yaml =
+        """
+        type: "hashicorp"
+        serverHost: "localhost"
+        keyPath: "/v1/secret/data/mykey"
+        token: "my-token"
+        """;
+
+    final HashicorpSigningMetadata metadata =
+        yamlMapper.readValue(yaml, HashicorpSigningMetadata.class);
+
+    assertThat(metadata.getAuthMethod()).isEqualTo(VaultAuthMethod.TOKEN);
+    assertThat(metadata.getToken()).isEqualTo("my-token");
+  }
+
+  @Test
+  void deserializesWithNullAuthMethodDefaultsToToken() throws IOException {
+    final String yaml =
+        """
+        type: "hashicorp"
+        serverHost: "localhost"
+        keyPath: "/v1/secret/data/mykey"
+        token: "my-token"
+        authMethod: null
+        """;
+
+    final HashicorpSigningMetadata metadata =
+        yamlMapper.readValue(yaml, HashicorpSigningMetadata.class);
+
+    assertThat(metadata.getAuthMethod()).isEqualTo(VaultAuthMethod.TOKEN);
+    assertThat(metadata.getToken()).isEqualTo("my-token");
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
This PR implements native Kubernetes Service Account authentication for Hashicorp Vault, allowing Web3Signer to authenticate with Vault without requiring a static token.

### Key Changes
- Added `KUBERNETES` as a valid `authMethod` in `HashicorpSigningMetadata`.
- Implemented `authenticateWithKubernetes` in `HashicorpConnection` to exchange a K8s JWT for a Vault client token using the `/v1/auth/kubernetes/login` endpoint.
- Added support for configurable `kubernetesRole`, `kubernetesAuthPath` (default: `kubernetes`), and `kubernetesServiceAccountTokenPath` (default: `/var/run/secrets/kubernetes.io/serviceaccount/token`).
- Refactored `AbstractArtifactSignerFactory` to support dynamic token acquisition.
- Maintained backward compatibility for existing static `token` authentication.
- Added unit and integration tests.

## Fixed Issue(s)
None.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Vault credentials are obtained for Hashicorp-backed signing keys at load time; misconfiguration could block signer startup, though TOKEN remains the default and auth-path validation reduces URL manipulation risk.
> 
> **Overview**
> Adds **Hashicorp Vault Kubernetes auth** so Hashicorp signing YAML can obtain a Vault client token from the pod service-account JWT instead of a static `token`.
> 
> **Hashicorp signing metadata** gains `authMethod` (`TOKEN` default, or `KUBERNETES`), plus optional `kubernetesRole`, `kubernetesAuthPath`, and `kubernetesServiceAccountTokenPath`. The `token` field is no longer required at deserialization time; runtime validation enforces `token` for `TOKEN` and `kubernetesRole` for `KUBERNETES`. Relative service-account token paths are resolved against the config directory.
> 
> **Keystorage** implements `authenticateWithKubernetes` on `HashicorpConnection` (JWT read, `POST /v1/auth/<path>/login`, parse `client_token`) with `KubernetesAuthOptions` defaults and auth-path hardening. Signer creation in `AbstractArtifactSignerFactory` exchanges for a token when using Kubernetes auth, then fetches secrets as before. **InterruptedException** handling is split out for Vault HTTP calls.
> 
> Coverage includes unit tests for options/metadata, a mock-server integration test for login + secret read, and a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88c684e6da68cab3c4947401b235c35e0e8e9ea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->