### PR TITLE
Update besu version to 26.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-besuVersion=25.12.0
-besuDistroUrl=https://github.com/hyperledger/besu/releases/download/${besuVersion}/besu-${besuVersion}.tar.gz
+besuVersion=26.5.0
+besuDistroUrl=https://github.com/besu-eth/besu/releases/download/${besuVersion}/besu-${besuVersion}.tar.gz
 
 hashicorpVaultVersion=1.9.2
 hashicorpVaultUrl=https://releases.hashicorp.com/vault


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Update besu version to 26.5.0. Also update the Besu release path.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> A major Besu version bump can affect signing/crypto behavior and integration tests that depend on the bundled Besu artifact, though the change is limited to build configuration.
> 
> **Overview**
> Bumps the **Besu** dependency from **25.12.0** to **26.5.0** in `gradle.properties` and points `besuDistroUrl` at the **besu-eth/besu** GitHub release host instead of **hyperledger/besu**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de245df367aa1191313832ceca4e51cb578b14ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->