### PR TITLE
fix: make token optional in HashicorpSigningMetadata for Kubernetes auth

### DIFF
--- a/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/HashicorpSigningMetadata.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/config/metadata/HashicorpSigningMetadata.java
@@ -26,8 +26,8 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 public class HashicorpSigningMetadata extends SigningMetadata {
   public static final String TYPE = "hashicorp";
   private final String serverHost;
-  private final String token;
   private final String keyPath;
+  private String token;
 
   // Optional Fields (will be populated if need be).
   private Integer serverPort;
@@ -47,12 +47,15 @@ public class HashicorpSigningMetadata extends SigningMetadata {
   public HashicorpSigningMetadata(
       @JsonProperty(value = "serverHost", required = true) final String serverHost,
       @JsonProperty(value = "keyPath", required = true) final String keyPath,
-      @JsonProperty(value = "token") final String token,
       @JsonProperty(value = "keyType") final KeyType keyType) {
     super(TYPE, keyType != null ? keyType : KeyType.BLS);
     this.serverHost = serverHost;
-    this.token = token;
     this.keyPath = keyPath;
+  }
+
+  @JsonSetter("token")
+  public void setToken(final String value) {
+    this.token = value;
   }
 
   @JsonSetter("serverPort")

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/config/metadata/BlsArtifactSignerFactoryTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/config/metadata/BlsArtifactSignerFactoryTest.java
@@ -192,7 +192,8 @@ class BlsArtifactSignerFactoryTest {
     Files.writeString(malformedknownServers, "Illegal Known Servers.");
 
     final HashicorpSigningMetadata metaData =
-        new HashicorpSigningMetadata("localhost", "keyPath", "token", KeyType.BLS);
+        new HashicorpSigningMetadata("localhost", "keyPath", KeyType.BLS);
+    metaData.setToken("token");
     metaData.setTlsEnabled(true);
     metaData.setTlsKnownServersPath(malformedknownServers);
 
@@ -205,7 +206,7 @@ class BlsArtifactSignerFactoryTest {
   void kubernetesAuthServiceAccountTokenPathIsResolvedToAbsolute() {
     final Path relativeTokenPath = Path.of("relative-token");
     final HashicorpSigningMetadata metaData =
-        new HashicorpSigningMetadata("localhost", "keyPath", null, KeyType.BLS);
+        new HashicorpSigningMetadata("localhost", "keyPath", KeyType.BLS);
     metaData.setAuthMethod(VaultAuthMethod.KUBERNETES);
     metaData.setKubernetesRole("my-role");
     metaData.setKubernetesServiceAccountTokenPath(relativeTokenPath);


### PR DESCRIPTION
## PR Description

Fix deserialization of `HashicorpSigningMetadata` when using Kubernetes authentication. `token` was a `@JsonCreator` constructor parameter, which caused Jackson to treat it as required even when `authMethod: KUBERNETES` is set. This resulted in a `MismatchedInputException: Missing required creator property 'token'` when loading key config files without a `token` field.

The fix removes `token` from the `@JsonCreator` constructor and exposes it via `@JsonSetter` instead, consistent with how all other optional fields (`serverPort`, `keyName`, etc.) are handled in the same class. Token auth is unaffected — the factory validates at runtime that `token` is present when `authMethod` is `TOKEN`.

## Fixed Issue(s)

Follow-up bug fix for the Kubernetes auth feature introduced in #1195.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Jackson binding change with existing runtime validation for token auth; test updates only beyond the metadata class.
> 
> **Overview**
> Fixes Jackson deserialization for Hashicorp Vault key configs that use **Kubernetes** auth without a `token` field. `token` is no longer a `@JsonCreator` constructor argument (which made Jackson require it); it is set via `@JsonSetter("token")` like other optional metadata fields.
> 
> **TOKEN** auth behavior is unchanged: `AbstractArtifactSignerFactory` still fails at runtime if `token` is missing or blank when `authMethod` is TOKEN. Unit tests construct `HashicorpSigningMetadata` with the slimmer constructor and call `setToken` where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e37c588c1b2685a7174ab4362b22f9e4c5f24272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->